### PR TITLE
fix remembered_size acc error

### DIFF
--- a/src/gc-arena/src/arena.rs
+++ b/src/gc-arena/src/arena.rs
@@ -241,6 +241,11 @@ impl<R: for<'a> Rootable<'a> + ?Sized> Arena<R> {
         self.context.total_allocated()
     }
 
+    #[inline]
+    pub fn remembered_size(&self) -> usize {
+        self.context.remembered_size()
+    }
+
     /// When the garbage collector is not sleeping, all allocated objects cause the arena to
     /// accumulate "allocation debt". This debt is then be used to time incremental garbage
     /// collection based on the tuning parameters set in `ArenaParameters`. The allocation debt is

--- a/src/gc-arena/src/context.rs
+++ b/src/gc-arena/src/context.rs
@@ -282,14 +282,13 @@ impl Context {
                         self.phase.set(Phase::Sleep);
 
                         // Do not let debt or remembered size accumulate across cycles.
-                        // when we enter sleep, zero them out.
+                        // When we enter sleep, zero them out.
                         self.allocation_debt.set(0.0);
                         let remembered_size = self.remembered_size.replace(0);
 
-                        let sleep = f64_to_usize(
-                            remembered_size as f64 * self.parameters.pause_factor,
-                        )
-                        .min(self.parameters.min_sleep);
+                        let sleep =
+                            f64_to_usize(remembered_size as f64 * self.parameters.pause_factor)
+                                .min(self.parameters.min_sleep);
 
                         self.wakeup_total.set(self.total_allocated.get() + sleep);
                     }

--- a/src/gc-arena/src/context.rs
+++ b/src/gc-arena/src/context.rs
@@ -139,6 +139,11 @@ impl Context {
         self.total_allocated.get()
     }
 
+    #[inline]
+    pub(crate) fn remembered_size(&self) -> usize {
+        self.remembered_size.get()
+    }
+
     // If the garbage collector is currently in the sleep phase,
     // add the root to the gray queue and transition to the `Propagate` phase.
     pub(crate) fn wake(&self) {
@@ -276,12 +281,13 @@ impl Context {
                         self.sweep_prev.set(None);
                         self.phase.set(Phase::Sleep);
 
-                        // Do not let debt accumulate across cycles, when we enter sleep, zero the
-                        // debt out.
+                        // Do not let debt or remembered size accumulate across cycles.
+                        // when we enter sleep, zero them out.
                         self.allocation_debt.set(0.0);
+                        let remembered_size = self.remembered_size.replace(0);
 
                         let sleep = f64_to_usize(
-                            self.remembered_size.get() as f64 * self.parameters.pause_factor,
+                            remembered_size as f64 * self.parameters.pause_factor,
                         )
                         .min(self.parameters.min_sleep);
 

--- a/src/gc-arena/tests/tests.rs
+++ b/src/gc-arena/tests/tests.rs
@@ -491,9 +491,10 @@ fn test_collect_overflow() {
         test: Gc<'gc, [u8; 256]>,
     }
 
-    let mut arena = Arena::<Rootable![TestRoot<'gc>]>::new(ArenaParameters::default(), |mc| TestRoot {
-        test: Gc::allocate(mc, [0; 256]),
-    });
+    let mut arena =
+        Arena::<Rootable![TestRoot<'gc>]>::new(ArenaParameters::default(), |mc| TestRoot {
+            test: Gc::allocate(mc, [0; 256]),
+        });
 
     for _ in 0..1024 {
         arena.collect_all();


### PR DESCRIPTION
Closes #44. Solves the overflow crash from accumulating `remembered_size` across collect cycles. I'm by no means an expert on this crate, so please check this thoroughly.

It seems like `remembered_size` was meant to be a running total through one collection cycle, but was not being reset to zero at the end of sweeping like `allocation_debt` was. To solve this, I just set it to zero along with `allocation_debt` and use the old value in the calculation of `sleep` for `wakeup_total`.

I've also included a regression test that makes sure that several similar values in `Context` all remain bounded. Unfortunately this required exposing a new public method in `Arena` for getting the value of `remembered_size`. Feel free to make changes if this can be avoided. I would have normally made it `pub(crate)`, but the test module is not actually part of the crate it seems.