### PR TITLE
generic arenas

### DIFF
--- a/src/gc-arena/src/arena.rs
+++ b/src/gc-arena/src/arena.rs
@@ -97,18 +97,14 @@ impl ArenaParameters {
 /// pointers and manually ensuring that invariants are held.
 #[macro_export]
 macro_rules! make_arena {
-    ($arena:ident, $root:ident) => {
-        make_arena!(pub(self) $arena, $root);
-    };
-
-    ($vis:vis $arena:ident, $root:ident) => {
+    ($vis:vis $arena:ident $(( $($arena_generics:tt)* ))?, $root:ident $(( $($root_generics:tt)* ))?) => {
         // Instead of generating an impl of `RootProvider`, we use a trait object.
         // The projection `<R as RootProvider<'gc>>::Root` is used to obtain the root
         // type with the lifetime `'gc` applied
         // By using a trait object, we avoid the need to generate a new type for each
         // invocation of this macro, which would lead to name conflicts if the macro was
         // used multiple times in the same scope.
-        $vis type $arena = $crate::Arena<dyn for<'a> $crate::RootProvider<'a, Root = $root<'a>>>;
+        $vis type $arena $(< $($arena_generics)* >)? = $crate::Arena<dyn for<'a> $crate::RootProvider<'a, Root = $root<'a, $($($root_generics)*)?>>>;
     };
 }
 

--- a/src/gc-arena/src/arena.rs
+++ b/src/gc-arena/src/arena.rs
@@ -97,28 +97,14 @@ impl ArenaParameters {
 /// pointers and manually ensuring that invariants are held.
 #[macro_export]
 macro_rules! make_arena {
-    ($vis:vis $arena:ident < $($rest:tt)*)               => { make_arena!(@arena $vis $arena () $($rest)*); };
-    ($vis:vis $arena:ident , $root:ident < $($rest:tt)*) => { make_arena!(@root $vis $arena () $root () $($rest)*); };
-    ($vis:vis $arena:ident , $root:ident)                => { make_arena!(@done $vis $arena () $root ()); };
-
-    (@arena $vis:vis $arena:ident ($($arena_gen:tt)*) $tok:tt , $($rest:tt)*)                                   => { make_arena!(@arena $vis $arena ($($arena_gen)* $tok ,) $($rest)*); };
-    (@arena $vis:vis $arena:ident ($($arena_gen:tt)*) $tok:tt > , $root:ident < $($rest:tt)*)                   => { make_arena!(@root $vis $arena ($($arena_gen)* $tok) $root () $($rest)*); };
-    (@arena $vis:vis $arena:ident ($($arena_gen:tt)*) $tok:tt > , $root:ident)                                  => { make_arena!(@done $vis $arena ($($arena_gen)* $tok) $root ()); };
-    (@arena $vis:vis $arena:ident ($($arena_gen:tt)*) const $var:ident : $ty:ty , $($rest:tt)*)                 => { make_arena!(@arena $vis $arena ($($arena_gen)* const $var : $ty ,) $($rest)*); };
-    (@arena $vis:vis $arena:ident ($($arena_gen:tt)*) const $var:ident : $ty:ty > , $root:ident < $($rest:tt)*) => { make_arena!(@root $vis $arena ($($arena_gen)* const $var : $ty) $root () $($rest)*); };
-    (@arena $vis:vis $arena:ident ($($arena_gen:tt)*) const $var:ident : $ty:ty > , $root:ident)                => { make_arena!(@done $vis $arena ($($arena_gen)* const $var : $ty) $root ()); };
-
-    (@root $vis:vis $arena:ident ($($arena_gen:tt)*) $root:ident ($($root_gen:tt)*) $ty:ty , $($rest:tt)*) => { make_arena!(@root $vis $arena ($($arena_gen)*) $root ($($root_gen)* $ty ,) $($rest)*); };
-    (@root $vis:vis $arena:ident ($($arena_gen:tt)*) $root:ident ($($root_gen:tt)*) $ty:ty >)              => { make_arena!(@done $vis $arena ($($arena_gen)*) $root ($($root_gen)* $ty)); };
-
-    (@done $vis:vis $arena:ident ($($arena_gen:tt)*) $root:ident ($($root_gen:tt)*)) => {
+    ($vis:vis $arena:ident $(( $($arena_gen:tt)* ))?, $root:ident $(( $($root_gen:tt)* ))?) => {
         // Instead of generating an impl of `RootProvider`, we use a trait object.
         // The projection `<R as RootProvider<'gc>>::Root` is used to obtain the root
         // type with the lifetime `'gc` applied
         // By using a trait object, we avoid the need to generate a new type for each
         // invocation of this macro, which would lead to name conflicts if the macro was
         // used multiple times in the same scope.
-        $vis type $arena<$($arena_gen)*> = $crate::Arena<dyn for<'gc> $crate::RootProvider<'gc, Root = $root<'gc, $($root_gen)*>>>;
+        $vis type $arena $( <$($arena_gen)*> )? = $crate::Arena<dyn for<'gc> $crate::RootProvider<'gc, Root = $root<'gc, $( $($root_gen)* )?>>>;
     };
 }
 

--- a/src/gc-arena/src/arena.rs
+++ b/src/gc-arena/src/arena.rs
@@ -101,17 +101,15 @@ macro_rules! make_arena {
     ($vis:vis $arena:ident , $root:ident < $($rest:tt)*) => { make_arena!(@root $vis $arena () $root () $($rest)*); };
     ($vis:vis $arena:ident , $root:ident)                => { make_arena!(@done $vis $arena () $root ()); };
 
-    (@arena $vis:vis $arena:ident ($($arena_gen:tt)*) $ty:ident , $($rest:tt)*)                                 => { make_arena!(@arena $vis $arena ($($arena_gen)* $ty ,) $($rest)*); };
-    (@arena $vis:vis $arena:ident ($($arena_gen:tt)*) $ty:ident > , $root:ident < $($rest:tt)*)                 => { make_arena!(@root $vis $arena ($($arena_gen)* $ty) $root () $($rest)*); };
-    (@arena $vis:vis $arena:ident ($($arena_gen:tt)*) $ty:ident > , $root:ident)                                => { make_arena!(@done $vis $arena ($($arena_gen)* $ty) $root ()); };
+    (@arena $vis:vis $arena:ident ($($arena_gen:tt)*) $tok:tt , $($rest:tt)*)                                   => { make_arena!(@arena $vis $arena ($($arena_gen)* $tok ,) $($rest)*); };
+    (@arena $vis:vis $arena:ident ($($arena_gen:tt)*) $tok:tt > , $root:ident < $($rest:tt)*)                   => { make_arena!(@root $vis $arena ($($arena_gen)* $tok) $root () $($rest)*); };
+    (@arena $vis:vis $arena:ident ($($arena_gen:tt)*) $tok:tt > , $root:ident)                                  => { make_arena!(@done $vis $arena ($($arena_gen)* $tok) $root ()); };
     (@arena $vis:vis $arena:ident ($($arena_gen:tt)*) const $var:ident : $ty:ty , $($rest:tt)*)                 => { make_arena!(@arena $vis $arena ($($arena_gen)* const $var : $ty ,) $($rest)*); };
     (@arena $vis:vis $arena:ident ($($arena_gen:tt)*) const $var:ident : $ty:ty > , $root:ident < $($rest:tt)*) => { make_arena!(@root $vis $arena ($($arena_gen)* const $var : $ty) $root () $($rest)*); };
     (@arena $vis:vis $arena:ident ($($arena_gen:tt)*) const $var:ident : $ty:ty > , $root:ident)                => { make_arena!(@done $vis $arena ($($arena_gen)* const $var : $ty) $root ()); };
 
-    (@root $vis:vis $arena:ident ($($arena_gen:tt)*) $root:ident ($($root_gen:tt)*) $ty:ty , $($rest:tt)*)                    => { make_arena!(@root $vis $arena ($($arena_gen)*) $root ($($root_gen)* $ty ,) $($rest)*); };
-    (@root $vis:vis $arena:ident ($($arena_gen:tt)*) $root:ident ($($root_gen:tt)*) $ty:ty >)                                 => { make_arena!(@done $vis $arena ($($arena_gen)*) $root ($($root_gen)* $ty)); };
-    (@root $vis:vis $arena:ident ($($arena_gen:tt)*) $root:ident ($($root_gen:tt)*) const $var:ident : $ty:ty , $($rest:tt)*) => { make_arena!(@root $vis $arena ($($arena_gen)*) $root ($($root_gen)* const $var : $ty ,) $($rest)*); };
-    (@root $vis:vis $arena:ident ($($arena_gen:tt)*) $root:ident ($($root_gen:tt)*) const $var:ident : $ty:ty >)              => { make_arena!(@done $vis $arena ($($arena_gen)*) $root ($($root_gen)* const $var : $ty)); };
+    (@root $vis:vis $arena:ident ($($arena_gen:tt)*) $root:ident ($($root_gen:tt)*) $ty:ty , $($rest:tt)*) => { make_arena!(@root $vis $arena ($($arena_gen)*) $root ($($root_gen)* $ty ,) $($rest)*); };
+    (@root $vis:vis $arena:ident ($($arena_gen:tt)*) $root:ident ($($root_gen:tt)*) $ty:ty >)              => { make_arena!(@done $vis $arena ($($arena_gen)*) $root ($($root_gen)* $ty)); };
 
     (@done $vis:vis $arena:ident ($($arena_gen:tt)*) $root:ident ($($root_gen:tt)*)) => {
         // Instead of generating an impl of `RootProvider`, we use a trait object.
@@ -120,7 +118,7 @@ macro_rules! make_arena {
         // By using a trait object, we avoid the need to generate a new type for each
         // invocation of this macro, which would lead to name conflicts if the macro was
         // used multiple times in the same scope.
-        $vis type $arena <$($arena_gen)*> = $crate::Arena<dyn for<'gc> $crate::RootProvider<'gc, Root = $root<'gc, $($root_gen)*>>>;
+        $vis type $arena<$($arena_gen)*> = $crate::Arena<dyn for<'gc> $crate::RootProvider<'gc, Root = $root<'gc, $($root_gen)*>>>;
     };
 }
 

--- a/src/gc-arena/src/arena.rs
+++ b/src/gc-arena/src/arena.rs
@@ -104,7 +104,7 @@ macro_rules! make_arena {
         // By using a trait object, we avoid the need to generate a new type for each
         // invocation of this macro, which would lead to name conflicts if the macro was
         // used multiple times in the same scope.
-        $vis type $arena $(< $($arena_generics)* >)? = $crate::Arena<dyn for<'a> $crate::RootProvider<'a, Root = $root<'a, $($($root_generics)*)?>>>;
+        $vis type $arena $(< $($arena_generics)* >)? = $crate::Arena<dyn for<'gc> $crate::RootProvider<'gc, Root = $root<'gc, $($($root_generics)*)?>>>;
     };
 }
 

--- a/src/gc-arena/src/arena.rs
+++ b/src/gc-arena/src/arena.rs
@@ -97,14 +97,30 @@ impl ArenaParameters {
 /// pointers and manually ensuring that invariants are held.
 #[macro_export]
 macro_rules! make_arena {
-    ($vis:vis $arena:ident $(( $($arena_generics:tt)* ))?, $root:ident $(( $($root_generics:tt)* ))?) => {
+    ($vis:vis $arena:ident < $($rest:tt)*)               => { make_arena!(@arena $vis $arena () $($rest)*); };
+    ($vis:vis $arena:ident , $root:ident < $($rest:tt)*) => { make_arena!(@root $vis $arena () $root () $($rest)*); };
+    ($vis:vis $arena:ident , $root:ident)                => { make_arena!(@done $vis $arena () $root ()); };
+
+    (@arena $vis:vis $arena:ident ($($arena_gen:tt)*) $ty:ident , $($rest:tt)*)                                 => { make_arena!(@arena $vis $arena ($($arena_gen)* $ty ,) $($rest)*); };
+    (@arena $vis:vis $arena:ident ($($arena_gen:tt)*) $ty:ident > , $root:ident < $($rest:tt)*)                 => { make_arena!(@root $vis $arena ($($arena_gen)* $ty) $root () $($rest)*); };
+    (@arena $vis:vis $arena:ident ($($arena_gen:tt)*) $ty:ident > , $root:ident)                                => { make_arena!(@done $vis $arena ($($arena_gen)* $ty) $root ()); };
+    (@arena $vis:vis $arena:ident ($($arena_gen:tt)*) const $var:ident : $ty:ty , $($rest:tt)*)                 => { make_arena!(@arena $vis $arena ($($arena_gen)* const $var : $ty ,) $($rest)*); };
+    (@arena $vis:vis $arena:ident ($($arena_gen:tt)*) const $var:ident : $ty:ty > , $root:ident < $($rest:tt)*) => { make_arena!(@root $vis $arena ($($arena_gen)* const $var : $ty) $root () $($rest)*); };
+    (@arena $vis:vis $arena:ident ($($arena_gen:tt)*) const $var:ident : $ty:ty > , $root:ident)                => { make_arena!(@done $vis $arena ($($arena_gen)* const $var : $ty) $root ()); };
+
+    (@root $vis:vis $arena:ident ($($arena_gen:tt)*) $root:ident ($($root_gen:tt)*) $ty:ty , $($rest:tt)*)                    => { make_arena!(@root $vis $arena ($($arena_gen)*) $root ($($root_gen)* $ty ,) $($rest)*); };
+    (@root $vis:vis $arena:ident ($($arena_gen:tt)*) $root:ident ($($root_gen:tt)*) $ty:ty >)                                 => { make_arena!(@done $vis $arena ($($arena_gen)*) $root ($($root_gen)* $ty)); };
+    (@root $vis:vis $arena:ident ($($arena_gen:tt)*) $root:ident ($($root_gen:tt)*) const $var:ident : $ty:ty , $($rest:tt)*) => { make_arena!(@root $vis $arena ($($arena_gen)*) $root ($($root_gen)* const $var : $ty ,) $($rest)*); };
+    (@root $vis:vis $arena:ident ($($arena_gen:tt)*) $root:ident ($($root_gen:tt)*) const $var:ident : $ty:ty >)              => { make_arena!(@done $vis $arena ($($arena_gen)*) $root ($($root_gen)* const $var : $ty)); };
+
+    (@done $vis:vis $arena:ident ($($arena_gen:tt)*) $root:ident ($($root_gen:tt)*)) => {
         // Instead of generating an impl of `RootProvider`, we use a trait object.
         // The projection `<R as RootProvider<'gc>>::Root` is used to obtain the root
         // type with the lifetime `'gc` applied
         // By using a trait object, we avoid the need to generate a new type for each
         // invocation of this macro, which would lead to name conflicts if the macro was
         // used multiple times in the same scope.
-        $vis type $arena $(< $($arena_generics)* >)? = $crate::Arena<dyn for<'gc> $crate::RootProvider<'gc, Root = $root<'gc, $($($root_generics)*)?>>>;
+        $vis type $arena <$($arena_gen)*> = $crate::Arena<dyn for<'gc> $crate::RootProvider<'gc, Root = $root<'gc, $($root_gen)*>>>;
     };
 }
 

--- a/src/gc-arena/tests/tests.rs
+++ b/src/gc-arena/tests/tests.rs
@@ -256,7 +256,7 @@ fn generic_make_arena() {
     #[derive(Collect)]
     #[collect(no_drop)]
     struct Test<'gc, T: 'gc + Collect, const N: usize, U: 'gc + Collect>(Gc<'gc, T>, [(); N], U);
-    make_arena!(TestArena<T, const N: usize, U>, Test<(T, T), N, Gc<'gc, U>>);
+    make_arena!(TestArena(T, const N: usize, U), Test((T, T), N, Gc<'gc, U>));
 
     fn test<const N: usize, T: 'static + Collect + Copy, U: 'static + Collect + Copy>(
         v: T,

--- a/src/gc-arena/tests/tests.rs
+++ b/src/gc-arena/tests/tests.rs
@@ -252,6 +252,22 @@ fn derive_collect() {
 }
 
 #[test]
+fn generic_make_arena() {
+    #[derive(Collect)]
+    #[collect(no_drop)]
+    struct Test<'gc, T: 'gc + Collect>(Gc<'gc, T>);
+    make_arena!(TestArena(T), Test(T));
+
+    fn test<T: 'static + Collect + Copy>(v: T) -> T {
+        let arena = TestArena::new(Default::default(), |mc| Test(Gc::allocate(mc, v)));
+        arena.mutate(|_, arena| *arena.0)
+    }
+
+    assert_eq!(test(34), 34);
+    assert_eq!(test(false), false);
+}
+
+#[test]
 fn ui() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/*.rs");

--- a/src/gc-arena/tests/tests.rs
+++ b/src/gc-arena/tests/tests.rs
@@ -256,7 +256,7 @@ fn generic_make_arena() {
     #[derive(Collect)]
     #[collect(no_drop)]
     struct Test<'gc, T: 'gc + Collect, const N: usize, U: 'gc + Collect>(Gc<'gc, T>, [(); N], U);
-    make_arena!(TestArena(T, const N: usize, U), Test((T, T), N, Gc<'gc, U>));
+    make_arena!(TestArena<T, const N: usize, U>, Test<(T, T), N, Gc<'gc, U>>);
 
     fn test<const N: usize, T: 'static + Collect + Copy, U: 'static + Collect + Copy>(
         v: T,


### PR DESCRIPTION
I ran into an issue where a generic function needs to take a type `T` as input and internally use an arena based on `T`. But rust doesn't allow items to reference type parameters of the parent scope, so (I believe) this is impossible currently. Easy solution: allow arenas to be generic. This just adds a little syntax to the `make_arena!` macro that lets you introduce and use generic parameters by just dumping the entire contents of a parenthesis-wrapped token tree into generic param brackets. So we can now do things like this:

```rs
#[derive(Collect)]
#[collect(no_drop)]
struct Test<'gc, T: 'gc + Collect>(Gc<'gc, T>);
make_arena!(TestArena(T), Test(T)); // introduce and then use a type param T

fn test<T: 'static + Collect + Copy>(v: T) -> T {
    let arena = TestArena::new(Default::default(), |mc| Test(Gc::allocate(mc, v)));
    arena.mutate(|_, arena| *arena.0)
}

assert_eq!(test(34), 34);
assert_eq!(test(false), false);
```

The reason for taking token trees like `( $($t:tt)* )` rather than a comma-separated ident list like `< $($t:ident),* >` was for two reasons: 1) it allows the left (introducing) side to have const generics like `Foo(const N: usize)` and 2) it allows the right to have non-trivial type expressions like `Bar(<T as Thingy>::Output)`. It also makes it really easy to parse with `macro_rules!` since parenthesis mark the boundaries of token trees. There's probably some token munching magic we could do to allow angle brackets instead of parenthesis for this, but I don't think it's worth the effort in this case as long as we document it well.

This also renames the `'a` lifetime in the dyn trait decl to `'gc` to match existing standards since it is exposed to the root type generic parameters: e.g., you can write something like `make_arena!(Foo(T), Bar(Gc<'gc, T>)`.

I also removed the macro overload without `$vis:vis` because apparently `:vis` matches empty string and in that case is equivalent to `pub(self)` anyway.