### PR TITLE
Update UI tests to match latest Rust output

### DIFF
--- a/src/gc-arena/src/context.rs
+++ b/src/gc-arena/src/context.rs
@@ -71,7 +71,7 @@ impl Drop for Context {
                         while let Some(ptr) = drop_resume.0.take() {
                             let gc_box = ptr.as_ref();
                             drop_resume.0 = gc_box.next.get();
-                            Box::from_raw(ptr.as_ptr());
+                            drop(Box::from_raw(ptr.as_ptr()));
                         }
                     }
                 }
@@ -211,7 +211,7 @@ impl Context {
                             work_done += sweep_size as f64;
                             self.allocation_debt
                                 .set((self.allocation_debt.get() - sweep_size as f64).max(0.0));
-                            Box::from_raw(sweep_ptr.as_ptr());
+                            drop(Box::from_raw(sweep_ptr.as_ptr()));
                         } else {
                             // If the next object in the sweep portion of the main list is black, we
                             // need to keep it but turn it back white.  No gray objects should be in

--- a/src/gc-arena/tests/ui/bad_collect_bound.stderr
+++ b/src/gc-arena/tests/ui/bad_collect_bound.stderr
@@ -1,21 +1,20 @@
 error[E0277]: the trait bound `NotCollect: Collect` is not satisfied
-  --> $DIR/bad_collect_bound.rs:8:5
-   |
-8  |     field: NotCollect
-   |     ^^^^^ the trait `Collect` is not implemented for `NotCollect`
-   |
-  ::: $WORKSPACE/src/gc-arena/src/collect.rs
-   |
-   |         Self: Sized,
-   |               ----- required by this bound in `needs_trace`
-   |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `NotCollect: Collect` is not satisfied
  --> $DIR/bad_collect_bound.rs:8:5
   |
+5 | #[derive(Collect)]
+  |          ------- in this derive macro expansion
+...
 8 |     field: NotCollect
-  |     ^^^^^ the trait `Collect` is not implemented for `NotCollect`
+  |     ^^^^^^^^^^^^^^^^^ the trait `Collect` is not implemented for `NotCollect`
   |
-  = note: required by `trace`
-  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = help: the following other types implement trait `Collect`:
+            &'a T
+            &'a mut T
+            ()
+            (A, B)
+            (A, B, C)
+            (A, B, C, D)
+            (A, B, C, D, E)
+            (A, B, C, D, E, F)
+          and 76 others
+  = note: this error originates in the derive macro `Collect` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/gc-arena/tests/ui/no_drop_and_drop_impl.stderr
+++ b/src/gc-arena/tests/ui/no_drop_and_drop_impl.stderr
@@ -1,4 +1,4 @@
-error[E0119]: conflicting implementations of trait `gc_arena::MustNotImplDrop` for type `Foo`:
+error[E0119]: conflicting implementations of trait `gc_arena::MustNotImplDrop` for type `Foo`
  --> $DIR/no_drop_and_drop_impl.rs:3:10
   |
 3 | #[derive(Collect)]
@@ -7,4 +7,4 @@ error[E0119]: conflicting implementations of trait `gc_arena::MustNotImplDrop` f
   = note: conflicting implementation in crate `gc_arena`:
           - impl<T> MustNotImplDrop for T
             where T: Drop;
-  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the derive macro `Collect` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/gc-arena/tests/ui/require_static_not_static.stderr
+++ b/src/gc-arena/tests/ui/require_static_not_static.stderr
@@ -1,24 +1,7 @@
-error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
+error: lifetime may not live long enough
   --> $DIR/require_static_not_static.rs:13:5
-   |
-13 |     MyStruct::<'a>::needs_trace();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: first, the lifetime cannot outlive the lifetime `'a` as defined on the function body at 12:29...
-  --> $DIR/require_static_not_static.rs:12:29
    |
 12 | fn assert_my_struct_collect<'a>() {
-   |                             ^^
-note: ...so that the types are compatible
-  --> $DIR/require_static_not_static.rs:13:5
-   |
+   |                             -- lifetime `'a` defined here
 13 |     MyStruct::<'a>::needs_trace();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: expected `Collect`
-              found `Collect`
-   = note: but, the lifetime must be valid for the static lifetime...
-note: ...so that the type `NoCollectImpl<'_>` will meet its required lifetime bounds
-  --> $DIR/require_static_not_static.rs:13:5
-   |
-13 |     MyStruct::<'a>::needs_trace();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`


### PR DESCRIPTION
The error messages have changed, but the UI tests still correctly fail.