### PR TITLE
Use `trybuild` to test errors generated by gc-arena-derive

### DIFF
--- a/src/gc-arena/Cargo.toml
+++ b/src/gc-arena/Cargo.toml
@@ -13,3 +13,4 @@ gc-arena-derive = { path = "../gc-arena-derive", version = "0.2" }
 
 [dev-dependencies]
 rand = "0.5"
+trybuild = "1.0"

--- a/src/gc-arena/src/no_drop.rs
+++ b/src/gc-arena/src/no_drop.rs
@@ -4,4 +4,5 @@
 #[doc(hidden)]
 pub trait MustNotImplDrop {}
 
+#[allow(drop_bounds)]
 impl<T: Drop> MustNotImplDrop for T {}

--- a/src/gc-arena/tests/tests.rs
+++ b/src/gc-arena/tests/tests.rs
@@ -180,3 +180,9 @@ fn derive_collect() {
     assert_eq!(Test5::needs_trace(), true);
     assert_eq!(Test6::needs_trace(), false);
 }
+
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/src/gc-arena/tests/ui/no_drop_and_drop_impl.rs
+++ b/src/gc-arena/tests/ui/no_drop_and_drop_impl.rs
@@ -1,0 +1,12 @@
+use gc_arena::Collect;
+
+#[derive(Collect)]
+#[collect(no_drop)]
+struct Foo {
+}
+
+impl Drop for Foo {
+    fn drop(&mut self) {}
+}
+
+fn main() {}

--- a/src/gc-arena/tests/ui/no_drop_and_drop_impl.stderr
+++ b/src/gc-arena/tests/ui/no_drop_and_drop_impl.stderr
@@ -1,0 +1,10 @@
+error[E0119]: conflicting implementations of trait `gc_arena::MustNotImplDrop` for type `Foo`:
+ --> $DIR/no_drop_and_drop_impl.rs:3:10
+  |
+3 | #[derive(Collect)]
+  |          ^^^^^^^
+  |
+  = note: conflicting implementation in crate `gc_arena`:
+          - impl<T> MustNotImplDrop for T
+            where T: Drop;
+  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
The soundness of the code generated by `gc-arena-derive` relies on
certain things *not* compiling. Currently, this is not testing, making
it possible to accidentally introduce unsoundess.

This commit uses the `trybuild` crate to add compile-fail tests. To
start out, I've added a single test that verifies that
`#[collect(no_drop)]` causes a compilation error if a `Drop` impl is
present.