### PR TITLE
loosen struct def trait bounds

### DIFF
--- a/src/gc-arena/src/context.rs
+++ b/src/gc-arena/src/context.rs
@@ -340,7 +340,7 @@ impl Context {
     unsafe fn write_barrier<T: Collect>(&self, ptr: NonNull<GcBox<T>>) {
         // During the propagating phase, if we are mutating a black object, we may add a white
         // object to it and invalidate the invariant that black objects may not point to white
-        // objects.  Turn black obejcts to gray to prevent this.
+        // objects.  Turn black objects to gray to prevent this.
         let gc_box = ptr.as_ref();
         if self.phase.get() == Phase::Propagate && gc_box.flags.color() == GcColor::Black {
             gc_box.flags.set_color(GcColor::Gray);

--- a/src/gc-arena/src/gc.rs
+++ b/src/gc-arena/src/gc.rs
@@ -13,7 +13,7 @@ use crate::types::{GcBox, Invariant};
 /// through "generativity" such `Gc` pointers may not escape the arena they were born in or be
 /// stored inside TLS.  This, combined with correct `Collect` implementations, means that `Gc`
 /// pointers will never be dangling and are always safe to access.
-pub struct Gc<'gc, T: 'gc + Collect> {
+pub struct Gc<'gc, T: 'gc> {
     pub(crate) ptr: NonNull<GcBox<T>>,
     _invariant: Invariant<'gc>,
 }

--- a/src/gc-arena/src/gc.rs
+++ b/src/gc-arena/src/gc.rs
@@ -26,9 +26,9 @@ impl<'gc, T: 'gc + Collect> Debug for Gc<'gc, T> {
     }
 }
 
-impl<'gc, T: Collect + 'gc> Copy for Gc<'gc, T> {}
+impl<'gc, T: 'gc> Copy for Gc<'gc, T> {}
 
-impl<'gc, T: Collect + 'gc> Clone for Gc<'gc, T> {
+impl<'gc, T: 'gc> Clone for Gc<'gc, T> {
     fn clone(&self) -> Gc<'gc, T> {
         *self
     }

--- a/src/gc-arena/src/gc_cell.rs
+++ b/src/gc-arena/src/gc_cell.rs
@@ -11,7 +11,7 @@ use crate::GcWeakCell;
 /// must be accompanied by a call to `Gc::write_barrier`.  This type wraps the given `T` in a
 /// `RefCell` in such a way that writing to the `RefCell` is always accompanied by a call to
 /// `Gc::write_barrier`.
-pub struct GcCell<'gc, T: 'gc + Collect>(Gc<'gc, GcRefCell<T>>);
+pub struct GcCell<'gc, T: 'gc>(Gc<'gc, GcRefCell<T>>);
 
 impl<'gc, T: Collect + 'gc> Copy for GcCell<'gc, T> {}
 
@@ -85,7 +85,7 @@ impl<'gc, T: 'gc + Collect> GcCell<'gc, T> {
     }
 }
 
-pub(crate) struct GcRefCell<T: Collect> {
+pub(crate) struct GcRefCell<T> {
     cell: RefCell<T>,
 }
 

--- a/src/gc-arena/src/gc_cell.rs
+++ b/src/gc-arena/src/gc_cell.rs
@@ -13,9 +13,9 @@ use crate::GcWeakCell;
 /// `Gc::write_barrier`.
 pub struct GcCell<'gc, T: 'gc>(Gc<'gc, GcRefCell<T>>);
 
-impl<'gc, T: Collect + 'gc> Copy for GcCell<'gc, T> {}
+impl<'gc, T: 'gc> Copy for GcCell<'gc, T> {}
 
-impl<'gc, T: Collect + 'gc> Clone for GcCell<'gc, T> {
+impl<'gc, T: 'gc> Clone for GcCell<'gc, T> {
     fn clone(&self) -> GcCell<'gc, T> {
         *self
     }

--- a/src/gc-arena/src/gc_weak.rs
+++ b/src/gc-arena/src/gc_weak.rs
@@ -4,19 +4,19 @@ use crate::{CollectionContext, MutationContext};
 
 use core::fmt::{self, Debug};
 
-pub struct GcWeak<'gc, T: 'gc + Collect> {
+pub struct GcWeak<'gc, T> {
     pub(crate) inner: Gc<'gc, T>,
 }
 
-impl<'gc, T: Collect + 'gc> Copy for GcWeak<'gc, T> {}
+impl<'gc, T> Copy for GcWeak<'gc, T> {}
 
-impl<'gc, T: Collect + 'gc> Clone for GcWeak<'gc, T> {
+impl<'gc, T> Clone for GcWeak<'gc, T> {
     fn clone(&self) -> GcWeak<'gc, T> {
         *self
     }
 }
 
-impl<'gc, T: 'gc + Collect> Debug for GcWeak<'gc, T> {
+impl<'gc, T> Debug for GcWeak<'gc, T> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "(GcWeak)")
     }

--- a/src/gc-arena/src/gc_weak_cell.rs
+++ b/src/gc-arena/src/gc_weak_cell.rs
@@ -3,19 +3,19 @@ use crate::{collect::Collect, MutationContext};
 
 use core::fmt::{self, Debug};
 
-pub struct GcWeakCell<'gc, T: 'gc + Collect> {
+pub struct GcWeakCell<'gc, T> {
     pub(crate) inner: GcCell<'gc, T>,
 }
 
-impl<'gc, T: Collect + 'gc> Copy for GcWeakCell<'gc, T> {}
+impl<'gc, T> Copy for GcWeakCell<'gc, T> {}
 
-impl<'gc, T: Collect + 'gc> Clone for GcWeakCell<'gc, T> {
+impl<'gc, T> Clone for GcWeakCell<'gc, T> {
     fn clone(&self) -> GcWeakCell<'gc, T> {
         *self
     }
 }
 
-impl<'gc, T: 'gc + Collect> Debug for GcWeakCell<'gc, T> {
+impl<'gc, T> Debug for GcWeakCell<'gc, T> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "(GcWeakCell)")
     }

--- a/src/gc-arena/src/types.rs
+++ b/src/gc-arena/src/types.rs
@@ -26,7 +26,7 @@ pub(crate) enum GcColor {
     Black,
 }
 
-pub(crate) struct GcBox<T: Collect + ?Sized> {
+pub(crate) struct GcBox<T: ?Sized> {
     pub(crate) flags: GcFlags,
     pub(crate) next: Cell<Option<NonNull<GcBox<dyn Collect>>>>,
     pub(crate) value: ManuallyDrop<UnsafeCell<T>>,

--- a/src/gc-arena/tests/tests.rs
+++ b/src/gc-arena/tests/tests.rs
@@ -259,7 +259,7 @@ fn ui() {
 
 #[test]
 fn recursive_struct_indirect_gc() {
-    #[derive(Collect)]
+    #[derive(Clone, Copy, Collect)]
     #[collect(no_drop)]
     pub enum Value<'gc, S: 'gc> {
         #[allow(dead_code)]
@@ -275,7 +275,7 @@ fn recursive_struct_indirect_gc() {
 
 #[test]
 fn recursive_struct_indirect_gccell() {
-    #[derive(Collect)]
+    #[derive(Clone, Copy, Collect)]
     #[collect(no_drop)]
     pub enum Value<'gc, S: 'gc> {
         #[allow(dead_code)]

--- a/src/gc-arena/tests/tests.rs
+++ b/src/gc-arena/tests/tests.rs
@@ -256,3 +256,35 @@ fn ui() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/*.rs");
 }
+
+#[test]
+fn recursive_struct_indirect_gc() {
+    #[derive(Collect)]
+    #[collect(no_drop)]
+    pub enum Value<'gc, S: 'gc> {
+        #[allow(dead_code)]
+        Closure(Gc<'gc, Closure<'gc, S>>),
+    }
+
+    #[derive(Collect)]
+    #[collect(no_drop)]
+    pub struct Closure<'gc, S: 'gc> {
+        pub vars: Vec<Value<'gc, S>>,
+    }
+}
+
+#[test]
+fn recursive_struct_indirect_gccell() {
+    #[derive(Collect)]
+    #[collect(no_drop)]
+    pub enum Value<'gc, S: 'gc> {
+        #[allow(dead_code)]
+        Closure(GcCell<'gc, Closure<'gc, S>>),
+    }
+
+    #[derive(Collect)]
+    #[collect(no_drop)]
+    pub struct Closure<'gc, S: 'gc> {
+        pub vars: Vec<Value<'gc, S>>,
+    }
+}

--- a/src/gc-arena/tests/tests.rs
+++ b/src/gc-arena/tests/tests.rs
@@ -4,7 +4,9 @@ use rand::distributions::Distribution;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use gc_arena::{make_arena, unsafe_empty_collect, ArenaParameters, Collect, Gc, GcCell, GcWeak, GcWeakCell};
+use gc_arena::{
+    make_arena, unsafe_empty_collect, ArenaParameters, Collect, Gc, GcCell, GcWeak, GcWeakCell,
+};
 
 #[test]
 fn simple_allocation() {

--- a/src/gc-arena/tests/tests.rs
+++ b/src/gc-arena/tests/tests.rs
@@ -4,7 +4,7 @@ use rand::distributions::Distribution;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use gc_arena::{make_arena, unsafe_empty_collect, ArenaParameters, Collect, Gc, GcCell, GcWeak, GcWeakCell, MutationContext};
+use gc_arena::{make_arena, unsafe_empty_collect, ArenaParameters, Collect, Gc, GcCell, GcWeak, GcWeakCell};
 
 #[test]
 fn simple_allocation() {


### PR DESCRIPTION
Closes #21. It seems like the early requirement of `T: Collect` directly in the definition of several types (notably `Gc` and `GcCell`) was causing the rust compiler's trait bound satisfaction check to decay into infinite recursion for both direct and indirect recursive types. Simply removing this early requirement (on only the struct definitions) but keeping all the bounds on implementations solves the problem, and I believe doesn't impose any unsoundness since the struct does nothing on its own and all the implementators use (and need) `Collect` on their own.