### PR TITLE
Expand upon `Lock` APIs

### DIFF
--- a/src/gc-arena/src/dynamic_roots.rs
+++ b/src/gc-arena/src/dynamic_roots.rs
@@ -4,7 +4,8 @@ use alloc::{
 };
 use core::mem;
 
-use crate::{Collect, Gc, MutationContext, RefLock, Root, Rootable};
+use crate::lock::RefLock;
+use crate::{Collect, Gc, MutationContext, Root, Rootable};
 
 // SAFETY: Allows us to conert `Gc<'gc>` pointers to `Gc<'static>` and back, and this is VERY
 // sketchy. We know it is safe because:

--- a/src/gc-arena/src/dynamic_roots.rs
+++ b/src/gc-arena/src/dynamic_roots.rs
@@ -53,7 +53,7 @@ impl<'gc> DynamicRootSet<'gc> {
         mc: MutationContext<'gc, '_>,
         root: Root<'gc, R>,
     ) -> DynamicRoot<R> {
-        let mut inner = self.0.write_ref_cell(mc).borrow_mut();
+        let mut inner = self.0.unlock(mc).borrow_mut();
 
         let handle = Rc::new(Handle {
             set_id: inner.set_id.clone(),

--- a/src/gc-arena/src/lib.rs
+++ b/src/gc-arena/src/lib.rs
@@ -16,7 +16,7 @@ mod context;
 mod dynamic_roots;
 mod gc;
 mod gc_weak;
-mod lock;
+pub mod lock;
 mod no_drop;
 mod static_collect;
 mod types;
@@ -33,7 +33,6 @@ pub use self::{
     dynamic_roots::{DynamicRoot, DynamicRootSet},
     gc::Gc,
     gc_weak::GcWeak,
-    lock::{Lock, RefLock},
     no_drop::MustNotImplDrop,
     static_collect::StaticCollect,
 };

--- a/src/gc-arena/src/lock.rs
+++ b/src/gc-arena/src/lock.rs
@@ -1,3 +1,5 @@
+//! GC-aware interior mutability types.
+
 use core::{
     cell::{BorrowError, BorrowMutError, Cell, Ref, RefCell, RefMut},
     fmt,

--- a/src/gc-arena/src/lock.rs
+++ b/src/gc-arena/src/lock.rs
@@ -46,6 +46,21 @@ impl<T> Lock<T> {
     pub fn new(t: T) -> Lock<T> {
         Self { cell: Cell::new(t) }
     }
+
+    pub fn get(&self) -> T where T: Copy {
+        self.cell.get()
+    }
+
+    pub fn into_inner(self) -> T {
+        self.cell.into_inner()
+    }
+
+    pub fn take(&self) -> T where T: Default {
+        // Despite mutating the contained value, this doesn't need a write barrier,
+        // as, thanks to lifetime parametricity, a `Default::default()` cannot ever
+        // safely obtain a `MutationContext` or other external `Gc` pointers.
+        self.cell.take()
+    }
 }
 
 impl<T: ?Sized> Lock<T> {
@@ -62,11 +77,9 @@ impl<T: ?Sized> Lock<T> {
     pub unsafe fn as_cell(&self) -> &Cell<T> {
         &self.cell
     }
-}
 
-impl<T: Copy> Lock<T> {
-    pub fn get(&self) -> T {
-        self.cell.get()
+    pub fn get_mut(&mut self) -> &mut T {
+        self.cell.get_mut()
     }
 }
 
@@ -194,6 +207,17 @@ impl<T> RefLock<T> {
             cell: RefCell::new(t),
         }
     }
+
+    pub fn into_inner(self) -> T {
+        self.cell.into_inner()
+    }
+
+    pub fn take(&self) -> T where T: Default {
+        // Despite mutating the contained value, this doesn't need a write barrier,
+        // as, thanks to lifetime parametricity, a `Default::default()` cannot ever
+        // safely obtain a `MutationContext` or other external `Gc` pointers.
+        self.cell.take()
+    }
 }
 
 impl<T: ?Sized> RefLock<T> {
@@ -218,6 +242,10 @@ impl<T: ?Sized> RefLock<T> {
     /// manually before collection is triggered.
     pub unsafe fn as_ref_cell(&self) -> &RefCell<T> {
         &self.cell
+    }
+
+    pub fn get_mut(&mut self) -> &mut T {
+        self.cell.get_mut()
     }
 }
 

--- a/src/gc-arena/tests/tests.rs
+++ b/src/gc-arena/tests/tests.rs
@@ -52,7 +52,7 @@ fn weak_allocation() {
             .map(|gc| Gc::ptr_eq(gc, root.test.borrow().unwrap()))
             .unwrap_or(false));
 
-        *root.test.write_ref_cell(mc).borrow_mut() = None;
+        *root.test.unlock(mc).borrow_mut() = None;
     });
     let mut done = false;
     while !done {
@@ -129,7 +129,7 @@ fn repeated_allocation_deallocation() {
 
     for _ in 0..40 {
         arena.mutate(|mc, root| {
-            let mut map = root.0.write_ref_cell(mc).borrow_mut();
+            let mut map = root.0.unlock(mc).borrow_mut();
             for _ in 0..50 {
                 let i = key_range.sample(&mut rng);
                 if let Some(old) = map.insert(i, Gc::new(mc, (i, r.clone()))) {
@@ -172,7 +172,7 @@ fn all_dropped() {
     });
 
     arena.mutate(|mc, root| {
-        let mut v = root.0.write_ref_cell(mc).borrow_mut();
+        let mut v = root.0.unlock(mc).borrow_mut();
         for _ in 0..100 {
             v.push(Gc::new(mc, r.clone()));
         }
@@ -198,13 +198,13 @@ fn all_garbage_collected() {
     });
 
     arena.mutate(|mc, root| {
-        let mut v = root.0.write_ref_cell(mc).borrow_mut();
+        let mut v = root.0.unlock(mc).borrow_mut();
         for _ in 0..100 {
             v.push(Gc::new(mc, r.clone()));
         }
     });
     arena.mutate(|mc, root| {
-        root.0.write_ref_cell(mc).borrow_mut().clear();
+        root.0.unlock(mc).borrow_mut().clear();
     });
     arena.collect_all();
     arena.collect_all();

--- a/src/gc-arena/tests/tests.rs
+++ b/src/gc-arena/tests/tests.rs
@@ -3,9 +3,10 @@ use rand::distributions::Distribution;
 #[cfg(feature = "std")]
 use std::{collections::HashMap, rc::Rc};
 
+use gc_arena::lock::RefLock;
 use gc_arena::{
     unsafe_empty_collect, unsize, Arena, ArenaParameters, Collect, DynamicRootSet, Gc, GcWeak,
-    RefLock, Rootable,
+    Rootable,
 };
 
 #[test]


### PR DESCRIPTION
A bunch of bells and whistles:
- move the lock types into their separate module, to not clutter the crate root;
- implement *all* the traits;
- add some extra methods (`into_inner`, `get_mut`, `take`);
- replace `Gc::write_(ref_)cell` by `Gc::unlock` and the `Unlock` trait;
- add type aliases for `Gc`+locks combinations.

I wanted to add `OnceLock` too, but I realized that `OnceCell` will only be stabilized in Rust 1.70, so I guess I'll have to wait a little still.
