### PR TITLE
Define a single `Arena` struct and generate a type alias in `make_arena`

### DIFF
--- a/src/gc-arena/src/arena.rs
+++ b/src/gc-arena/src/arena.rs
@@ -122,7 +122,7 @@ pub trait RootProvider<'a> {
 }
 
 pub struct Arena<R: for<'a> RootProvider<'a> + ?Sized> {
-    context: crate::Context,
+    context: Context,
     root: ManuallyDrop<<R as RootProvider<'static>>::Root>,
 }
 
@@ -137,7 +137,7 @@ impl<R: for<'a> RootProvider<'a> + ?Sized> Arena<R> {
         F: for<'gc> FnOnce(crate::MutationContext<'gc, '_>) -> <R as RootProvider<'gc>>::Root,
     {
         unsafe {
-            let context = crate::Context::new(arena_parameters);
+            let context = Context::new(arena_parameters);
             // Note - we transmute the `MutationContext` to a `'static` lifetime here,
             // instead of transmuting the root type returned by `f`. Transmuting the root
             // type is allowed in nightly versions of rust
@@ -164,7 +164,7 @@ impl<R: for<'a> RootProvider<'a> + ?Sized> Arena<R> {
         ) -> Result<<R as RootProvider<'gc>>::Root, E>,
     {
         unsafe {
-            let context = crate::Context::new(arena_parameters);
+            let context = Context::new(arena_parameters);
             let mutation_context: MutationContext<'static, '_> =
                 ::core::mem::transmute(context.mutation_context());
             let root: <R as RootProvider<'static>>::Root = f(mutation_context)?;

--- a/src/gc-arena/src/context.rs
+++ b/src/gc-arena/src/context.rs
@@ -42,7 +42,7 @@ impl<'context> CollectionContext<'context> {
 
 // Main gc context type, public because it must be accessible from the `make_arena!` macro.
 #[doc(hidden)]
-pub struct Context {
+pub(crate) struct Context {
     parameters: ArenaParameters,
 
     phase: Cell<Phase>,
@@ -83,7 +83,7 @@ impl Drop for Context {
 }
 
 impl Context {
-    pub unsafe fn new(parameters: ArenaParameters) -> Context {
+    pub(crate) unsafe fn new(parameters: ArenaParameters) -> Context {
         Context {
             parameters,
             phase: Cell::new(Phase::Wake),
@@ -101,7 +101,7 @@ impl Context {
 
     // Creates a MutationContext with an unbounded 'gc lifetime.
     #[inline]
-    pub unsafe fn mutation_context<'gc, 'context>(
+    pub(crate) unsafe fn mutation_context<'gc, 'context>(
         &'context self,
     ) -> MutationContext<'gc, 'context> {
         MutationContext {
@@ -111,17 +111,17 @@ impl Context {
     }
 
     #[inline]
-    pub fn allocation_debt(&self) -> f64 {
+    pub(crate) fn allocation_debt(&self) -> f64 {
         self.allocation_debt.get()
     }
 
     #[inline]
-    pub fn total_allocated(&self) -> usize {
+    pub(crate) fn total_allocated(&self) -> usize {
         self.total_allocated.get()
     }
 
     // If the garbage collector is currently in the sleep phase, transition to the wake phase.
-    pub fn wake(&self) {
+    pub(crate) fn wake(&self) {
         if self.phase.get() == Phase::Sleep {
             self.phase.set(Phase::Wake);
         }
@@ -135,7 +135,7 @@ impl Context {
     //
     // In order for this to be safe, at the time of call no `Gc` pointers can be live that are not
     // reachable from the given root object.
-    pub unsafe fn do_collection<R: Collect>(&self, root: &R, work: f64) -> f64 {
+    pub(crate) unsafe fn do_collection<R: Collect>(&self, root: &R, work: f64) -> f64 {
         let mut work_done = 0.0;
         let cc = CollectionContext { context: self };
 

--- a/src/gc-arena/src/lib.rs
+++ b/src/gc-arena/src/lib.rs
@@ -19,7 +19,7 @@ mod static_collect;
 mod types;
 
 pub use self::{
-    arena::{rootless_arena, ArenaParameters},
+    arena::{rootless_arena, Arena, ArenaParameters, RootProvider},
     collect::Collect,
     context::{CollectionContext, Context, MutationContext},
     gc::Gc,

--- a/src/gc-arena/src/lib.rs
+++ b/src/gc-arena/src/lib.rs
@@ -21,7 +21,7 @@ mod types;
 pub use self::{
     arena::{rootless_arena, Arena, ArenaParameters, RootProvider},
     collect::Collect,
-    context::{CollectionContext, Context, MutationContext},
+    context::{CollectionContext, MutationContext},
     gc::Gc,
     gc_cell::GcCell,
     no_drop::MustNotImplDrop,


### PR DESCRIPTION
Surprisingly, this doesn't require GATs, and is actually simpler than a GAT-based solution. The core idea is to define a trait:

```rust
pub trait RootProvider<'a> {
    type Root: Collect;
}
```

In `Arena`, we use the higher-ranked trait bound
`R: for<'a> RootProvider<'a>`. Then, writing
`<R as RootProvider<'gc>>::Root` gives us the root type with some arbitrary lifetime `'gc` substituted.

The `make_arena` macro can then simply declare the type alias `type MyArenaName = Arena<dyn for<'a> RootProvider<'a, Root = UserRoot<'a>>>`

Since a `RootProvider` trait object implements `RootProvider`, the projection `<R as RootProvider<'gc>>::Root` will evaluate to `UserRoot<'gc>`, without the need to define any additional structs or trait impls.