### PR TITLE
Allow Gc and GcCell pointers to be reconstituted from raw pointers

### DIFF
--- a/src/gc-arena/src/gc.rs
+++ b/src/gc-arena/src/gc.rs
@@ -1,11 +1,14 @@
+use core::alloc::Layout;
 use core::fmt::{self, Debug, Display, Pointer};
 use core::marker::PhantomData;
+use core::mem::align_of;
 use core::ops::Deref;
 use core::ptr::NonNull;
 
 use crate::collect::Collect;
 use crate::context::{CollectionContext, MutationContext};
 use crate::gc_weak::GcWeak;
+use crate::layout_polyfill;
 use crate::types::{GcBox, Invariant};
 
 /// A garbage collected pointer to a type T.  Implements Copy, and is implemented as a plain machine
@@ -62,10 +65,7 @@ impl<'gc, T: Collect + 'gc> Deref for Gc<'gc, T> {
 
 impl<'gc, T: 'gc + Collect> Gc<'gc, T> {
     pub fn allocate(mc: MutationContext<'gc, '_>, t: T) -> Gc<'gc, T> {
-        Gc {
-            ptr: unsafe { mc.allocate(t) },
-            _invariant: PhantomData,
-        }
+        unsafe { Self::from_inner(mc.allocate(t)) }
     }
 
     pub fn downgrade(this: Gc<'gc, T>) -> GcWeak<'gc, T> {
@@ -88,4 +88,43 @@ impl<'gc, T: 'gc + Collect> Gc<'gc, T> {
     pub fn as_ptr(gc: Gc<'gc, T>) -> *const T {
         unsafe { gc.ptr.as_ref().value.get() }
     }
+
+    unsafe fn from_inner(ptr: NonNull<GcBox<T>>) -> Self {
+        Self {
+            ptr,
+            _invariant: PhantomData,
+        }
+    }
+
+    unsafe fn from_ptr(ptr: *mut GcBox<T>) -> Self {
+        unsafe { Self::from_inner(NonNull::new_unchecked(ptr)) }
+    }
+
+    /// Construct a [Gc] from a raw pointer
+    ///
+    /// # Safety
+    ///
+    /// You must guarantee the following:
+    /// - The pointer _must_ come from a call to [`Gc::as_ptr`].
+    /// - The pointer _must_ be valid.  This means it must either be generated and used within the
+    /// same arena mutation call or be traced between arena mutations (e.g. via a type that traces
+    /// it) so that it remains live.
+    pub unsafe fn from_raw(ptr: *const T) -> Self {
+        let offset = data_offset::<T>();
+
+        let raw = ptr.cast::<u8>();
+
+        // Reverse the offset to find the original GcBox.
+        let gc_ptr = unsafe { raw.sub(offset) as *mut GcBox<T> };
+
+        unsafe { Self::from_ptr(gc_ptr) }
+    }
+}
+
+/// Get the offset within a `GcBox` for the payload behind a pointer.
+fn data_offset<T>() -> usize {
+    // Calculates the aligned offset of the value contained within a GcBox.
+    // Because GcBox is repr(C), the contained value will always be the last field in memory.
+    let layout = Layout::new::<GcBox<()>>();
+    layout.size() + layout_polyfill::layout_padding_needed_for(&layout, align_of::<T>())
 }

--- a/src/gc-arena/src/gc.rs
+++ b/src/gc-arena/src/gc.rs
@@ -1,9 +1,10 @@
 use core::alloc::Layout;
+use core::cell::UnsafeCell;
 use core::fmt::{self, Debug, Display, Pointer};
 use core::marker::PhantomData;
 use core::mem::align_of;
 use core::ops::Deref;
-use core::ptr::NonNull;
+use core::ptr::{self, NonNull};
 
 use crate::collect::Collect;
 use crate::context::{CollectionContext, MutationContext};
@@ -86,7 +87,13 @@ impl<'gc, T: 'gc + Collect> Gc<'gc, T> {
     }
 
     pub fn as_ptr(gc: Gc<'gc, T>) -> *const T {
-        unsafe { gc.ptr.as_ref().value.get() }
+        let ptr: *mut GcBox<T> = NonNull::as_ptr(gc.ptr);
+
+        // SAFETY: This cannot go through Deref::deref or create temporary
+        // references because we need to preserve pointer provenance in order
+        // to play nicely with stacked borrows. So, this gets a pointer to the
+        // underlying value without creating any temporary references.
+        unsafe { UnsafeCell::raw_get(ptr::addr_of!((*ptr).value) as _) }
     }
 
     unsafe fn from_inner(ptr: NonNull<GcBox<T>>) -> Self {

--- a/src/gc-arena/src/gc_cell.rs
+++ b/src/gc-arena/src/gc_cell.rs
@@ -78,16 +78,30 @@ impl<'gc, T: 'gc + Collect> GcCell<'gc, T> {
         this.as_ptr() == other.as_ptr()
     }
 
-    pub fn as_ptr(self) -> *mut T {
+    pub fn as_ptr(&self) -> *const GcRefCell<T> {
+        Gc::as_ptr(self.0)
+    }
+
+    /// Returns a pointer to the inner `T`
+    pub fn inner_ptr(&self) -> *mut T {
         self.0.cell.as_ptr()
     }
 
+    /// Construct a [GcCell] from a raw pointer
+    ///
+    /// # Safety
+    ///
+    /// See the safety guidelines for [`Gc::from_raw`].
+    pub unsafe fn from_raw(ptr: *const GcRefCell<T>) -> Self {
+        Self(Gc::from_raw(ptr))
+    }
+
     #[track_caller]
-    pub fn read<'a>(&'a self) -> Ref<'a, T> {
+    pub fn read(&self) -> Ref<'_, T> {
         self.0.cell.borrow()
     }
 
-    pub fn try_read<'a>(&'a self) -> Result<Ref<'a, T>, BorrowError> {
+    pub fn try_read(&self) -> Result<Ref<'_, T>, BorrowError> {
         self.0.cell.try_borrow()
     }
 
@@ -108,7 +122,7 @@ impl<'gc, T: 'gc + Collect> GcCell<'gc, T> {
     }
 }
 
-pub(crate) struct GcRefCell<T: Collect> {
+pub struct GcRefCell<T: Collect> {
     cell: RefCell<T>,
 }
 

--- a/src/gc-arena/src/layout_polyfill.rs
+++ b/src/gc-arena/src/layout_polyfill.rs
@@ -1,0 +1,15 @@
+use core::alloc::Layout;
+
+#[cfg(alloc_layout_extra)]
+#[inline]
+pub(crate) fn layout_padding_needed_for(this: &Layout, align: usize) -> usize {
+    layout.padding_needed_for(align)
+}
+
+#[cfg(not(alloc_layout_extra))]
+#[inline]
+pub(crate) fn layout_padding_needed_for(this: &Layout, align: usize) -> usize {
+    let len = this.size();
+    let len_rounded_up = len.wrapping_add(align).wrapping_sub(1) & !align.wrapping_sub(1);
+    len_rounded_up.wrapping_sub(len)
+}

--- a/src/gc-arena/src/lib.rs
+++ b/src/gc-arena/src/lib.rs
@@ -16,6 +16,7 @@ mod gc;
 mod gc_cell;
 mod gc_weak;
 mod gc_weak_cell;
+mod layout_polyfill;
 mod no_drop;
 mod static_collect;
 mod types;
@@ -30,4 +31,5 @@ pub use self::{
     gc_weak_cell::GcWeakCell,
     no_drop::MustNotImplDrop,
     static_collect::StaticCollect,
+    types::Invariant,
 };

--- a/src/gc-arena/src/types.rs
+++ b/src/gc-arena/src/types.rs
@@ -26,6 +26,7 @@ pub(crate) enum GcColor {
     Black,
 }
 
+#[repr(C)]
 pub(crate) struct GcBox<T: Collect + ?Sized> {
     pub(crate) flags: GcFlags,
     pub(crate) next: Cell<Option<NonNull<GcBox<dyn Collect>>>>,
@@ -109,4 +110,4 @@ impl GcFlags {
 }
 
 // Phantom type that holds a lifetime and ensures that it is invariant.
-pub(crate) type Invariant<'a> = PhantomData<Cell<&'a ()>>;
+pub type Invariant<'a> = PhantomData<Cell<&'a ()>>;


### PR DESCRIPTION
This adds a `from_raw` method on the `Gc` and `GcCell` types to allow garbage-collected pointers to be round-tripped through raw pointers.  This is useful to allow these types to participate in e.g. pointer tagging and NaN boxing schemes.

This also fixes a soundness issue (detected by miri) regarding stacked borrows in `Gc`'s `as_ptr` implementation.