### PR TITLE
Add #[track_caller] for better panic error messages

### DIFF
--- a/src/gc-arena/src/gc_cell.rs
+++ b/src/gc-arena/src/gc_cell.rs
@@ -50,6 +50,7 @@ impl<'gc, T: 'gc + Collect> GcCell<'gc, T> {
         self.0.cell.as_ptr()
     }
 
+    #[track_caller]
     pub fn read<'a>(&'a self) -> Ref<'a, T> {
         self.0.cell.borrow()
     }
@@ -58,6 +59,7 @@ impl<'gc, T: 'gc + Collect> GcCell<'gc, T> {
         self.0.cell.try_borrow()
     }
 
+    #[track_caller]
     pub fn write<'a>(&'a self, mc: MutationContext<'gc, '_>) -> RefMut<'a, T> {
         let b = self.0.cell.borrow_mut();
         Gc::write_barrier(mc, self.0);


### PR DESCRIPTION
Before:
```
Error message: panicked at 'already borrowed: BorrowMutError', gc-arena-0.2.0/src/gc_cell.rs:62:29
```
After: it shows the line that actually tried calling read()/write().
```
Error message: panicked at 'already borrowed: BorrowMutError', core/src/avm1/activation.rs:1186:48
```
Should help a bit with pinpointing error sources for library users :)