### PR TITLE
Add weak pointers `GcWeak` and `GcWeakCell`

### DIFF
--- a/src/gc-arena/src/gc.rs
+++ b/src/gc-arena/src/gc.rs
@@ -5,6 +5,7 @@ use core::ptr::NonNull;
 
 use crate::collect::Collect;
 use crate::context::{CollectionContext, MutationContext};
+use crate::gc_weak::GcWeak;
 use crate::types::{GcBox, Invariant};
 
 /// A garbage collected pointer to a type T.  Implements Copy, and is implemented as a plain machine
@@ -55,6 +56,10 @@ impl<'gc, T: 'gc + Collect> Gc<'gc, T> {
             ptr: unsafe { mc.allocate(t) },
             _invariant: PhantomData,
         }
+    }
+
+    pub fn downgrade(this: Gc<'gc, T>) -> GcWeak<'gc, T> {
+        GcWeak { inner: this }
     }
 
     /// When implementing `Collect` on types with internal mutability containing `Gc` pointers, this

--- a/src/gc-arena/src/gc_cell.rs
+++ b/src/gc-arena/src/gc_cell.rs
@@ -4,6 +4,7 @@ use core::fmt::{self, Debug};
 use crate::collect::Collect;
 use crate::context::{CollectionContext, MutationContext};
 use crate::gc::Gc;
+use crate::GcWeakCell;
 
 /// A garbage collected pointer to a type T that may be safely mutated.  When a type that may hold
 /// `Gc` pointers is mutated, it may adopt new `Gc` pointers, and in order for this to be safe this
@@ -42,6 +43,14 @@ impl<'gc, T: 'gc + Collect> GcCell<'gc, T> {
         ))
     }
 
+    pub fn downgrade(this: GcCell<'gc, T>) -> GcWeakCell<'gc, T> {
+        GcWeakCell { inner: this }
+    }
+
+    pub(crate) unsafe fn get_inner(&self) -> Gc<'gc, GcRefCell<T>> {
+        self.0
+    }
+
     pub fn ptr_eq(this: GcCell<'gc, T>, other: GcCell<'gc, T>) -> bool {
         this.as_ptr() == other.as_ptr()
     }
@@ -76,7 +85,7 @@ impl<'gc, T: 'gc + Collect> GcCell<'gc, T> {
     }
 }
 
-struct GcRefCell<T: Collect> {
+pub(crate) struct GcRefCell<T: Collect> {
     cell: RefCell<T>,
 }
 

--- a/src/gc-arena/src/gc_weak.rs
+++ b/src/gc-arena/src/gc_weak.rs
@@ -1,0 +1,38 @@
+use crate::collect::Collect;
+use crate::gc::Gc;
+use crate::{CollectionContext, MutationContext};
+
+use core::fmt::{self, Debug};
+
+pub struct GcWeak<'gc, T: 'gc + Collect> {
+    pub(crate) inner: Gc<'gc, T>,
+}
+
+impl<'gc, T: Collect + 'gc> Copy for GcWeak<'gc, T> {}
+
+impl<'gc, T: Collect + 'gc> Clone for GcWeak<'gc, T> {
+    fn clone(&self) -> GcWeak<'gc, T> {
+        *self
+    }
+}
+
+impl<'gc, T: 'gc + Collect> Debug for GcWeak<'gc, T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "(GcWeak)")
+    }
+}
+
+unsafe impl<'gc, T: 'gc + Collect> Collect for GcWeak<'gc, T> {
+    fn trace(&self, _cc: CollectionContext) {
+        unsafe {
+            let gc = self.inner.ptr.as_ref();
+            gc.flags.set_has_weak_ref(true);
+        }
+    }
+}
+
+impl<'gc, T: Collect + 'gc> GcWeak<'gc, T> {
+    pub fn upgrade(&self, mc: MutationContext<'gc, '_>) -> Option<Gc<'gc, T>> {
+        unsafe { mc.upgrade(self.inner.ptr).then(|| self.inner) }
+    }
+}

--- a/src/gc-arena/src/gc_weak.rs
+++ b/src/gc-arena/src/gc_weak.rs
@@ -26,7 +26,7 @@ unsafe impl<'gc, T: 'gc + Collect> Collect for GcWeak<'gc, T> {
     fn trace(&self, _cc: CollectionContext) {
         unsafe {
             let gc = self.inner.ptr.as_ref();
-            gc.flags.set_has_weak_ref(true);
+            gc.flags.set_traced_weak_ref(true);
         }
     }
 }

--- a/src/gc-arena/src/gc_weak_cell.rs
+++ b/src/gc-arena/src/gc_weak_cell.rs
@@ -1,0 +1,38 @@
+use crate::GcCell;
+use crate::{collect::Collect, MutationContext};
+
+use core::fmt::{self, Debug};
+
+pub struct GcWeakCell<'gc, T: 'gc + Collect> {
+    pub(crate) inner: GcCell<'gc, T>,
+}
+
+impl<'gc, T: Collect + 'gc> Copy for GcWeakCell<'gc, T> {}
+
+impl<'gc, T: Collect + 'gc> Clone for GcWeakCell<'gc, T> {
+    fn clone(&self) -> GcWeakCell<'gc, T> {
+        *self
+    }
+}
+
+impl<'gc, T: 'gc + Collect> Debug for GcWeakCell<'gc, T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "(GcWeakCell)")
+    }
+}
+
+unsafe impl<'gc, T: 'gc + Collect> Collect for GcWeakCell<'gc, T> {
+    fn trace(&self, _cc: crate::CollectionContext) {
+        unsafe {
+            let gc = self.inner.get_inner().ptr.as_ref();
+
+            gc.flags.set_has_weak_ref(true);
+        }
+    }
+}
+
+impl<'gc, T: Collect + 'gc> GcWeakCell<'gc, T> {
+    pub fn upgrade(&self, mc: MutationContext<'gc, '_>) -> Option<GcCell<'gc, T>> {
+        unsafe { mc.upgrade(self.inner.get_inner().ptr).then(|| self.inner) }
+    }
+}

--- a/src/gc-arena/src/gc_weak_cell.rs
+++ b/src/gc-arena/src/gc_weak_cell.rs
@@ -26,7 +26,7 @@ unsafe impl<'gc, T: 'gc + Collect> Collect for GcWeakCell<'gc, T> {
         unsafe {
             let gc = self.inner.get_inner().ptr.as_ref();
 
-            gc.flags.set_has_weak_ref(true);
+            gc.flags.set_traced_weak_ref(true);
         }
     }
 }

--- a/src/gc-arena/src/lib.rs
+++ b/src/gc-arena/src/lib.rs
@@ -14,6 +14,8 @@ mod collect_impl;
 mod context;
 mod gc;
 mod gc_cell;
+mod gc_weak;
+mod gc_weak_cell;
 mod no_drop;
 mod static_collect;
 mod types;
@@ -24,6 +26,8 @@ pub use self::{
     context::{CollectionContext, Context, MutationContext},
     gc::Gc,
     gc_cell::GcCell,
+    gc_weak::GcWeak,
+    gc_weak_cell::GcWeakCell,
     no_drop::MustNotImplDrop,
     static_collect::StaticCollect,
 };

--- a/src/gc-arena/src/types.rs
+++ b/src/gc-arena/src/types.rs
@@ -6,8 +6,21 @@ use crate::collect::Collect;
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub(crate) enum GcColor {
+    /// An object that was not reached during tracing.
+    /// During `Phase::Sweep`, we will free all white objects
+    /// that existed *before* the start of the current `Phase::Sweep`.
+    /// Objects allocated during `Phase::Sweep` will be white, but will
+    /// not be freed.
     White,
+    /// An object reachable from a Black object, but that has not
+    /// yet been traced using `Collect::trace`. We also mark black
+    /// objects as gray during `Phase::Propagate` in response to a
+    /// `write_barrier` call, so that we re-trace and find any objects
+    /// newly reachable from the mutated object.
     Gray,
+    /// An object that was reached during tracing. It will not be freed
+    /// during `Phase::Sweep`. At the end of `Phase::Sweep`, all black
+    /// objects will be reset to white.
     Black,
 }
 
@@ -48,9 +61,40 @@ impl GcFlags {
         self.0.get() & 0x4 != 0x0
     }
 
+    /// This is `true` if we've traced a weak pointer during to this `GcBox`
+    /// during the most recent `Phase::Propagate`. This is reset back to
+    /// `false` during `Phase::Sweep`.
+    #[inline]
+    pub(crate) fn has_weak_ref(&self) -> bool {
+        self.0.get() & 0x8 != 0x0
+    }
+
+    /// Determines whether or not we've dropped the stored `dyn Collect` value.
+    /// When we garbage-collect a `GcBox` that still has outstanding weak pointers,
+    /// we set `alive` to false. When there are no more weak pointers remaining,
+    /// we will deallocate the `GcBox`, but skip dropping the `dyn Collect` value
+    /// (since we've already done it).
+    #[inline]
+    pub(crate) fn alive(&self) -> bool {
+        self.0.get() & 0x10 != 0x0
+    }
+
+    #[inline]
     pub(crate) fn set_needs_trace(&self, needs_trace: bool) {
         self.0
             .set((self.0.get() & !0x4) | if needs_trace { 0x4 } else { 0x0 });
+    }
+
+    #[inline]
+    pub(crate) fn set_has_weak_ref(&self, has_weak_ref: bool) {
+        self.0
+            .set((self.0.get() & !0x8) | if has_weak_ref { 0x8 } else { 0x0 });
+    }
+
+    #[inline]
+    pub(crate) fn set_alive(&self, alive: bool) {
+        self.0
+            .set((self.0.get() & !0x10) | if alive { 0x10 } else { 0x0 });
     }
 }
 

--- a/src/gc-arena/tests/ui/bad_collect_bound.stderr
+++ b/src/gc-arena/tests/ui/bad_collect_bound.stderr
@@ -16,5 +16,5 @@ error[E0277]: the trait bound `NotCollect: Collect` is not satisfied
             (A, B, C, D)
             (A, B, C, D, E)
             (A, B, C, D, E, F)
-          and 45 others
+          and 47 others
   = note: this error originates in the derive macro `Collect` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This is a combination of work by EmperorBale and me. It adds weak-pointer version of `Gc` and `GcCell`, named `GcWeak` and `GcWeakCell` respectively. These can be created by calling `downgrade()` on the corresponding 'strong' struct (`Gc`/`GcCell`).

You can attempt to upgrade a weak pointer to a strong pointer by calling `upgrade`. This will succeed as long as the target object has not yet been freed (it will also fail during `Phase::Sweep` when the target object is going to be freed, but has not yet been freed).

To support this, `GcBox` now has two additional flags: `alive` and `has_weak_ref`. When an allocation with weak pointers is garbage-collected, we just run the destructor on the `Collect` value if there are still weak pointers. The `GcBox` itself is not deallocated, so that the weak pointers are still able to access the flags. In a later `Phase::Sweep` where all of the weak pointers are gone, we actually deallocate the memory for the `GcBox`.

I've also added comments to existing code, to make it clear how weak pointers interact with the existing invariants.