### PR TITLE
Get rid of a bad footgun with `Collect` impls on `&T`

### DIFF
--- a/src/gc-arena/src/collect_impl.rs
+++ b/src/gc-arena/src/collect_impl.rs
@@ -74,14 +74,7 @@ static_collect!(std::ffi::OsStr);
 #[cfg(feature = "std")]
 static_collect!(std::ffi::OsString);
 
-unsafe impl<'a, T: ?Sized> Collect for &'a T {
-    #[inline]
-    fn needs_trace() -> bool {
-        false
-    }
-}
-
-unsafe impl<'a, T: ?Sized> Collect for &'a mut T {
+unsafe impl<T: ?Sized> Collect for &'static T {
     #[inline]
     fn needs_trace() -> bool {
         false

--- a/src/gc-arena/tests/ui/bad_collect_bound.stderr
+++ b/src/gc-arena/tests/ui/bad_collect_bound.stderr
@@ -8,13 +8,13 @@ error[E0277]: the trait bound `NotCollect: Collect` is not satisfied
   |     ^^^^^ the trait `Collect` is not implemented for `NotCollect`
   |
   = help: the following other types implement trait `Collect`:
-            &'a T
-            &'a mut T
+            &'static T
             ()
             (A, B)
             (A, B, C)
             (A, B, C, D)
             (A, B, C, D, E)
             (A, B, C, D, E, F)
+            (A, B, C, D, E, F, G)
           and $N others
   = note: this error originates in the derive macro `Collect` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
The existing `Collect` impls on reference types *are* sound, but they're a huge footgun because it's easy to accidentally call `<&T as Collect>::trace` instead of `T::trace`.

Just remove them and have an impl only for `&'static T`. Now, if you accidentally try to call `<&T as Collect>::trace`, you will at least get a compiler error instead of a silent footgun.