### PR TITLE
Shrink GC object headers 

### DIFF
--- a/src/gc-arena/Cargo.toml
+++ b/src/gc-arena/Cargo.toml
@@ -14,6 +14,7 @@ std = []
 
 [dependencies]
 gc-arena-derive = { path = "../gc-arena-derive", version = "0.2.2"}
+sptr = "0.3.2"
 
 [dev-dependencies]
 rand = "0.8"

--- a/src/gc-arena/src/context.rs
+++ b/src/gc-arena/src/context.rs
@@ -301,7 +301,8 @@ impl Context {
     }
 
     fn allocate<T: Collect>(&self, t: T) -> NonNull<GcBoxInner<T>> {
-        let header = GcBoxHeader::new::<T>(self.all.get());
+        let header = GcBoxHeader::new::<T>();
+        header.set_next(self.all.get());
         header.set_live(true);
         header.set_needs_trace(T::needs_trace());
 

--- a/src/gc-arena/src/gc.rs
+++ b/src/gc-arena/src/gc.rs
@@ -56,7 +56,7 @@ impl<'gc, T: ?Sized + 'gc> Deref for Gc<'gc, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
-        unsafe { &*self.ptr.as_ref().value() }
+        unsafe { &self.ptr.as_ref().value }
     }
 }
 
@@ -88,6 +88,7 @@ impl<'gc, T: ?Sized + 'gc> Gc<'gc, T> {
     }
 
     pub fn as_ptr(gc: Gc<'gc, T>) -> *const T {
-        unsafe { gc.ptr.as_ref().value() }
+        let inner = unsafe { gc.ptr.as_ref() };
+        core::ptr::addr_of!(inner.value) as *const T
     }
 }

--- a/src/gc-arena/src/gc_weak.rs
+++ b/src/gc-arena/src/gc_weak.rs
@@ -27,7 +27,7 @@ unsafe impl<'gc, T: ?Sized + 'gc> Collect for GcWeak<'gc, T> {
     fn trace(&self, _cc: CollectionContext) {
         unsafe {
             let gc = GcBox::erase(self.inner.ptr);
-            gc.flags().set_traced_weak_ref(true);
+            gc.header().set_traced_weak_ref(true);
         }
     }
 }

--- a/src/gc-arena/src/gc_weak.rs
+++ b/src/gc-arena/src/gc_weak.rs
@@ -24,10 +24,9 @@ impl<'gc, T: ?Sized + 'gc> Debug for GcWeak<'gc, T> {
 }
 
 unsafe impl<'gc, T: ?Sized + 'gc> Collect for GcWeak<'gc, T> {
-    fn trace(&self, _cc: CollectionContext) {
+    fn trace(&self, cc: CollectionContext) {
         unsafe {
-            let gc = GcBox::erase(self.inner.ptr);
-            gc.header().set_traced_weak_ref(true);
+            cc.trace_weak(GcBox::erase(self.inner.ptr));
         }
     }
 }

--- a/src/gc-arena/src/gc_weak_cell.rs
+++ b/src/gc-arena/src/gc_weak_cell.rs
@@ -26,7 +26,7 @@ unsafe impl<'gc, T: ?Sized + 'gc> Collect for GcWeakCell<'gc, T> {
     fn trace(&self, _cc: crate::CollectionContext) {
         unsafe {
             let gc = GcBox::erase(self.inner.0.ptr);
-            gc.flags().set_traced_weak_ref(true);
+            gc.header().set_traced_weak_ref(true);
         }
     }
 }

--- a/src/gc-arena/src/gc_weak_cell.rs
+++ b/src/gc-arena/src/gc_weak_cell.rs
@@ -23,10 +23,9 @@ impl<'gc, T: ?Sized + 'gc> Debug for GcWeakCell<'gc, T> {
 }
 
 unsafe impl<'gc, T: ?Sized + 'gc> Collect for GcWeakCell<'gc, T> {
-    fn trace(&self, _cc: crate::CollectionContext) {
+    fn trace(&self, cc: crate::CollectionContext) {
         unsafe {
-            let gc = GcBox::erase(self.inner.0.ptr);
-            gc.header().set_traced_weak_ref(true);
+            cc.trace_weak(GcBox::erase(self.inner.0.ptr));
         }
     }
 }

--- a/src/gc-arena/src/lib.rs
+++ b/src/gc-arena/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![cfg_attr(miri, feature(strict_provenance))]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/src/gc-arena/src/types.rs
+++ b/src/gc-arena/src/types.rs
@@ -38,23 +38,9 @@ impl GcBox {
         }
     }
 
-    /// Gets the GC flags.
     #[inline(always)]
-    pub(crate) fn flags(&self) -> &GcFlags {
-        unsafe { &self.0.as_ref().flags }
-    }
-
-    /// Gets the next element in the global linked list of allocated objects.
-    #[inline(always)]
-    pub(crate) fn next(&self) -> &Cell<Option<GcBox>> {
-        unsafe { &self.0.as_ref().next }
-    }
-
-    /// Returns the (shallow) size occupied by this box in memory.
-    #[inline(always)]
-    pub(crate) fn size_of_box(&self) -> usize {
-        let inner = unsafe { self.0.as_ref() };
-        inner.vtable.box_layout.size()
+    pub(crate) fn header(&self) -> &GcBoxHeader {
+        unsafe { &self.0.as_ref().header }
     }
 
     /// Traces the stored value.
@@ -62,8 +48,7 @@ impl GcBox {
     /// **SAFETY**: `Self::drop_in_place` must not have been called.
     #[inline(always)]
     pub(crate) unsafe fn trace_value(&self, cc: crate::CollectionContext) {
-        let vtable = self.0.as_ref().vtable;
-        (vtable.trace_value)(*self, cc)
+        (self.header().vtable.trace_value)(*self, cc)
     }
 
     /// Drops the stored value.
@@ -72,8 +57,7 @@ impl GcBox {
     /// (but accessing the `GcBox` itself is still safe).
     #[inline(always)]
     pub(crate) unsafe fn drop_in_place(&mut self) {
-        let vtable = self.0.as_ref().vtable;
-        (vtable.drop_value)(*self)
+        (self.header().vtable.drop_value)(*self)
     }
 
     /// Deallocates the box. Failing to call `Self::drop_in_place` beforehand
@@ -83,34 +67,25 @@ impl GcBox {
     /// pointers again.
     #[inline(always)]
     pub(crate) unsafe fn dealloc(self) {
-        let vtable = self.0.as_ref().vtable;
+        let layout = self.header().vtable.box_layout;
         let ptr = self.0.as_ptr() as *mut u8;
         // SAFETY: the pointer was `Box`-allocated with this layout.
-        alloc::alloc::dealloc(ptr, vtable.box_layout);
+        alloc::alloc::dealloc(ptr, layout);
     }
 }
 
-/// A typed GC'd value, together with its metadata.
-/// This type is never manipulated directly by the GC algorithm, allowing
-/// user-facing `Gc`s to freely cast their pointer to it.
-#[repr(C)]
-pub(crate) struct GcBoxInner<T: ?Sized> {
+pub(crate) struct GcBoxHeader {
     // The GC flags, used to track the state of the `GcBox`.
-    flags: GcFlags,
+    flags: Cell<u8>,
     /// The next element in the global linked list of allocated objects.
     next: Cell<Option<GcBox>>,
     /// A custom virtual function table for handling type-specific operations.
     vtable: &'static CollectVtable,
-    /// The typed value stored in this `GcBox`.
-    value: mem::ManuallyDrop<T>,
 }
 
-impl<T: ?Sized> GcBoxInner<T> {
+impl GcBoxHeader {
     #[inline(always)]
-    pub(crate) fn new(flags: GcFlags, next: Option<GcBox>, t: T) -> Self
-    where
-        T: Collect + Sized,
-    {
+    pub fn new<T: Collect>(next: Option<GcBox>) -> Self {
         // Helper trait to materialize vtables in static memory.
         trait HasCollectVtable {
             const VTABLE: CollectVtable;
@@ -121,16 +96,94 @@ impl<T: ?Sized> GcBoxInner<T> {
         }
 
         Self {
-            flags,
+            flags: Cell::new(0),
             next: Cell::new(next),
             vtable: &<T as HasCollectVtable>::VTABLE,
-            value: mem::ManuallyDrop::new(t),
         }
     }
 
+    /// Gets the next element in the global linked list of allocated objects.
     #[inline(always)]
-    pub(crate) fn value(&self) -> &T {
-        &*self.value
+    pub(crate) fn next(&self) -> Option<GcBox> {
+        self.next.get()
+    }
+
+    /// Sets the next element in the global linked list of allocated objects.
+    #[inline(always)]
+    pub(crate) fn set_next(&self, next: Option<GcBox>) {
+        self.next.set(next)
+    }
+
+    /// Returns the (shallow) size occupied by this box in memory.
+    #[inline(always)]
+    pub(crate) fn size_of_box(&self) -> usize {
+        self.vtable.box_layout.size()
+    }
+
+    #[inline]
+    pub(crate) fn color(&self) -> GcColor {
+        match self.flags.get() & 0x3 {
+            0x0 => GcColor::White,
+            0x1 => GcColor::Gray,
+            0x2 => GcColor::Black,
+            // this is needed for the compiler to codegen a simple AND.
+            // SAFETY: only possible extra value is 0x3,
+            // and the only place where we set these bits is in set_color
+            _ => unsafe { core::hint::unreachable_unchecked() },
+        }
+    }
+
+    #[inline]
+    pub(crate) fn set_color(&self, color: GcColor) {
+        self.flags.set(
+            (self.flags.get() & !0x3)
+                | match color {
+                    GcColor::White => 0x0,
+                    GcColor::Gray => 0x1,
+                    GcColor::Black => 0x2,
+                },
+        )
+    }
+    #[inline]
+    pub(crate) fn needs_trace(&self) -> bool {
+        self.flags.get() & 0x4 != 0x0
+    }
+
+    /// This is `true` if we've traced a weak pointer during to this `GcBox`
+    /// during the most recent `Phase::Propagate`. This is reset back to
+    /// `false` during `Phase::Sweep`.
+    #[inline]
+    pub(crate) fn traced_weak_ref(&self) -> bool {
+        self.flags.get() & 0x8 != 0x0
+    }
+
+    /// Determines whether or not we've dropped the `dyn Collect` value
+    /// stored in `GcBox.value`
+    /// When we garbage-collect a `GcBox` that still has outstanding weak pointers,
+    /// we set `alive` to false. When there are no more weak pointers remaining,
+    /// we will deallocate the `GcBox`, but skip dropping the `dyn Collect` value
+    /// (since we've already done it).
+    #[inline]
+    pub(crate) fn is_live(&self) -> bool {
+        self.flags.get() & 0x10 != 0x0
+    }
+
+    #[inline]
+    pub(crate) fn set_needs_trace(&self, needs_trace: bool) {
+        self.flags
+            .set((self.flags.get() & !0x4) | if needs_trace { 0x4 } else { 0x0 });
+    }
+
+    #[inline]
+    pub(crate) fn set_traced_weak_ref(&self, traced_weak_ref: bool) {
+        self.flags
+            .set((self.flags.get() & !0x8) | if traced_weak_ref { 0x8 } else { 0x0 });
+    }
+
+    #[inline]
+    pub(crate) fn set_live(&self, alive: bool) {
+        self.flags
+            .set((self.flags.get() & !0x10) | if alive { 0x10 } else { 0x0 });
     }
 }
 
@@ -165,6 +218,28 @@ impl CollectVtable {
     }
 }
 
+/// A typed GC'd value, together with its metadata.
+/// This type is never manipulated directly by the GC algorithm, allowing
+/// user-facing `Gc`s to freely cast their pointer to it.
+pub(crate) struct GcBoxInner<T: ?Sized> {
+    header: GcBoxHeader,
+    /// The typed value stored in this `GcBox`.
+    pub(crate) value: mem::ManuallyDrop<T>,
+}
+
+impl<T: ?Sized> GcBoxInner<T> {
+    #[inline(always)]
+    pub(crate) fn new(header: GcBoxHeader, t: T) -> Self
+    where
+        T: Collect + Sized,
+    {
+        Self {
+            header,
+            value: mem::ManuallyDrop::new(t),
+        }
+    }
+}
+
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub(crate) enum GcColor {
     /// An object that has not yet been reached by tracing (if we're in a tracing phase).
@@ -184,82 +259,6 @@ pub(crate) enum GcColor {
     /// during `Phase::Sweep`. At the end of `Phase::Sweep`, all black
     /// objects will be reset to white.
     Black,
-}
-
-pub(crate) struct GcFlags(Cell<u8>);
-
-impl GcFlags {
-    #[inline]
-    pub(crate) fn new() -> GcFlags {
-        GcFlags(Cell::new(0))
-    }
-
-    #[inline]
-    pub(crate) fn color(&self) -> GcColor {
-        match self.0.get() & 0x3 {
-            0x0 => GcColor::White,
-            0x1 => GcColor::Gray,
-            0x2 => GcColor::Black,
-            // this is needed for the compiler to codegen a simple AND.
-            // SAFETY: only possible extra value is 0x3,
-            // and the only place where we set these bits is in set_color
-            _ => unsafe { core::hint::unreachable_unchecked() },
-        }
-    }
-
-    #[inline]
-    pub(crate) fn set_color(&self, color: GcColor) {
-        self.0.set(
-            (self.0.get() & !0x3)
-                | match color {
-                    GcColor::White => 0x0,
-                    GcColor::Gray => 0x1,
-                    GcColor::Black => 0x2,
-                },
-        )
-    }
-
-    #[inline]
-    pub(crate) fn needs_trace(&self) -> bool {
-        self.0.get() & 0x4 != 0x0
-    }
-
-    /// This is `true` if we've traced a weak pointer during to this `GcBox`
-    /// during the most recent `Phase::Propagate`. This is reset back to
-    /// `false` during `Phase::Sweep`.
-    #[inline]
-    pub(crate) fn traced_weak_ref(&self) -> bool {
-        self.0.get() & 0x8 != 0x0
-    }
-
-    /// Determines whether or not we've dropped the `dyn Collect` value
-    /// stored in `GcBox.value`
-    /// When we garbage-collect a `GcBox` that still has outstanding weak pointers,
-    /// we set `alive` to false. When there are no more weak pointers remaining,
-    /// we will deallocate the `GcBox`, but skip dropping the `dyn Collect` value
-    /// (since we've already done it).
-    #[inline]
-    pub(crate) fn is_live(&self) -> bool {
-        self.0.get() & 0x10 != 0x0
-    }
-
-    #[inline]
-    pub(crate) fn set_needs_trace(&self, needs_trace: bool) {
-        self.0
-            .set((self.0.get() & !0x4) | if needs_trace { 0x4 } else { 0x0 });
-    }
-
-    #[inline]
-    pub(crate) fn set_traced_weak_ref(&self, traced_weak_ref: bool) {
-        self.0
-            .set((self.0.get() & !0x8) | if traced_weak_ref { 0x8 } else { 0x0 });
-    }
-
-    #[inline]
-    pub(crate) fn set_live(&self, alive: bool) {
-        self.0
-            .set((self.0.get() & !0x10) | if alive { 0x10 } else { 0x0 });
-    }
 }
 
 // Phantom type that holds a lifetime and ensures that it is invariant.


### PR DESCRIPTION
This PR reduces the size of the GC object metadata from 3 `usize`s to 2 `usize`s. This is achieved in two ways:

- Using pointer tagging to store the GC flags in the low bits of the vtable pointer; to ensure enough bits are available, the `CollectVtable` type is now over-aligned.
- Removing the `traced_weak_ref` flag in favor of a 4th color: `GcColor::WhiteWeak`.