### PR TITLE
  Allow using `#[collect(require_static)]` on fields 

### DIFF
--- a/src/gc-arena-derive/src/lib.rs
+++ b/src/gc-arena-derive/src/lib.rs
@@ -1,8 +1,9 @@
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
+use syn::spanned::Spanned;
 use synstructure::{decl_derive, AddBounds};
 
-fn collect_derive(s: synstructure::Structure) -> TokenStream {
+fn collect_derive(mut s: synstructure::Structure) -> TokenStream {
     // Deriving `Collect` must be done with care, because an implementation of `Drop` is not
     // necessarily safe for `Collect` types.  This derive macro has three available modes to ensure
     // that this is safe:
@@ -57,6 +58,8 @@ fn collect_derive(s: synstructure::Structure) -> TokenStream {
         quote!()
     };
 
+    let mut errors = vec![];
+
     let collect_impl = if mode == Mode::RequireStatic {
         s.clone().add_bounds(AddBounds::None).gen_impl(quote! {
             gen unsafe impl gc_arena::Collect for @Self #where_clause {
@@ -69,6 +72,91 @@ fn collect_derive(s: synstructure::Structure) -> TokenStream {
     } else {
         let mut needs_trace_body = TokenStream::new();
         quote!(false).to_tokens(&mut needs_trace_body);
+
+        let mut static_bindings = vec![];
+
+        // Ignore all bindings that have `#[collect(require_static)]`
+        // For each binding with `#[collect(require_static)]`, we
+        // push a bound of the form `FieldType: 'static` to `static_bindings`,
+        // which will be added to the genererated `Collect` impl.
+        // The presence of the bound guarantees that the field cannot hold
+        // any `Gc` pointers, so it's safe to ignore that field in `needs_trace`
+        // and `trace`
+        s.filter(|b| {
+            let mut static_binding = false;
+            let mut seen_collect = false;
+            for attr in &b.ast().attrs {
+                match attr.parse_meta() {
+                    Ok(syn::Meta::List(syn::MetaList { path, nested, .. })) => {
+                        if path.is_ident("collect") {
+                            if seen_collect {
+                                errors.push(
+                                    syn::parse::Error::new(
+                                        path.span(),
+                                        "Cannot specify multiple `#[collect]` attributes!",
+                                    )
+                                    .to_compile_error(),
+                                );
+                            }
+                            seen_collect = true;
+
+                            let mut valid = false;
+                            if let Some(syn::NestedMeta::Meta(syn::Meta::Path(path))) =
+                                nested.first()
+                            {
+                                if path.is_ident("require_static") {
+                                    static_binding = true;
+                                    static_bindings.push(b.ast().ty.clone());
+                                    valid = true;
+                                }
+                            }
+
+                            if !valid {
+                                errors.push(
+                                    syn::parse::Error::new(
+                                        nested.span(),
+                                        "Only `#[collect(require_static)]` is supported on a field",
+                                    )
+                                    .to_compile_error(),
+                                );
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            !static_binding
+        });
+
+        for static_binding in static_bindings {
+            s.add_where_predicate(syn::parse_quote! { #static_binding: 'static });
+        }
+
+        // `#[collect(require_static)]` only makes sense on fields, not enum
+        // variants. Emit an error if it is used in the wrong place
+        if let syn::Data::Enum(..) = s.ast().data {
+            for v in s.variants() {
+                for attr in v.ast().attrs {
+                    match attr.parse_meta() {
+                        Ok(syn::Meta::List(syn::MetaList { path, nested, .. })) => {
+                            if path.is_ident("collect") {
+                                errors.push(
+                                    syn::parse::Error::new(
+                                        nested.span(),
+                                        "`#[collect]` is not suppported on enum variants",
+                                    )
+                                    .to_compile_error(),
+                                );
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        // We've already called `s.filter`, so we we won't try to call
+        // `needs_trace` for the types of fields that have `#[collect(require_static)]`
         for v in s.variants() {
             for b in v.bindings() {
                 let ty = &b.ast().ty;
@@ -76,7 +164,7 @@ fn collect_derive(s: synstructure::Structure) -> TokenStream {
                     .to_tokens(&mut needs_trace_body);
             }
         }
-
+        // Likewise, this will skip any fields that have `#[collect(require_static)]`
         let trace_body = s.each(|bi| quote!(gc_arena::Collect::trace(#bi, cc)));
 
         s.clone().add_bounds(AddBounds::Fields).gen_impl(quote! {
@@ -106,6 +194,7 @@ fn collect_derive(s: synstructure::Structure) -> TokenStream {
     quote! {
         #collect_impl
         #drop_impl
+        #(#errors)*
     }
 }
 

--- a/src/gc-arena/Cargo.toml
+++ b/src/gc-arena/Cargo.toml
@@ -13,3 +13,4 @@ gc-arena-derive = { path = "../gc-arena-derive", version = "0.2" }
 
 [dev-dependencies]
 rand = "0.5"
+trybuild = "1.0"

--- a/src/gc-arena/src/no_drop.rs
+++ b/src/gc-arena/src/no_drop.rs
@@ -4,4 +4,5 @@
 #[doc(hidden)]
 pub trait MustNotImplDrop {}
 
+#[allow(drop_bounds)]
 impl<T: Drop> MustNotImplDrop for T {}

--- a/src/gc-arena/tests/tests.rs
+++ b/src/gc-arena/tests/tests.rs
@@ -179,6 +179,29 @@ fn derive_collect() {
     assert_eq!(Test4::needs_trace(), false);
     assert_eq!(Test5::needs_trace(), true);
     assert_eq!(Test6::needs_trace(), false);
+
+    struct NoImpl;
+
+    #[allow(unused)]
+    #[derive(Collect)]
+    #[collect(no_drop)]
+    struct Test7 {
+        #[collect(require_static)]
+        field: NoImpl,
+    }
+
+    #[allow(unused)]
+    #[derive(Collect)]
+    #[collect(no_drop)]
+    enum Test8 {
+        First {
+            #[collect(require_static)]
+            field: NoImpl,
+        },
+    }
+
+    assert_eq!(Test7::needs_trace(), false);
+    assert_eq!(Test8::needs_trace(), false);
 }
 
 #[test]

--- a/src/gc-arena/tests/tests.rs
+++ b/src/gc-arena/tests/tests.rs
@@ -180,3 +180,9 @@ fn derive_collect() {
     assert_eq!(Test5::needs_trace(), true);
     assert_eq!(Test6::needs_trace(), false);
 }
+
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/src/gc-arena/tests/ui/invalid_collect_field.rs
+++ b/src/gc-arena/tests/ui/invalid_collect_field.rs
@@ -1,0 +1,9 @@
+use gc_arena::Collect;
+
+#[derive(Collect)]
+#[collect(no_drop)]
+struct MyStruct {
+    #[collect(invalid_arg)] field: u8
+}
+
+fn main() {}

--- a/src/gc-arena/tests/ui/invalid_collect_field.stderr
+++ b/src/gc-arena/tests/ui/invalid_collect_field.stderr
@@ -1,0 +1,5 @@
+error: Only `#[collect(require_static)]` is supported on a field
+ --> $DIR/invalid_collect_field.rs:6:15
+  |
+6 |     #[collect(invalid_arg)] field: u8
+  |               ^^^^^^^^^^^

--- a/src/gc-arena/tests/ui/multiple_require_static.rs
+++ b/src/gc-arena/tests/ui/multiple_require_static.rs
@@ -1,0 +1,11 @@
+use gc_arena::Collect;
+
+#[derive(Collect)]
+#[collect(no_drop)]
+struct MyStruct {
+    #[collect(require_static)]
+    #[collect(require_static)]
+    field: bool
+}
+
+fn main() {}

--- a/src/gc-arena/tests/ui/multiple_require_static.stderr
+++ b/src/gc-arena/tests/ui/multiple_require_static.stderr
@@ -1,0 +1,5 @@
+error: Cannot specify multiple `#[collect]` attributes!
+ --> $DIR/multiple_require_static.rs:7:7
+  |
+7 |     #[collect(require_static)]
+  |       ^^^^^^^

--- a/src/gc-arena/tests/ui/no_drop_and_drop_impl.rs
+++ b/src/gc-arena/tests/ui/no_drop_and_drop_impl.rs
@@ -1,0 +1,12 @@
+use gc_arena::Collect;
+
+#[derive(Collect)]
+#[collect(no_drop)]
+struct Foo {
+}
+
+impl Drop for Foo {
+    fn drop(&mut self) {}
+}
+
+fn main() {}

--- a/src/gc-arena/tests/ui/no_drop_and_drop_impl.stderr
+++ b/src/gc-arena/tests/ui/no_drop_and_drop_impl.stderr
@@ -1,0 +1,10 @@
+error[E0119]: conflicting implementations of trait `gc_arena::MustNotImplDrop` for type `Foo`:
+ --> $DIR/no_drop_and_drop_impl.rs:3:10
+  |
+3 | #[derive(Collect)]
+  |          ^^^^^^^
+  |
+  = note: conflicting implementation in crate `gc_arena`:
+          - impl<T> MustNotImplDrop for T
+            where T: Drop;
+  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/gc-arena/tests/ui/require_static_enum_variant.rs
+++ b/src/gc-arena/tests/ui/require_static_enum_variant.rs
@@ -1,0 +1,12 @@
+use gc_arena::Collect;
+
+#[derive(Collect)]
+#[collect(no_drop)]
+enum MyEnum {
+    #[collect(require_static)]
+    First {
+        field: u8
+    }
+}
+
+fn main() {}

--- a/src/gc-arena/tests/ui/require_static_enum_variant.stderr
+++ b/src/gc-arena/tests/ui/require_static_enum_variant.stderr
@@ -1,0 +1,5 @@
+error: `#[collect]` is not suppported on enum variants
+ --> $DIR/require_static_enum_variant.rs:6:15
+  |
+6 |     #[collect(require_static)]
+  |               ^^^^^^^^^^^^^^

--- a/src/gc-arena/tests/ui/require_static_not_static.rs
+++ b/src/gc-arena/tests/ui/require_static_not_static.rs
@@ -1,0 +1,16 @@
+use gc_arena::Collect;
+
+struct NoCollectImpl<'a>(&'a bool);
+
+#[derive(Collect)]
+#[collect(no_drop)]
+struct MyStruct<'a> {
+    #[collect(require_static)]
+    field: NoCollectImpl<'a>
+}
+
+fn assert_my_struct_collect<'a>() {
+    MyStruct::<'a>::needs_trace();
+}
+
+fn main() {}

--- a/src/gc-arena/tests/ui/require_static_not_static.stderr
+++ b/src/gc-arena/tests/ui/require_static_not_static.stderr
@@ -1,0 +1,24 @@
+error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
+  --> $DIR/require_static_not_static.rs:13:5
+   |
+13 |     MyStruct::<'a>::needs_trace();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: first, the lifetime cannot outlive the lifetime `'a` as defined on the function body at 12:29...
+  --> $DIR/require_static_not_static.rs:12:29
+   |
+12 | fn assert_my_struct_collect<'a>() {
+   |                             ^^
+note: ...so that the types are compatible
+  --> $DIR/require_static_not_static.rs:13:5
+   |
+13 |     MyStruct::<'a>::needs_trace();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: expected `Collect`
+              found `Collect`
+   = note: but, the lifetime must be valid for the static lifetime...
+note: ...so that the type `NoCollectImpl<'_>` will meet its required lifetime bounds
+  --> $DIR/require_static_not_static.rs:13:5
+   |
+13 |     MyStruct::<'a>::needs_trace();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Currently, `#[collect(require_static)]` can be used on an entire
struct/enum. This commit allows `#[collect(require_static)]` to be
applied to individual fields or field bindings of a struct/enum.

When applied, we generate a where-clause bound ensuring that the type of
the field binding outlives 'static. This allows us to ignore the field
in `needs_trace` and `trace`.

As a result, it's now possible to use `#[derive(Collect)]` on a
struct/enum containing foreign types, as long as those foreign types are
'static.