### PR TITLE
Add `ptr_eq` and `as_ptr` to weak types

### DIFF
--- a/src/gc-arena/src/gc_weak.rs
+++ b/src/gc-arena/src/gc_weak.rs
@@ -39,4 +39,12 @@ impl<'gc, T: ?Sized + 'gc> GcWeak<'gc, T> {
             mc.upgrade(ptr).then(|| self.inner)
         }
     }
+
+    pub fn ptr_eq(this: GcWeak<'gc, T>, other: GcWeak<'gc, T>) -> bool {
+        this.as_ptr() == other.as_ptr()
+    }
+
+    pub fn as_ptr(self) -> *const T {
+        Gc::as_ptr(self.inner)
+    }
 }

--- a/src/gc-arena/src/gc_weak_cell.rs
+++ b/src/gc-arena/src/gc_weak_cell.rs
@@ -38,4 +38,12 @@ impl<'gc, T: ?Sized + 'gc> GcWeakCell<'gc, T> {
             mc.upgrade(ptr).then(|| self.inner)
         }
     }
+
+    pub fn ptr_eq(this: GcWeakCell<'gc, T>, other: GcWeakCell<'gc, T>) -> bool {
+        this.as_ptr() == other.as_ptr()
+    }
+
+    pub fn as_ptr(self) -> *mut T {
+        self.inner.as_ptr()
+    }
 }


### PR DESCRIPTION
These work the same way as the corresponding methods on the strong versions of these types.