### PR TITLE
Add the ability to unsafely coerce `Gc` pointers to a different type.

### DIFF
--- a/src/gc-arena/src/context.rs
+++ b/src/gc-arena/src/context.rs
@@ -39,7 +39,7 @@ pub struct CollectionContext<'context> {
 }
 
 impl<'context> CollectionContext<'context> {
-    pub(crate) unsafe fn trace(self, gc_box: GcBox) {
+    pub(crate) fn trace(self, gc_box: GcBox) {
         self.context.trace(gc_box)
     }
 
@@ -355,8 +355,7 @@ impl Context {
         }
     }
 
-    // SAFETY: the `GcBox` must contain a live object.
-    unsafe fn trace(&self, gc_box: GcBox) {
+    fn trace(&self, gc_box: GcBox) {
         let header = gc_box.header();
         match header.color() {
             GcColor::Black | GcColor::Gray => {}
@@ -410,7 +409,7 @@ impl Context {
         //   `WhiteWeak` means that a `GcWeak` / `GcWeakCell` existed during the last `Phase::Propagate.`
         //
         //   Therefore, a `WhiteWeak` object is guaranteed to be deallocated during this `Phase::Sweep`,
-        // and we must not upgrade it.
+        //   and we must not upgrade it.
         //
         //   Conversely, it's always safe to upgrade a white object that is not `WhiteWeak`.
         //   In order to call `upgrade`, you must have a `GcWeak/GcWeakCell`. Since it is not `WhiteWeak`

--- a/src/gc-arena/src/gc.rs
+++ b/src/gc-arena/src/gc.rs
@@ -72,12 +72,14 @@ impl<'gc, T: Collect + 'gc> Gc<'gc, T> {
             _invariant: PhantomData,
         }
     }
+}
 
+impl<'gc, T: 'gc> Gc<'gc, T> {
     /// Cast the internal pointer to a different type.
     ///
     /// SAFETY:
     /// It must be valid to dereference a `*mut U` that has come from casting a `*mut T`.
-    pub unsafe fn cast<U>(this: Gc<'gc, T>) -> Gc<'gc, U> {
+    pub unsafe fn cast<U: 'gc>(this: Gc<'gc, T>) -> Gc<'gc, U> {
         Gc {
             ptr: NonNull::cast(this.ptr),
             _invariant: PhantomData,

--- a/src/gc-arena/src/gc.rs
+++ b/src/gc-arena/src/gc.rs
@@ -67,6 +67,17 @@ impl<'gc, T: Collect + 'gc> Gc<'gc, T> {
             _invariant: PhantomData,
         }
     }
+
+    /// Cast the internal pointer to a different type.
+    ///
+    /// SAFETY:
+    /// It must be valid to dereference a `*mut U` that has come from casting a `*mut T`.
+    pub unsafe fn cast<U>(this: Gc<'gc, T>) -> Gc<'gc, U> {
+        Gc {
+            ptr: NonNull::cast(this.ptr),
+            _invariant: PhantomData,
+        }
+    }
 }
 
 impl<'gc, T: ?Sized + 'gc> Gc<'gc, T> {

--- a/src/gc-arena/src/gc_weak.rs
+++ b/src/gc-arena/src/gc_weak.rs
@@ -55,3 +55,15 @@ impl<'gc, T: ?Sized + 'gc> GcWeak<'gc, T> {
         Gc::as_ptr(self.inner)
     }
 }
+
+impl<'gc, T: Collect + 'gc> GcWeak<'gc, T> {
+    /// Cast the internal pointer to a different type.
+    ///
+    /// SAFETY:
+    /// It must be valid to dereference a `*mut U` that has come from casting a `*mut T`.
+    pub unsafe fn cast<U>(this: GcWeak<'gc, T>) -> GcWeak<'gc, U> {
+        GcWeak {
+            inner: Gc::cast::<U>(this.inner),
+        }
+    }
+}

--- a/src/gc-arena/src/gc_weak.rs
+++ b/src/gc-arena/src/gc_weak.rs
@@ -56,12 +56,12 @@ impl<'gc, T: ?Sized + 'gc> GcWeak<'gc, T> {
     }
 }
 
-impl<'gc, T: Collect + 'gc> GcWeak<'gc, T> {
+impl<'gc, T: 'gc> GcWeak<'gc, T> {
     /// Cast the internal pointer to a different type.
     ///
     /// SAFETY:
     /// It must be valid to dereference a `*mut U` that has come from casting a `*mut T`.
-    pub unsafe fn cast<U>(this: GcWeak<'gc, T>) -> GcWeak<'gc, U> {
+    pub unsafe fn cast<U: 'gc>(this: GcWeak<'gc, T>) -> GcWeak<'gc, U> {
         GcWeak {
             inner: Gc::cast::<U>(this.inner),
         }

--- a/src/gc-arena/src/gc_weak.rs
+++ b/src/gc-arena/src/gc_weak.rs
@@ -66,4 +66,16 @@ impl<'gc, T: Collect + 'gc> GcWeak<'gc, T> {
             inner: Gc::cast::<U>(this.inner),
         }
     }
+
+    /// Retrieve a `GcWeak` from a raw pointer obtained from `GcWeak::as_ptr`
+    ///
+    /// SAFETY:
+    /// The provided pointer must have been obtained from `GcWeak::as_ptr` or `Gc::as_ptr`, and
+    /// the pointer must not have been *fully* collected yet (it may be a dropped but live weak
+    /// pointer).
+    pub unsafe fn from_ptr(ptr: *const T) -> GcWeak<'gc, T> {
+        GcWeak {
+            inner: Gc::from_ptr(ptr),
+        }
+    }
 }

--- a/src/gc-arena/src/types.rs
+++ b/src/gc-arena/src/types.rs
@@ -218,6 +218,7 @@ impl CollectVtable {
 /// A typed GC'd value, together with its metadata.
 /// This type is never manipulated directly by the GC algorithm, allowing
 /// user-facing `Gc`s to freely cast their pointer to it.
+#[repr(C)]
 pub(crate) struct GcBoxInner<T: ?Sized> {
     header: GcBoxHeader,
     /// The typed value stored in this `GcBox`.

--- a/src/gc-arena/tests/tests.rs
+++ b/src/gc-arena/tests/tests.rs
@@ -536,6 +536,26 @@ fn cast() {
 }
 
 #[test]
+fn ptr_magic() {
+    gc_arena::rootless_arena(|mc| {
+        #[derive(Debug, Eq, PartialEq, Collect)]
+        #[collect(require_static)]
+        struct S(u8, u32, u64);
+
+        let a = Gc::allocate(mc, S(3, 4, 5));
+
+        let aptr = Gc::as_ptr(a);
+
+        unsafe {
+            assert_eq!(*aptr, S(3, 4, 5));
+
+            let b = Gc::from_ptr(aptr);
+            assert_eq!(*b, S(3, 4, 5));
+        }
+    });
+}
+
+#[test]
 fn ui() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/*.rs");


### PR DESCRIPTION
This adds `Gc::cast` and `GcWeak::cast`, similar to `NonNull::cast`.

Obviously unsafe, but this can be useful to do object header tricks.

Includes a drive by change to add `#[repr(C)]` back to `GcBoxInner`, as I think that's still required? I spent some time thinking about the soundness of pointer casting and noticed it was missing, there is even a note elsewhere in `types.rs` that mentions soundness is dependent on it being`#[repr(C)]`.