### PR TITLE
Use `quote_spanned` when generating calls to `gc_arena` methods

### DIFF
--- a/src/gc-arena/tests/ui/bad_collect_bound.rs
+++ b/src/gc-arena/tests/ui/bad_collect_bound.rs
@@ -1,0 +1,11 @@
+use gc_arena::Collect;
+
+struct NotCollect;
+
+#[derive(Collect)]
+#[collect(no_drop)]
+struct MyStruct {
+    field: NotCollect
+}
+
+fn main() {}

--- a/src/gc-arena/tests/ui/bad_collect_bound.stderr
+++ b/src/gc-arena/tests/ui/bad_collect_bound.stderr
@@ -1,0 +1,18 @@
+error[E0277]: the trait bound `NotCollect: Collect` is not satisfied
+  --> $DIR/bad_collect_bound.rs:8:5
+   |
+8  |     field: NotCollect
+   |     ^^^^^^^^^^^^^^^^^ the trait `Collect` is not implemented for `NotCollect`
+   |
+  ::: $WORKSPACE/src/gc-arena/src/collect.rs
+   |
+   |         Self: Sized,
+   |               ----- required by this bound in `needs_trace`
+
+error[E0277]: the trait bound `NotCollect: Collect` is not satisfied
+ --> $DIR/bad_collect_bound.rs:8:5
+  |
+8 |     field: NotCollect
+  |     ^^^^^^^^^^^^^^^^^ the trait `Collect` is not implemented for `NotCollect`
+  |
+  = note: required by `trace`


### PR DESCRIPTION
We now span calls to `Collect::needs_trace` and `Collect::trace`
with the span of the field that we're generating the call for. This
leads to nicer error messages when a trait bound is not fulfulled (and
likely better runtime backtraces as well)