### PR TITLE
Basic support for `Gc` pointers to unsized types

### DIFF
--- a/src/gc-arena/src/dynamic_roots.rs
+++ b/src/gc-arena/src/dynamic_roots.rs
@@ -4,7 +4,7 @@ use alloc::{
 };
 use core::mem;
 
-use crate::{types::GcBoxPtr, Collect, Gc, GcCell, MutationContext, Root, Rootable};
+use crate::{types::GcBox, Collect, Gc, GcCell, MutationContext, Root, Rootable};
 
 // SAFETY: Allows us to conert `Gc<'gc>` pointers to `Gc<'static>` and back, and this is VERY
 // sketchy. We know it is safe because:
@@ -55,7 +55,7 @@ impl<'gc> DynamicRootSet<'gc> {
 
         let rc = Rc::new(inner.set_id.clone());
         inner.handles.push(Handle {
-            ptr: unsafe { GcBoxPtr::erase(root.ptr) },
+            ptr: unsafe { GcBox::erase(root.ptr) },
             rc: Rc::downgrade(&rc),
         });
 
@@ -108,6 +108,6 @@ unsafe impl<'gc> Collect for Inner {
 }
 
 struct Handle {
-    ptr: GcBoxPtr,
+    ptr: GcBox,
     rc: Weak<Rc<SetId>>,
 }

--- a/src/gc-arena/src/gc.rs
+++ b/src/gc-arena/src/gc.rs
@@ -15,7 +15,7 @@ use crate::types::{GcBox, GcBoxInner, Invariant};
 /// pointers will never be dangling and are always safe to access.
 pub struct Gc<'gc, T: ?Sized + 'gc> {
     pub(crate) ptr: NonNull<GcBoxInner<T>>,
-    _invariant: Invariant<'gc>,
+    pub(crate) _invariant: Invariant<'gc>,
 }
 
 impl<'gc, T: Debug + ?Sized + 'gc> Debug for Gc<'gc, T> {

--- a/src/gc-arena/src/gc.rs
+++ b/src/gc-arena/src/gc.rs
@@ -63,7 +63,7 @@ impl<'gc, T: ?Sized + 'gc> Deref for Gc<'gc, T> {
 impl<'gc, T: Collect + 'gc> Gc<'gc, T> {
     pub fn allocate(mc: MutationContext<'gc, '_>, t: T) -> Gc<'gc, T> {
         Gc {
-            ptr: unsafe { mc.allocate(t) },
+            ptr: mc.allocate(t),
             _invariant: PhantomData,
         }
     }

--- a/src/gc-arena/src/gc_weak.rs
+++ b/src/gc-arena/src/gc_weak.rs
@@ -5,25 +5,25 @@ use crate::{CollectionContext, MutationContext};
 
 use core::fmt::{self, Debug};
 
-pub struct GcWeak<'gc, T: 'gc + Collect> {
+pub struct GcWeak<'gc, T: ?Sized + 'gc> {
     pub(crate) inner: Gc<'gc, T>,
 }
 
-impl<'gc, T: Collect + 'gc> Copy for GcWeak<'gc, T> {}
+impl<'gc, T: ?Sized + 'gc> Copy for GcWeak<'gc, T> {}
 
-impl<'gc, T: Collect + 'gc> Clone for GcWeak<'gc, T> {
+impl<'gc, T: ?Sized + 'gc> Clone for GcWeak<'gc, T> {
     fn clone(&self) -> GcWeak<'gc, T> {
         *self
     }
 }
 
-impl<'gc, T: 'gc + Collect> Debug for GcWeak<'gc, T> {
+impl<'gc, T: ?Sized + 'gc> Debug for GcWeak<'gc, T> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "(GcWeak)")
     }
 }
 
-unsafe impl<'gc, T: 'gc + Collect> Collect for GcWeak<'gc, T> {
+unsafe impl<'gc, T: ?Sized + 'gc> Collect for GcWeak<'gc, T> {
     fn trace(&self, _cc: CollectionContext) {
         unsafe {
             let gc = GcBox::erase(self.inner.ptr);
@@ -32,7 +32,7 @@ unsafe impl<'gc, T: 'gc + Collect> Collect for GcWeak<'gc, T> {
     }
 }
 
-impl<'gc, T: Collect + 'gc> GcWeak<'gc, T> {
+impl<'gc, T: ?Sized + 'gc> GcWeak<'gc, T> {
     pub fn upgrade(&self, mc: MutationContext<'gc, '_>) -> Option<Gc<'gc, T>> {
         unsafe {
             let ptr = GcBox::erase(self.inner.ptr);

--- a/src/gc-arena/src/gc_weak.rs
+++ b/src/gc-arena/src/gc_weak.rs
@@ -1,6 +1,6 @@
 use crate::collect::Collect;
 use crate::gc::Gc;
-use crate::types::GcBoxPtr;
+use crate::types::GcBox;
 use crate::{CollectionContext, MutationContext};
 
 use core::fmt::{self, Debug};
@@ -26,7 +26,7 @@ impl<'gc, T: 'gc + Collect> Debug for GcWeak<'gc, T> {
 unsafe impl<'gc, T: 'gc + Collect> Collect for GcWeak<'gc, T> {
     fn trace(&self, _cc: CollectionContext) {
         unsafe {
-            let gc = GcBoxPtr::erase(self.inner.ptr);
+            let gc = GcBox::erase(self.inner.ptr);
             gc.flags().set_traced_weak_ref(true);
         }
     }
@@ -35,7 +35,7 @@ unsafe impl<'gc, T: 'gc + Collect> Collect for GcWeak<'gc, T> {
 impl<'gc, T: Collect + 'gc> GcWeak<'gc, T> {
     pub fn upgrade(&self, mc: MutationContext<'gc, '_>) -> Option<Gc<'gc, T>> {
         unsafe {
-            let ptr = GcBoxPtr::erase(self.inner.ptr);
+            let ptr = GcBox::erase(self.inner.ptr);
             mc.upgrade(ptr).then(|| self.inner)
         }
     }

--- a/src/gc-arena/src/gc_weak_cell.rs
+++ b/src/gc-arena/src/gc_weak_cell.rs
@@ -4,25 +4,25 @@ use crate::{collect::Collect, MutationContext};
 
 use core::fmt::{self, Debug};
 
-pub struct GcWeakCell<'gc, T: 'gc + Collect> {
+pub struct GcWeakCell<'gc, T: ?Sized + 'gc> {
     pub(crate) inner: GcCell<'gc, T>,
 }
 
-impl<'gc, T: Collect + 'gc> Copy for GcWeakCell<'gc, T> {}
+impl<'gc, T: ?Sized + 'gc> Copy for GcWeakCell<'gc, T> {}
 
-impl<'gc, T: Collect + 'gc> Clone for GcWeakCell<'gc, T> {
+impl<'gc, T: ?Sized + 'gc> Clone for GcWeakCell<'gc, T> {
     fn clone(&self) -> GcWeakCell<'gc, T> {
         *self
     }
 }
 
-impl<'gc, T: 'gc + Collect> Debug for GcWeakCell<'gc, T> {
+impl<'gc, T: ?Sized + 'gc> Debug for GcWeakCell<'gc, T> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "(GcWeakCell)")
     }
 }
 
-unsafe impl<'gc, T: 'gc + Collect> Collect for GcWeakCell<'gc, T> {
+unsafe impl<'gc, T: ?Sized + 'gc> Collect for GcWeakCell<'gc, T> {
     fn trace(&self, _cc: crate::CollectionContext) {
         unsafe {
             let gc = GcBox::erase(self.inner.0.ptr);
@@ -31,7 +31,7 @@ unsafe impl<'gc, T: 'gc + Collect> Collect for GcWeakCell<'gc, T> {
     }
 }
 
-impl<'gc, T: Collect + 'gc> GcWeakCell<'gc, T> {
+impl<'gc, T: ?Sized + 'gc> GcWeakCell<'gc, T> {
     pub fn upgrade(&self, mc: MutationContext<'gc, '_>) -> Option<GcCell<'gc, T>> {
         unsafe {
             let ptr = GcBox::erase(self.inner.0.ptr);

--- a/src/gc-arena/src/gc_weak_cell.rs
+++ b/src/gc-arena/src/gc_weak_cell.rs
@@ -1,4 +1,4 @@
-use crate::types::GcBoxPtr;
+use crate::types::GcBox;
 use crate::GcCell;
 use crate::{collect::Collect, MutationContext};
 
@@ -25,7 +25,7 @@ impl<'gc, T: 'gc + Collect> Debug for GcWeakCell<'gc, T> {
 unsafe impl<'gc, T: 'gc + Collect> Collect for GcWeakCell<'gc, T> {
     fn trace(&self, _cc: crate::CollectionContext) {
         unsafe {
-            let gc = GcBoxPtr::erase(self.inner.0.ptr);
+            let gc = GcBox::erase(self.inner.0.ptr);
             gc.flags().set_traced_weak_ref(true);
         }
     }
@@ -34,7 +34,7 @@ unsafe impl<'gc, T: 'gc + Collect> Collect for GcWeakCell<'gc, T> {
 impl<'gc, T: Collect + 'gc> GcWeakCell<'gc, T> {
     pub fn upgrade(&self, mc: MutationContext<'gc, '_>) -> Option<GcCell<'gc, T>> {
         unsafe {
-            let ptr = GcBoxPtr::erase(self.inner.0.ptr);
+            let ptr = GcBox::erase(self.inner.0.ptr);
             mc.upgrade(ptr).then(|| self.inner)
         }
     }

--- a/src/gc-arena/src/lib.rs
+++ b/src/gc-arena/src/lib.rs
@@ -20,6 +20,11 @@ mod gc_weak_cell;
 mod no_drop;
 mod static_collect;
 mod types;
+mod unsize;
+
+// Not public API.
+#[doc(hidden)]
+pub use unsize::__CoercePtrInternal;
 
 pub use self::{
     arena::{rootless_arena, Arena, ArenaParameters, Root, Rootable},

--- a/src/gc-arena/src/unsize.rs
+++ b/src/gc-arena/src/unsize.rs
@@ -1,0 +1,136 @@
+use core::marker::PhantomData;
+use core::ptr::NonNull;
+
+use crate::gc_cell::GcRefCell;
+use crate::types::GcBoxInner;
+use crate::{Gc, GcCell, GcWeak, GcWeakCell};
+
+/// Unsizes a [`Gc`] pointer (also works with [`GcWeak`], [`GcCell`] and [`GcWeakCell`]).
+///
+/// This macro is a `gc_arena`-specific replacement for the nightly-only `CoerceUnsized` trait.
+///
+/// ## Usage
+///
+/// ```rust
+/// # use std::fmt::Display;
+/// # use gc_arena::{Gc, unsize};
+/// # fn main() {
+/// # gc_arena::rootless_arena(|mc| {
+/// // Unsizing arrays to slices.
+/// let mut slice;
+/// slice = unsize!(Gc::allocate(mc, [1, 2]) => [u8]);
+/// assert_eq!(slice.len(), 2);
+/// slice = unsize!(Gc::allocate(mc, [42; 4]) => [u8]);
+/// assert_eq!(slice.len(), 4);
+///
+/// // Unsizing values to trait objects.
+/// let mut display;
+/// display = unsize!(Gc::allocate(mc, "Hello world!".to_owned()) => dyn Display);
+/// assert_eq!(display.to_string(), "Hello world!");
+/// display = unsize!(Gc::allocate(mc, 123456) => dyn Display);
+/// assert_eq!(display.to_string(), "123456");
+/// # })
+/// # }
+/// ```
+///
+/// The `unsize` macro is safe, and will fail to compile when trying to coerce between
+/// incompatible types.
+/// ```rust,compile_fail
+/// # use std::error::Error;
+/// # use gc_arena::{Gc, unsize};
+/// # fn main() {
+/// # gc_arena::rootless_arena(|mc| {
+/// // Error: `Option<char>` doesn't implement `Error`.
+/// let _ = unsize!(Gc::allocate(mc, Some('💥')) => dyn Error);
+/// # })
+/// # }
+/// ```
+#[macro_export]
+macro_rules! unsize {
+    ($gc:expr => $ty:ty) => {{
+        let gc = $gc;
+        // SAFETY: the closure has a trivial body and must be a valid pointer
+        // coercion, if it compiles. Additionally, the `__CoercePtrInternal` trait
+        // ensures that the resulting GC pointer has the correct `'gc` lifetime.
+        unsafe {
+            $crate::__CoercePtrInternal::__coerce_unchecked(gc, |p: *mut _| -> *mut $ty { p })
+        }
+    }};
+}
+
+// Not public API; implementation detail of the `unsize` macro.
+//
+// Maps a raw pointer coercion (`*mut FromPtr -> *mut ToPtr`) to
+// a smart pointer coercion (`Self -> Dst`).
+#[doc(hidden)]
+pub unsafe trait __CoercePtrInternal<Dst> {
+    type FromPtr;
+    type ToPtr: ?Sized;
+    // SAFETY: `coerce` must be a valid pointer coercion; in particular, the coerced
+    // pointer must have the same address and provenance as the original.
+    unsafe fn __coerce_unchecked<F>(self, coerce: F) -> Dst
+    where
+        F: FnOnce(*mut Self::FromPtr) -> *mut Self::ToPtr;
+}
+
+unsafe impl<'gc, T, U: ?Sized> __CoercePtrInternal<Gc<'gc, U>> for Gc<'gc, T> {
+    type FromPtr = T;
+    type ToPtr = U;
+
+    #[inline(always)]
+    unsafe fn __coerce_unchecked<F>(self, coerce: F) -> Gc<'gc, U>
+    where
+        F: FnOnce(*mut T) -> *mut U,
+    {
+        let ptr = self.ptr.as_ptr() as *mut T;
+        let ptr = NonNull::new_unchecked(coerce(ptr) as *mut GcBoxInner<U>);
+        Gc {
+            ptr,
+            _invariant: PhantomData,
+        }
+    }
+}
+
+unsafe impl<'gc, T, U: ?Sized> __CoercePtrInternal<GcCell<'gc, U>> for GcCell<'gc, T> {
+    type FromPtr = T;
+    type ToPtr = U;
+
+    #[inline(always)]
+    unsafe fn __coerce_unchecked<F>(self, coerce: F) -> GcCell<'gc, U>
+    where
+        F: FnOnce(*mut T) -> *mut U,
+    {
+        GcCell(
+            self.0
+                .__coerce_unchecked(|p| coerce(p as *mut T) as *mut GcRefCell<U>),
+        )
+    }
+}
+
+unsafe impl<'gc, T, U: ?Sized> __CoercePtrInternal<GcWeak<'gc, U>> for GcWeak<'gc, T> {
+    type FromPtr = T;
+    type ToPtr = U;
+
+    #[inline(always)]
+    unsafe fn __coerce_unchecked<F>(self, coerce: F) -> GcWeak<'gc, U>
+    where
+        F: FnOnce(*mut T) -> *mut U,
+    {
+        let inner = self.inner.__coerce_unchecked(coerce);
+        GcWeak { inner }
+    }
+}
+
+unsafe impl<'gc, T, U: ?Sized> __CoercePtrInternal<GcWeakCell<'gc, U>> for GcWeakCell<'gc, T> {
+    type FromPtr = T;
+    type ToPtr = U;
+
+    #[inline(always)]
+    unsafe fn __coerce_unchecked<F>(self, coerce: F) -> GcWeakCell<'gc, U>
+    where
+        F: FnOnce(*mut T) -> *mut U,
+    {
+        let inner = self.inner.__coerce_unchecked(coerce);
+        GcWeakCell { inner }
+    }
+}


### PR DESCRIPTION
This rewrites the `GcBox` internals to use a manually-implemented vtable instead of relying on `dyn Collect`, enabling two improvements:
- with `GcBox` now self-contained, the unsizing coercion in `CollectionContext::trace/write_barrier` is no longer necessary, which means that `Gc` pointers can support unsized types;
- similarly, the only place where a `T: Collect` bound is now required is during allocation, this makes removing the bound on `Gc` (like in #22) viable.

This could also allow removing the `Self: Sized` bound on `Collect::needs_trace()`, but this is technically a breaking change (making the trait non-object-safe) so idk if it should be done?

A small wrinkle though: unsized coercions for custom smart pointers aren't possible in stable Rust, so I've added an `unsize!(gc => SomeUnsizedType)` macro instead; feel free to bikeshed the syntax if you don't agree with my choice.
