### PR TITLE
chore: update `gc-arena-derive` to use `syn` 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/rust:1.65.0
+      - image: cimg/rust:1.67.0
     steps:
       - checkout
       - run:

--- a/src/gc-arena-derive/Cargo.toml
+++ b/src/gc-arena-derive/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/kyren/gc-arena"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.24"
-quote = "1.0"
-syn = "1.0"
-synstructure = "0.12"
+proc-macro2 = "1.0.56"
+quote = "1.0.26"
+syn = "2.0.13"
+synstructure = "0.13"

--- a/src/gc-arena/tests/ui/multiple_require_static.stderr
+++ b/src/gc-arena/tests/ui/multiple_require_static.stderr
@@ -1,5 +1,5 @@
-error: Cannot specify multiple `#[collect]` attributes!
- --> $DIR/multiple_require_static.rs:7:7
+error: Cannot specify multiple `#[collect]` attributes! Consider merging them.
+ --> tests/ui/multiple_require_static.rs:7:7
   |
 7 |     #[collect(require_static)]
   |       ^^^^^^^

--- a/src/gc-arena/tests/ui/no_drop_and_drop_impl.stderr
+++ b/src/gc-arena/tests/ui/no_drop_and_drop_impl.stderr
@@ -1,4 +1,4 @@
-error[E0119]: conflicting implementations of trait `gc_arena::MustNotImplDrop` for type `Foo`
+error[E0119]: conflicting implementations of trait `MustNotImplDrop` for type `Foo`
  --> $DIR/no_drop_and_drop_impl.rs:3:10
   |
 3 | #[derive(Collect)]

--- a/src/gc-arena/tests/ui/require_static_enum_variant.stderr
+++ b/src/gc-arena/tests/ui/require_static_enum_variant.stderr
@@ -1,5 +1,5 @@
 error: `#[collect]` is not suppported on enum variants
- --> $DIR/require_static_enum_variant.rs:6:15
+ --> $DIR/require_static_enum_variant.rs:6:7
   |
 6 |     #[collect(require_static)]
-  |               ^^^^^^^^^^^^^^
+  |       ^^^^^^^


### PR DESCRIPTION
Some code simplifications made error messages slightly different.

This also bumps CI's rustc to make the UI test pass.