### PR TITLE
Expose the live GC flag as `GcWeak(Cell)::is_dropped`

### DIFF
--- a/src/gc-arena/src/gc_weak.rs
+++ b/src/gc-arena/src/gc_weak.rs
@@ -39,6 +39,14 @@ impl<'gc, T: ?Sized + 'gc> GcWeak<'gc, T> {
         }
     }
 
+    /// Returns whether the value referenced by this `GcWeak` has been dropped.
+    ///
+    /// Note that calling `upgrade` may still fail even when this method returns `false`.
+    pub fn is_dropped(self) -> bool {
+        let ptr = unsafe { GcBox::erase(self.inner.ptr) };
+        !ptr.header().is_live()
+    }
+
     pub fn ptr_eq(this: GcWeak<'gc, T>, other: GcWeak<'gc, T>) -> bool {
         this.as_ptr() == other.as_ptr()
     }

--- a/src/gc-arena/src/gc_weak_cell.rs
+++ b/src/gc-arena/src/gc_weak_cell.rs
@@ -38,6 +38,14 @@ impl<'gc, T: ?Sized + 'gc> GcWeakCell<'gc, T> {
         }
     }
 
+    /// Returns whether the value referenced by this `GcWeakCell` has been dropped.
+    ///
+    /// Note that calling `upgrade` may still fail even when this method returns `false`.
+    pub fn is_dropped(self) -> bool {
+        let ptr = unsafe { GcBox::erase(self.inner.0.ptr) };
+        !ptr.header().is_live()
+    }
+
     pub fn ptr_eq(this: GcWeakCell<'gc, T>, other: GcWeakCell<'gc, T>) -> bool {
         this.as_ptr() == other.as_ptr()
     }


### PR DESCRIPTION
This is mainly intended for implementors of weak data-structures, to allow the cleaning of stale references in `Collect::trace`, where fully upgrading a `GcWeak` isn't possible.

An alternative API would be to expose upgrade methods on `CollectionContext` instead, but this eems much more constraining on the possible space of GC algorithms.