### PR TITLE
add derive bound option

### DIFF
--- a/src/gc-arena-derive/src/lib.rs
+++ b/src/gc-arena-derive/src/lib.rs
@@ -252,4 +252,36 @@ fn collect_derive(mut s: synstructure::Structure) -> TokenStream {
     }
 }
 
-decl_derive!([Collect, attributes(collect)] => collect_derive);
+decl_derive! {
+    [Collect, attributes(collect)] =>
+    /// Derives the `Collect` trait needed to trace a gc type.
+    ///
+    /// To derive `Collect`, an additional attribute is required on the struct/enum called `collect`.
+    /// This has several optional arguments, but the only required argument is the derive strategy.
+    /// This can be one of
+    ///
+    /// - `#[collect(require_static)]` - Adds a `'static` bound, which allows for a no-op trace implementation.
+    ///   This is the ideal choice where possible.
+    /// - `#[collect(no_drop)]` - The typical safe tracing derive strategy which only has to add a requirement
+    ///   that your struct/enum does not have a custom implementation of `Drop`.
+    /// - `#[collect(unsafe_drop)]` - The most versatile tracing derive strategy which allows a custom drop implementation.
+    ///   However, this strategy can lead to unsoundness if care is not taken (see the above explanation of `Drop` interactions).
+    ///
+    /// The `collect` attribute also accepts a number of optional configuration settings:
+    ///
+    /// - `#[collect(bound = "<code>")]` - Replaces the default generated `where` clause with the given code.
+    ///   This can be an empty string to add no `where` clause, or otherwise must start with `"where"`,
+    ///   e.g., `#[collect(bound = "where T: Collect")]`.
+    ///   Note that this option is ignored for `require_static` mode since the only bound it produces is `Self: 'static`.
+    ///   Also note that providing an explicit bound in this way is safe, and only changes the trait bounds used
+    ///   to enable the implementation of `Collect`.
+    ///
+    /// Options may be passed to the `collect` attribute together, e.g., `#[collect(no_drop, bound = "")]`.
+    ///
+    /// The `collect` attribute may also be used on any field of an enum or struct, however the only allowed usage
+    /// is to specify the strategy as `require_static` (no other strategies are allowed, and no optional settings can be specified).
+    /// This will add a `'static` bound to the type of the field (regardless of an explicit `bound` setting)
+    /// in exchange for not having to trace into the given field (the ideal choice where possible).
+    /// Note that if the entire struct/enum is marked with `require_static` then this is unnecessary.
+    collect_derive
+}

--- a/src/gc-arena-derive/src/lib.rs
+++ b/src/gc-arena-derive/src/lib.rs
@@ -219,7 +219,7 @@ fn collect_derive(mut s: synstructure::Structure) -> TokenStream {
         let bounds_type = if override_bound.is_some() {
             AddBounds::None
         } else {
-            AddBounds::Fields
+            AddBounds::Generics
         };
         s.clone().add_bounds(bounds_type).gen_impl(quote! {
             gen unsafe impl gc_arena::Collect for @Self #where_clause {

--- a/src/gc-arena/src/collect.rs
+++ b/src/gc-arena/src/collect.rs
@@ -11,43 +11,13 @@ use crate::context::CollectionContext;
 ///   3. Internal mutability *must* not be used to adopt new `Gc` pointers without calling
 ///      `Gc::write_barrier` during the same arena mutation.
 ///
-/// It is, however, possible to implement this trait safely by procedurally deriving it, which
+/// It is, however, possible to implement this trait safely by procedurally deriving it (see [`gc_arena_derive::Collect`]), which
 /// requires that every field in the structure also implement `Collect`, and implements a safe,
 /// empty version of `Drop`.  Internally mutable types like `Cell` and `RefCell` do not implement
 /// `Collect` in such a way that it is possible to store `Gc` pointers inside them, so the write
 /// barrier requirement cannot be broken when procedurally deriving `Collect`.  A safe way of
 /// providing internal mutability in this case is to use `GcCell`, which provides internal
 /// mutability while ensuring that the write barrier is always executed.
-///
-/// ## Deriving `Collect`
-///
-/// To derive `Collect`, an additional attribute is required on the struct/enum called `collect`.
-/// This has several optional arguments, but the only required argument is the derive strategy.
-/// This can be one of
-///
-/// - `#[collect(require_static)]` - Adds a `'static` bound, which allows for a no-op trace implementation.
-///   This is the ideal choice where possible.
-/// - `#[collect(no_drop)]` - The typical safe tracing derive strategy which only has to add a requirement
-///   that your struct/enum does not have a custom implementation of `Drop`.
-/// - `#[collect(unsafe_drop)]` - The most versatile tracing derive strategy which allows a custom drop implementation.
-///   However, this strategy can lead to unsoundness if care is not taken (see the above explanation of `Drop` interactions).
-///
-/// The `collect` attribute also accepts a number of optional configuration settings:
-///
-/// - `#[collect(bound = "<code>")]` - Replaces the default generated `where` clause with the given code.
-///   This can be an empty string to add no `where` clause, or otherwise must start with `"where"`,
-///   e.g., `#[collect(bound = "where T: Collect")]`.
-///   Note that this option is ignored for `require_static` mode since the only bound it produces is `Self: 'static`.
-///   Also note that providing an explicit bound in this way is safe, and only changes the trait bounds used
-///   to enable the implementation of `Collect`.
-///
-/// Options may be passed to the `collect` attribute together, e.g., `#[collect(no_drop, bound = "")]`.
-///
-/// The `collect` attribute may also be used on any field of an enum or struct, however the only allowed usage
-/// is to specify the strategy as `require_static` (no other strategies are allowed, and no optional settings can be specified).
-/// This will add a `'static` bound to the type of the field (regardless of an explicit `bound` setting)
-/// in exchange for not having to trace into the given field (the ideal choice where possible).
-/// Note that if the entire struct/enum is marked with `require_static` then this is unnecessary.
 pub unsafe trait Collect {
     /// As an optimization, if this type can never hold a `Gc` pointer and `trace` is unnecessary to
     /// call, you may implement this method and return false.  The default implementation returns

--- a/src/gc-arena/src/collect.rs
+++ b/src/gc-arena/src/collect.rs
@@ -18,6 +18,36 @@ use crate::context::CollectionContext;
 /// barrier requirement cannot be broken when procedurally deriving `Collect`.  A safe way of
 /// providing internal mutability in this case is to use `GcCell`, which provides internal
 /// mutability while ensuring that the write barrier is always executed.
+///
+/// ## Deriving `Collect`
+///
+/// To derive `Collect`, an additional attribute is required on the struct/enum called `collect`.
+/// This has several optional arguments, but the only required argument is the derive strategy.
+/// This can be one of
+///
+/// - `#[collect(require_static)]` - Adds a `'static` bound, which allows for a no-op trace implementation.
+///   This is the ideal choice where possible.
+/// - `#[collect(no_drop)]` - The typical safe tracing derive strategy which only has to add a requirement
+///   that your struct/enum does not have a custom implementation of `Drop`.
+/// - `#[collect(unsafe_drop)]` - The most versatile tracing derive strategy which allows a custom drop implementation.
+///   However, this strategy can lead to unsoundness if care is not taken (see the above explanation of `Drop` interactions).
+///
+/// The `collect` attribute also accepts a number of optional configuration settings:
+///
+/// - `#[collect(bound = "<code>")]` - Replaces the default generated `where` clause with the given code.
+///   This can be an empty string to add no `where` clause, or otherwise must start with `"where"`,
+///   e.g., `#[collect(bound = "where T: Collect")]`.
+///   Note that this option is ignored for `require_static` mode since the only bound it produces is `Self: 'static`.
+///   Also note that providing an explicit bound in this way is safe, and only changes the trait bounds used
+///   to enable the implementation of `Collect`.
+///
+/// Options may be passed to the `collect` attribute together, e.g., `#[collect(no_drop, bound = "")]`.
+///
+/// The `collect` attribute may also be used on any field of an enum or struct, however the only allowed usage
+/// is to specify the strategy as `require_static` (no other strategies are allowed, and no optional settings can be specified).
+/// This will add a `'static` bound to the type of the field (regardless of an explicit `bound` setting)
+/// in exchange for not having to trace into the given field (the ideal choice where possible).
+/// Note that if the entire struct/enum is marked with `require_static` then this is unnecessary.
 pub unsafe trait Collect {
     /// As an optimization, if this type can never hold a `Gc` pointer and `trace` is unnecessary to
     /// call, you may implement this method and return false.  The default implementation returns

--- a/src/gc-sequence/src/and_then.rs
+++ b/src/gc-sequence/src/and_then.rs
@@ -4,7 +4,7 @@ use crate::Sequence;
 
 #[must_use = "sequences do nothing unless stepped"]
 #[derive(Debug, Collect)]
-#[collect(no_drop)]
+#[collect(no_drop, bound = "where S: Collect, I: Collect, F: 'static")]
 pub enum AndThen<S, F, I> {
     First(S, Option<StaticCollect<F>>),
     Second(Option<(I, StaticCollect<F>)>),
@@ -47,7 +47,10 @@ where
 
 #[must_use = "sequences do nothing unless stepped"]
 #[derive(Debug, Collect)]
-#[collect(no_drop)]
+#[collect(
+    no_drop,
+    bound = "where S: Collect, C: Collect, I: Collect, F: 'static"
+)]
 pub enum AndThenWith<S, C, F, I> {
     First(S, Option<(C, StaticCollect<F>)>),
     Second(Option<(C, I, StaticCollect<F>)>),

--- a/src/gc-sequence/src/map.rs
+++ b/src/gc-sequence/src/map.rs
@@ -4,7 +4,7 @@ use crate::Sequence;
 
 #[must_use = "sequences do nothing unless stepped"]
 #[derive(Debug, Collect)]
-#[collect(no_drop)]
+#[collect(no_drop, bound = "where S: Collect, F: 'static")]
 pub struct Map<S, F>(S, Option<StaticCollect<F>>);
 
 impl<S, F> Map<S, F> {
@@ -32,7 +32,7 @@ where
 
 #[must_use = "sequences do nothing unless stepped"]
 #[derive(Debug, Collect)]
-#[collect(no_drop)]
+#[collect(no_drop, bound = "where S: Collect, C: Collect, F: 'static")]
 pub struct MapWith<S, C, F>(S, Option<(C, StaticCollect<F>)>);
 
 impl<S, C, F> MapWith<S, C, F> {

--- a/src/gc-sequence/src/map_result.rs
+++ b/src/gc-sequence/src/map_result.rs
@@ -4,7 +4,7 @@ use crate::Sequence;
 
 #[must_use = "sequences do nothing unless stepped"]
 #[derive(Debug, Collect)]
-#[collect(no_drop)]
+#[collect(no_drop, bound = "where S: Collect, F: 'static")]
 pub struct MapOk<S, F>(S, Option<StaticCollect<F>>);
 
 impl<S, F> MapOk<S, F> {
@@ -35,7 +35,7 @@ where
 
 #[must_use = "sequences do nothing unless stepped"]
 #[derive(Debug, Collect)]
-#[collect(no_drop)]
+#[collect(no_drop, bound = "where S: Collect, C: Collect, F: 'static")]
 pub struct MapOkWith<S, C, F>(S, Option<(C, StaticCollect<F>)>);
 
 impl<S, C, F> MapOkWith<S, C, F> {
@@ -66,7 +66,7 @@ where
 
 #[must_use = "sequences do nothing unless stepped"]
 #[derive(Debug, Collect)]
-#[collect(no_drop)]
+#[collect(no_drop, bound = "where S: Collect, F: 'static")]
 pub struct MapError<S, F>(S, Option<StaticCollect<F>>);
 
 impl<S, F> MapError<S, F> {

--- a/src/gc-sequence/src/sequence_fn.rs
+++ b/src/gc-sequence/src/sequence_fn.rs
@@ -11,7 +11,7 @@ where
 
 #[must_use = "sequences do nothing unless stepped"]
 #[derive(Debug, Collect)]
-#[collect(no_drop)]
+#[collect(no_drop, bound = "where F: 'static")]
 pub struct SequenceFn<F>(Option<StaticCollect<F>>);
 
 impl<F> SequenceFn<F> {
@@ -43,7 +43,7 @@ where
 
 #[must_use = "sequences do nothing unless stepped"]
 #[derive(Debug, Collect)]
-#[collect(no_drop)]
+#[collect(no_drop, bound = "where C: Collect, F: 'static")]
 pub struct SequenceFnWith<C, F>(Option<(C, StaticCollect<F>)>);
 
 impl<C, F> SequenceFnWith<C, F> {

--- a/src/gc-sequence/src/then.rs
+++ b/src/gc-sequence/src/then.rs
@@ -4,7 +4,10 @@ use crate::Sequence;
 
 #[must_use = "sequences do nothing unless stepped"]
 #[derive(Debug, Collect)]
-#[collect(no_drop)]
+#[collect(
+    no_drop,
+    bound = "where <S as Sequence<'gc>>::Output: Collect, F: 'static"
+)]
 pub enum Then<'gc, S, F>
 where
     S: Sequence<'gc>,
@@ -49,7 +52,10 @@ where
 
 #[must_use = "sequences do nothing unless stepped"]
 #[derive(Debug, Collect)]
-#[collect(no_drop)]
+#[collect(
+    no_drop,
+    bound = "where C: Collect, <S as Sequence<'gc>>::Output: Collect, F: 'static"
+)]
 pub enum ThenWith<'gc, S, C, F>
 where
     S: Sequence<'gc>,


### PR DESCRIPTION
Closes #21. @kyren from further inspection I saw the trait bounds causing issues were not added by the proc macro when the `S` param was absent, since `synstructure` doesn't produce `where` clauses for structs/enums when everything is known (no generics). To fix this, I took your suggestion and added a `bound = "<code>"` option to `#[collect]` that overrides the default bounds added by `AddBounds::Fields`.

My original problem just uses the `S` param as a container for type aliases that already implement `Collect`, so using `#[collect(bound = "")]` solves my problem and i can successfully build again.

Also, when I first started using `gc-arena`, I found it a bit hard to get started just because of a lack of detail about how to actually derive `Collect` (since it needs the additional `#[collect]` attribute, which I had to look up in source for usage). So I also added some details about how to derive it to the `Collect` docs entry (including its ability to be used on fields, which I had no idea about prior to delving into this issue but is actually really useful for my library).