### PR TITLE
Inline trivial methods

### DIFF
--- a/src/gc-arena/src/arena.rs
+++ b/src/gc-arena/src/arena.rs
@@ -275,6 +275,7 @@ impl<R: for<'a> Rootable<'a> + ?Sized> Arena<R> {
     /// Run the current garbage collection cycle to completion, stopping once the garbage collector
     /// has entered the sleeping phase. If the garbage collector is currently sleeping, starts a new
     /// cycle and runs that cycle to completion.
+    #[inline]
     pub fn collect_all(&mut self) {
         self.context.wake();
         unsafe {

--- a/src/gc-arena/src/context.rs
+++ b/src/gc-arena/src/context.rs
@@ -359,7 +359,15 @@ impl Context {
         let header = gc_box.header();
         if self.phase.get() == Phase::Propagate && header.color() == GcColor::Black {
             header.set_color(GcColor::Gray);
-            self.gray_again.borrow_mut().push(gc_box);
+
+            // Outline the actual enqueueing code (which is somewhat expensive and won't be
+            // executed often) to promote the inlining of the write barrier.
+            #[cold]
+            fn enqueue(this: &Context, gc_box: GcBox) {
+                this.gray_again.borrow_mut().push(gc_box);
+            }
+
+            enqueue(&self, gc_box);
         }
     }
 

--- a/src/gc-arena/src/context.rs
+++ b/src/gc-arena/src/context.rs
@@ -18,14 +18,17 @@ pub struct MutationContext<'gc, 'context> {
 }
 
 impl<'gc, 'context> MutationContext<'gc, 'context> {
+    #[inline]
     pub(crate) fn allocate<T: 'gc + Collect>(self, t: T) -> NonNull<GcBoxInner<T>> {
         self.context.allocate(t)
     }
 
+    #[inline]
     pub(crate) fn write_barrier(self, gc_box: GcBox) {
         self.context.write_barrier(gc_box)
     }
 
+    #[inline]
     pub(crate) fn upgrade(self, gc_box: GcBox) -> bool {
         self.context.upgrade(gc_box)
     }
@@ -39,10 +42,12 @@ pub struct CollectionContext<'context> {
 }
 
 impl<'context> CollectionContext<'context> {
+    #[inline]
     pub(crate) fn trace(self, gc_box: GcBox) {
         self.context.trace(gc_box)
     }
 
+    #[inline]
     pub(crate) fn trace_weak(&self, gc_box: GcBox) {
         self.context.trace_weak(gc_box)
     }
@@ -150,6 +155,7 @@ impl Context {
 
     // If the garbage collector is currently in the sleep phase,
     // add the root to the gray queue and transition to the `Propagate` phase.
+    #[inline]
     pub(crate) fn wake(&self) {
         if self.phase.get() == Phase::Sleep {
             self.phase.set(Phase::Propagate);
@@ -157,6 +163,7 @@ impl Context {
         }
     }
 
+    #[inline]
     pub(crate) fn root_barrier(&self) {
         if self.phase.get() == Phase::Propagate {
             self.root_needs_trace.set(true);
@@ -344,6 +351,7 @@ impl Context {
         ptr
     }
 
+    #[inline]
     fn write_barrier(&self, gc_box: GcBox) {
         // During the propagating phase, if we are mutating a black object, we may add a white
         // object to it and invalidate the invariant that black objects may not point to white
@@ -355,6 +363,7 @@ impl Context {
         }
     }
 
+    #[inline]
     fn trace(&self, gc_box: GcBox) {
         let header = gc_box.header();
         match header.color() {
@@ -373,6 +382,7 @@ impl Context {
         }
     }
 
+    #[inline]
     fn trace_weak(&self, gc_box: GcBox) {
         let header = gc_box.header();
         if header.color() == GcColor::White {
@@ -382,6 +392,7 @@ impl Context {
 
     /// Determines whether or not a Gc pointer is safe to be upgraded.
     /// This is used by weak pointers to determine if it can safely upgrade to a strong pointer.
+    #[inline]
     fn upgrade(&self, gc_box: GcBox) -> bool {
         let header = gc_box.header();
 

--- a/src/gc-arena/src/dynamic_roots.rs
+++ b/src/gc-arena/src/dynamic_roots.rs
@@ -108,6 +108,7 @@ impl<R: for<'gc> Rootable<'gc> + ?Sized> DynamicRoot<R> {
     // Secondly, though the pointer to the object *itself* will not be dangling, any garbage
     // collected pointers the object holds *will* be dangling if the arena backing this root has
     // been dropped.
+    #[inline]
     pub fn as_ptr<'gc>(&self) -> *const Root<'gc, R> {
         unsafe { mem::transmute::<&Root<'static, R>, &Root<'gc, R>>(&self.handle.root) as *const _ }
     }

--- a/src/gc-arena/src/gc.rs
+++ b/src/gc-arena/src/gc.rs
@@ -45,12 +45,14 @@ impl<'gc, T: Display + ?Sized + 'gc> Display for Gc<'gc, T> {
 impl<'gc, T: ?Sized + 'gc> Copy for Gc<'gc, T> {}
 
 impl<'gc, T: ?Sized + 'gc> Clone for Gc<'gc, T> {
+    #[inline]
     fn clone(&self) -> Gc<'gc, T> {
         *self
     }
 }
 
 unsafe impl<'gc, T: ?Sized + 'gc> Collect for Gc<'gc, T> {
+    #[inline]
     fn trace(&self, cc: CollectionContext) {
         unsafe {
             cc.trace(GcBox::erase(self.ptr));
@@ -61,12 +63,14 @@ unsafe impl<'gc, T: ?Sized + 'gc> Collect for Gc<'gc, T> {
 impl<'gc, T: ?Sized + 'gc> Deref for Gc<'gc, T> {
     type Target = T;
 
+    #[inline]
     fn deref(&self) -> &T {
         unsafe { &self.ptr.as_ref().value }
     }
 }
 
 impl<'gc, T: Collect + 'gc> Gc<'gc, T> {
+    #[inline]
     pub fn new(mc: MutationContext<'gc, '_>, t: T) -> Gc<'gc, T> {
         Gc {
             ptr: mc.allocate(t),
@@ -80,6 +84,7 @@ impl<'gc, T: 'gc> Gc<'gc, T> {
     ///
     /// SAFETY:
     /// It must be valid to dereference a `*mut U` that has come from casting a `*mut T`.
+    #[inline]
     pub unsafe fn cast<U: 'gc>(this: Gc<'gc, T>) -> Gc<'gc, U> {
         Gc {
             ptr: NonNull::cast(this.ptr),
@@ -92,6 +97,7 @@ impl<'gc, T: 'gc> Gc<'gc, T> {
     /// SAFETY:
     /// The provided pointer must have been obtained from `Gc::as_ptr`, and the pointer must not
     /// have been collected yet.
+    #[inline]
     pub unsafe fn from_ptr(ptr: *const T) -> Gc<'gc, T> {
         let header_offset = {
             let base = mem::MaybeUninit::<GcBoxInner<T>>::uninit();
@@ -112,6 +118,7 @@ impl<'gc, T: 'gc> Gc<'gc, T> {
 
 impl<'gc, T: Unlock + ?Sized + 'gc> Gc<'gc, T> {
     /// Unlock the contents of this `Gc` safely by ensuring that the write barrier is called.
+    #[inline]
     pub fn unlock(&self, mc: MutationContext<'gc, '_>) -> &T::Unlocked {
         Gc::write_barrier(mc, *self);
         // SAFETY: see doc-comment.
@@ -120,6 +127,7 @@ impl<'gc, T: Unlock + ?Sized + 'gc> Gc<'gc, T> {
 }
 
 impl<'gc, T: ?Sized + 'gc> Gc<'gc, T> {
+    #[inline]
     pub fn downgrade(this: Gc<'gc, T>) -> GcWeak<'gc, T> {
         GcWeak { inner: this }
     }
@@ -127,16 +135,19 @@ impl<'gc, T: ?Sized + 'gc> Gc<'gc, T> {
     /// When implementing `Collect` on types with internal mutability containing `Gc` pointers, this
     /// method must be used to ensure safe mutability. Safe to call, but only necessary from unsafe
     /// code.
+    #[inline]
     pub fn write_barrier(mc: MutationContext<'gc, '_>, gc: Self) {
         unsafe {
             mc.write_barrier(GcBox::erase(gc.ptr));
         }
     }
 
+    #[inline]
     pub fn ptr_eq(this: Gc<'gc, T>, other: Gc<'gc, T>) -> bool {
         Gc::as_ptr(this) == Gc::as_ptr(other)
     }
 
+    #[inline]
     pub fn as_ptr(gc: Gc<'gc, T>) -> *const T {
         unsafe {
             let inner = gc.ptr.as_ptr();

--- a/src/gc-arena/src/gc_weak.rs
+++ b/src/gc-arena/src/gc_weak.rs
@@ -12,6 +12,7 @@ pub struct GcWeak<'gc, T: ?Sized + 'gc> {
 impl<'gc, T: ?Sized + 'gc> Copy for GcWeak<'gc, T> {}
 
 impl<'gc, T: ?Sized + 'gc> Clone for GcWeak<'gc, T> {
+    #[inline]
     fn clone(&self) -> GcWeak<'gc, T> {
         *self
     }
@@ -24,6 +25,7 @@ impl<'gc, T: ?Sized + 'gc> Debug for GcWeak<'gc, T> {
 }
 
 unsafe impl<'gc, T: ?Sized + 'gc> Collect for GcWeak<'gc, T> {
+    #[inline]
     fn trace(&self, cc: CollectionContext) {
         unsafe {
             cc.trace_weak(GcBox::erase(self.inner.ptr));
@@ -32,6 +34,7 @@ unsafe impl<'gc, T: ?Sized + 'gc> Collect for GcWeak<'gc, T> {
 }
 
 impl<'gc, T: ?Sized + 'gc> GcWeak<'gc, T> {
+    #[inline]
     pub fn upgrade(&self, mc: MutationContext<'gc, '_>) -> Option<Gc<'gc, T>> {
         unsafe {
             let ptr = GcBox::erase(self.inner.ptr);
@@ -42,15 +45,18 @@ impl<'gc, T: ?Sized + 'gc> GcWeak<'gc, T> {
     /// Returns whether the value referenced by this `GcWeak` has been dropped.
     ///
     /// Note that calling `upgrade` may still fail even when this method returns `false`.
+    #[inline]
     pub fn is_dropped(self) -> bool {
         let ptr = unsafe { GcBox::erase(self.inner.ptr) };
         !ptr.header().is_live()
     }
 
+    #[inline]
     pub fn ptr_eq(this: GcWeak<'gc, T>, other: GcWeak<'gc, T>) -> bool {
         this.as_ptr() == other.as_ptr()
     }
 
+    #[inline]
     pub fn as_ptr(self) -> *const T {
         Gc::as_ptr(self.inner)
     }
@@ -61,6 +67,7 @@ impl<'gc, T: 'gc> GcWeak<'gc, T> {
     ///
     /// SAFETY:
     /// It must be valid to dereference a `*mut U` that has come from casting a `*mut T`.
+    #[inline]
     pub unsafe fn cast<U: 'gc>(this: GcWeak<'gc, T>) -> GcWeak<'gc, U> {
         GcWeak {
             inner: Gc::cast::<U>(this.inner),
@@ -73,6 +80,7 @@ impl<'gc, T: 'gc> GcWeak<'gc, T> {
     /// The provided pointer must have been obtained from `GcWeak::as_ptr` or `Gc::as_ptr`, and
     /// the pointer must not have been *fully* collected yet (it may be a dropped but live weak
     /// pointer).
+    #[inline]
     pub unsafe fn from_ptr(ptr: *const T) -> GcWeak<'gc, T> {
         GcWeak {
             inner: Gc::from_ptr(ptr),

--- a/src/gc-arena/src/lock.rs
+++ b/src/gc-arena/src/lock.rs
@@ -55,10 +55,12 @@ macro_rules! make_lock_wrapper {
         pub type $gc_locked_type<'gc, T> = Gc<'gc, $locked_type<T>>;
 
         impl<T> $locked_type<T> {
+            #[inline]
             pub fn new(t: T) -> $locked_type<T> {
                 Self { cell: $unlocked_type::new(t) }
             }
 
+            #[inline]
             pub fn into_inner(self) -> T {
                 self.cell.into_inner()
             }
@@ -67,6 +69,7 @@ macro_rules! make_lock_wrapper {
         }
 
         impl<T: ?Sized> $locked_type<T> {
+            #[inline]
             pub fn as_ptr(&self) -> *mut T {
                 self.cell.as_ptr()
             }
@@ -82,10 +85,12 @@ macro_rules! make_lock_wrapper {
             #[doc = stringify!($unlocked_type)]
             /// `], unless the write barrier for the containing [`Gc`] pointer is invoked manuall
             /// before collection is triggered.
+            #[inline]
             pub unsafe fn $unsafe_unlock_method(&self) -> &$unlocked_type<T> {
                 &self.cell
             }
 
+            #[inline]
             pub fn get_mut(&mut self) -> &mut T {
                 self.cell.get_mut()
             }
@@ -94,18 +99,21 @@ macro_rules! make_lock_wrapper {
         impl<T: ?Sized> Unlock for $locked_type<T> {
             type Unlocked = $unlocked_type<T>;
 
+            #[inline]
             unsafe fn unlock_unchecked(&self) -> &Self::Unlocked {
                 &self.cell
             }
         }
 
         impl<T> From<T> for $locked_type<T> {
+            #[inline]
             fn from(t: T) -> Self {
                 Self::new(t)
             }
         }
 
         impl<T> From<$unlocked_type<T>> for $locked_type<T> {
+            #[inline]
             fn from(cell: $unlocked_type<T>) -> Self {
                 Self { cell }
             }
@@ -118,10 +126,12 @@ make_lock_wrapper!(
     locked = Lock as GcLock;
     unlocked = Cell unsafe as_cell;
     impl Sized {
+        #[inline]
         pub fn get(&self) -> T where T: Copy {
             self.cell.get()
         }
 
+        #[inline]
         pub fn take(&self) -> T where T: Default {
             // Despite mutating the contained value, this doesn't need a write barrier, as
             // the return value of `Default::default` can never contain (non-leaked) `Gc` pointers.
@@ -146,16 +156,19 @@ impl<T: Copy + fmt::Debug> fmt::Debug for Lock<T> {
 }
 
 impl<'gc, T: Copy + 'gc> Gc<'gc, Lock<T>> {
+    #[inline]
     pub fn get(&self) -> T {
         self.cell.get()
     }
 
+    #[inline]
     pub fn set(&self, mc: MutationContext<'gc, '_>, t: T) {
         self.unlock(mc).set(t);
     }
 }
 
 unsafe impl<'gc, T: Collect + Copy + 'gc> Collect for Lock<T> {
+    #[inline]
     fn trace(&self, cc: CollectionContext) {
         // Okay, so this calls `T::trace` on a *copy* of `T`.
         //
@@ -179,6 +192,7 @@ unsafe impl<'gc, T: Collect + Copy + 'gc> Collect for Lock<T> {
 
 // Can't use `#[derive]` because of the non-standard bounds.
 impl<T: Copy> Clone for Lock<T> {
+    #[inline]
     fn clone(&self) -> Self {
         Self::new(self.get())
     }
@@ -186,6 +200,7 @@ impl<T: Copy> Clone for Lock<T> {
 
 // Can't use `#[derive]` because of the non-standard bounds.
 impl<T: PartialEq + Copy> PartialEq for Lock<T> {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.get() == other.get()
     }
@@ -196,6 +211,7 @@ impl<T: Eq + Copy> Eq for Lock<T> {}
 
 // Can't use `#[derive]` because of the non-standard bounds.
 impl<T: PartialOrd + Copy> PartialOrd for Lock<T> {
+    #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         self.get().partial_cmp(&other.get())
     }
@@ -203,6 +219,7 @@ impl<T: PartialOrd + Copy> PartialOrd for Lock<T> {
 
 // Can't use `#[derive]` because of the non-standard bounds.
 impl<T: Ord + Copy> Ord for Lock<T> {
+    #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
         self.get().cmp(&other.get())
     }
@@ -213,6 +230,7 @@ make_lock_wrapper!(
     locked = RefLock as GcRefLock;
     unlocked = RefCell unsafe as_ref_cell;
     impl Sized {
+        #[inline]
         pub fn take(&self) -> T where T: Default {
             // See comment in `Lock::take`.
             self.cell.take()
@@ -220,10 +238,12 @@ make_lock_wrapper!(
     }
     impl ?Sized {
         #[track_caller]
+        #[inline]
         pub fn borrow<'a>(&'a self) -> Ref<'a, T> {
             self.cell.borrow()
         }
 
+        #[inline]
         pub fn try_borrow<'a>(&'a self) -> Result<Ref<'a, T>, BorrowError> {
             self.cell.try_borrow()
         }
@@ -255,19 +275,23 @@ impl<T: fmt::Debug + ?Sized> fmt::Debug for RefLock<T> {
 
 impl<'gc, T: ?Sized + 'gc> Gc<'gc, RefLock<T>> {
     #[track_caller]
+    #[inline]
     pub fn borrow<'a>(&'a self) -> Ref<'a, T> {
         RefLock::borrow(self)
     }
 
+    #[inline]
     pub fn try_borrow<'a>(&'a self) -> Result<Ref<'a, T>, BorrowError> {
         RefLock::try_borrow(self)
     }
 
     #[track_caller]
+    #[inline]
     pub fn borrow_mut<'a>(&'a self, mc: MutationContext<'gc, '_>) -> RefMut<'a, T> {
         self.unlock(mc).borrow_mut()
     }
 
+    #[inline]
     pub fn try_borrow_mut<'a>(
         &'a self,
         mc: MutationContext<'gc, '_>,
@@ -277,6 +301,7 @@ impl<'gc, T: ?Sized + 'gc> Gc<'gc, RefLock<T>> {
 }
 
 unsafe impl<'gc, T: Collect + ?Sized + 'gc> Collect for RefLock<T> {
+    #[inline]
     fn trace(&self, cc: CollectionContext) {
         self.borrow().trace(cc);
     }


### PR DESCRIPTION
Adds `#[inline]` to trivial methods, so that the compile-time wrappers get properly optimized out without having to enable LTO.