### PR TITLE
Add more useful Debug, Pointer, and Display impls

### DIFF
--- a/src/gc-arena/src/gc.rs
+++ b/src/gc-arena/src/gc.rs
@@ -1,4 +1,4 @@
-use core::fmt::{self, Debug};
+use core::fmt::{self, Debug, Display, Pointer};
 use core::marker::PhantomData;
 use core::ops::Deref;
 use core::ptr::NonNull;
@@ -18,11 +18,21 @@ pub struct Gc<'gc, T: 'gc + Collect> {
     _invariant: Invariant<'gc>,
 }
 
-impl<'gc, T: 'gc + Collect> Debug for Gc<'gc, T> {
+impl<'gc, T: 'gc + Collect + Debug> Debug for Gc<'gc, T> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_struct("Gc")
-            .field("ptr", unsafe { &self.ptr.as_ref().value.get() })
-            .finish()
+        fmt::Debug::fmt(&**self, fmt)
+    }
+}
+
+impl<'gc, T: 'gc + Collect> Pointer for Gc<'gc, T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Pointer::fmt(&Gc::as_ptr(*self), fmt)
+    }
+}
+
+impl<'gc, T: 'gc + Collect + Display> Display for Gc<'gc, T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&**self, fmt)
     }
 }
 


### PR DESCRIPTION
This adds more useful Debug and Pointer impls for the Gc and GcCell types, and adds a Display impl for the Gc type.  These impls mirror the implementations for Rc and RefCell from the standard library.

Note: this does mean that you will no longer be able to derive Debug on types that contain a Gc ~or GcCell~ if they themselves contain types that don't implement Debug.  You still can manually implement Debug in this case however.