### PR TITLE
Use hygiene from `Span::call_site()` to produce error messages

### DIFF
--- a/src/gc-arena-derive/Cargo.toml
+++ b/src/gc-arena-derive/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/kyren/gc-arena"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0"
+proc-macro2 = "1.0.24"
 quote = "1.0"
 syn = "1.0"
 synstructure = "0.12"

--- a/src/gc-arena/tests/ui/bad_collect_bound.stderr
+++ b/src/gc-arena/tests/ui/bad_collect_bound.stderr
@@ -8,6 +8,8 @@ error[E0277]: the trait bound `NotCollect: Collect` is not satisfied
    |
    |         Self: Sized,
    |               ----- required by this bound in `needs_trace`
+   |
+   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotCollect: Collect` is not satisfied
  --> $DIR/bad_collect_bound.rs:8:5
@@ -16,3 +18,4 @@ error[E0277]: the trait bound `NotCollect: Collect` is not satisfied
   |     ^^^^^^^^^^^^^^^^^ the trait `Collect` is not implemented for `NotCollect`
   |
   = note: required by `trace`
+  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
PR #12 used `quote_spanned` to make error messages have the span of the
corresponding field in the struct. However, there's no indication that
the error comes from `#[derive(Collect)]`, which could be confusing for
people unfamiliar with the crate.

This PR uses `Span::resolved_at` to give the generated spans the hygiene
information from the call site. This causes rustc to add a note about
the error message originating from a macro, while still keeping the
error message at the proper location.