### PR TITLE
Fix unsoundness in Hash{Map, Set}'s Collect implementation

### DIFF
--- a/src/gc-arena/src/collect_impl.rs
+++ b/src/gc-arena/src/collect_impl.rs
@@ -160,7 +160,7 @@ unsafe impl<K, V, S> Collect for HashMap<K, V, S>
 where
     K: Eq + Hash + Collect,
     V: Collect,
-    S: BuildHasher,
+    S: BuildHasher + 'static,
 {
     #[inline]
     fn needs_trace() -> bool {
@@ -180,7 +180,7 @@ where
 unsafe impl<T, S> Collect for HashSet<T, S>
 where
     T: Eq + Hash + Collect,
-    S: BuildHasher,
+    S: BuildHasher + 'static,
 {
     #[inline]
     fn needs_trace() -> bool {


### PR DESCRIPTION
These implementations accept arbitrary `S: BuildHasher`, but don't trace the value at all.

This adds an extra `S: 'static` bound to prevent smuggling Gc pointers through the hasher. (All 'real' hashers are `'static`, so this is better than adding a `Collect` bound w.r.t. third-party hashers support)