### PR TITLE
Modify names and lifetime signatures for ergonomics.

### DIFF
--- a/src/gc-arena-derive/src/lib.rs
+++ b/src/gc-arena-derive/src/lib.rs
@@ -199,7 +199,7 @@ fn collect_derive(mut s: synstructure::Structure) -> TokenStream {
                 }
 
                 #[inline]
-                fn trace(&self, cc: ::gc_arena::CollectionContext) {
+                fn trace(&self, cc: &::gc_arena::Collection) {
                     match *self { #trace_body }
                 }
             }

--- a/src/gc-arena/src/arena.rs
+++ b/src/gc-arena/src/arena.rs
@@ -1,7 +1,7 @@
 use core::{f64, marker::PhantomData, mem, usize};
 
 use crate::{
-    context::{Context, MutationContext},
+    context::{Context, Mutation},
     Collect,
 };
 
@@ -157,21 +157,21 @@ pub struct Arena<R: for<'a> Rootable<'a>> {
 
 impl<R: for<'a> Rootable<'a>> Arena<R> {
     /// Create a new arena with the given garbage collector tuning parameters. You must provide a
-    /// closure that accepts a `MutationContext` and returns the appropriate root.
+    /// closure that accepts a `&Mutation<'gc>` and returns the appropriate root.
     pub fn new<F>(arena_parameters: ArenaParameters, f: F) -> Arena<R>
     where
-        F: for<'gc> FnOnce(MutationContext<'gc, '_>) -> Root<'gc, R>,
+        F: for<'gc> FnOnce(&'gc Mutation<'gc>) -> Root<'gc, R>,
     {
         unsafe {
             let context = Context::new(arena_parameters);
-            // Note - we transmute the `MutationContext` to a `'static` lifetime here,
+            // Note - we transmute the `&Mutation` to a `'static` lifetime here,
             // instead of transmuting the root type returned by `f`. Transmuting the root
             // type is allowed in nightly versions of rust
             // (see https://github.com/rust-lang/rust/pull/101520#issuecomment-1252016235)
-            // but is not yet stable. Transmuting the `MutationContext` is completely invisible
+            // but is not yet stable. Transmuting the `&Mutation` is completely invisible
             // to the callback `f` (since it needs to handle an arbitrary lifetime),
             // and lets us stay compatible with older versions of Rust
-            let mutation_context: MutationContext<'static, '_> =
+            let mutation_context: &'static Mutation<'static> =
                 mem::transmute(context.mutation_context());
             let root: Root<'static, R> = f(mutation_context);
             Arena { context, root }
@@ -181,11 +181,11 @@ impl<R: for<'a> Rootable<'a>> Arena<R> {
     /// Similar to `new`, but allows for constructor that can fail.
     pub fn try_new<F, E>(arena_parameters: ArenaParameters, f: F) -> Result<Arena<R>, E>
     where
-        F: for<'gc> FnOnce(MutationContext<'gc, '_>) -> Result<Root<'gc, R>, E>,
+        F: for<'gc> FnOnce(&'gc Mutation<'gc>) -> Result<Root<'gc, R>, E>,
     {
         unsafe {
             let context = Context::new(arena_parameters);
-            let mutation_context: MutationContext<'static, '_> =
+            let mutation_context: &'static Mutation<'static> =
                 mem::transmute(context.mutation_context());
             let root: Root<'static, R> = f(mutation_context)?;
             Ok(Arena { context, root })
@@ -193,18 +193,22 @@ impl<R: for<'a> Rootable<'a>> Arena<R> {
     }
 
     /// The primary means of interacting with a garbage collected arena. Accepts a callback which
-    /// receives a `MutationContext` and a reference to the root, and can return any non garbage
+    /// receives a `&Mutation<'gc>` and a reference to the root, and can return any non garbage
     /// collected value. The callback may "mutate" any part of the object graph during this call,
     /// but no garbage collection will take place during this method.
     #[inline]
     pub fn mutate<'a, F, T>(&'a self, f: F) -> T
     where
-        F: for<'gc> FnOnce(MutationContext<'gc, 'a>, &'a Root<'gc, R>) -> T,
+        F: for<'gc> FnOnce(&'gc Mutation<'gc>, &Root<'gc, R>) -> T,
     {
         // The user-provided callback may return a (non-GC'd) value borrowed from the arena;
         // this is safe as all objects in the graph live until the next collection, which
         // requires exclusive access to the arena.
-        unsafe { f(self.context.mutation_context(), &self.root) }
+        unsafe {
+            let mutation_context: &'static Mutation<'static> =
+                mem::transmute(self.context.mutation_context());
+            f(mutation_context, &self.root)
+        }
     }
 
     /// An alternative version of [`Arena::mutate`] which allows mutating the root set, at the
@@ -212,23 +216,31 @@ impl<R: for<'a> Rootable<'a>> Arena<R> {
     #[inline]
     pub fn mutate_root<'a, F, T>(&'a mut self, f: F) -> T
     where
-        F: for<'gc> FnOnce(MutationContext<'gc, 'a>, &'a mut Root<'gc, R>) -> T,
+        F: for<'gc> FnOnce(&'gc Mutation<'gc>, &'a mut Root<'gc, R>) -> T,
     {
         self.context.root_barrier();
         // The user-provided callback may return a (non-GC'd) value borrowed from the arena;
         // this is safe as all objects in the graph live until the next collection, which
         // requires exclusive access to the arena. Additionally, the write barrier ensures
         // that any changes to the root set are properly picked up.
-        unsafe { f(self.context.mutation_context(), &mut self.root) }
+        unsafe {
+            let mutation_context: &'static Mutation<'static> =
+                mem::transmute(self.context.mutation_context());
+            f(mutation_context, &mut self.root)
+        }
     }
 
     #[inline]
     pub fn map_root<R2: for<'a> Rootable<'a>>(
         self,
-        f: impl for<'gc> FnOnce(MutationContext<'gc, '_>, Root<'gc, R>) -> Root<'gc, R2>,
+        f: impl for<'gc> FnOnce(&'gc Mutation<'gc>, Root<'gc, R>) -> Root<'gc, R2>,
     ) -> Arena<R2> {
         self.context.root_barrier();
-        let new_root: Root<'static, R2> = unsafe { f(self.context.mutation_context(), self.root) };
+        let new_root: Root<'static, R2> = unsafe {
+            let mutation_context: &'static Mutation<'static> =
+                mem::transmute(self.context.mutation_context());
+            f(mutation_context, self.root)
+        };
         Arena {
             context: self.context,
             root: new_root,
@@ -238,10 +250,14 @@ impl<R: for<'a> Rootable<'a>> Arena<R> {
     #[inline]
     pub fn try_map_root<R2: for<'a> Rootable<'a>, E>(
         self,
-        f: impl for<'gc> FnOnce(MutationContext<'gc, '_>, Root<'gc, R>) -> Result<Root<'gc, R2>, E>,
+        f: impl for<'gc> FnOnce(&'gc Mutation<'gc>, Root<'gc, R>) -> Result<Root<'gc, R2>, E>,
     ) -> Result<Arena<R2>, E> {
         self.context.root_barrier();
-        let new_root: Root<'static, R2> = unsafe { f(self.context.mutation_context(), self.root)? };
+        let new_root: Root<'static, R2> = unsafe {
+            let mutation_context: &'static Mutation<'static> =
+                mem::transmute(self.context.mutation_context());
+            f(mutation_context, self.root)?
+        };
         Ok(Arena {
             context: self.context,
             root: new_root,
@@ -299,7 +315,7 @@ impl<R: for<'a> Rootable<'a>> Arena<R> {
 /// be collected.
 pub fn rootless_arena<F, R>(f: F) -> R
 where
-    F: for<'gc> FnOnce(MutationContext<'gc, '_>) -> R,
+    F: for<'gc> FnOnce(&'gc Mutation<'gc>) -> R,
 {
     unsafe {
         let context = Context::new(ArenaParameters::default());

--- a/src/gc-arena/src/collect.rs
+++ b/src/gc-arena/src/collect.rs
@@ -1,4 +1,4 @@
-use crate::context::CollectionContext;
+use crate::context::Collection;
 
 /// A trait for garbage collected objects that can be placed into `Gc` pointers. This trait is
 /// unsafe, because `Gc` pointers inside an Arena are assumed never to be dangling, and in order to
@@ -34,5 +34,5 @@ pub unsafe trait Collect {
     /// implement `Collect`, a valid implementation would simply call `Collect::trace` on all the
     /// held values to ensure this.
     #[inline]
-    fn trace(&self, _cc: CollectionContext) {}
+    fn trace(&self, _cc: &Collection) {}
 }

--- a/src/gc-arena/src/collect_impl.rs
+++ b/src/gc-arena/src/collect_impl.rs
@@ -13,7 +13,7 @@ use core::marker::PhantomData;
 use std::collections::{HashMap, HashSet};
 
 use crate::collect::Collect;
-use crate::context::CollectionContext;
+use crate::context::Collection;
 
 /// If a type will never hold `Gc` pointers, you can use this macro to provide a simple empty
 /// `Collect` implementation.
@@ -110,7 +110,7 @@ unsafe impl<T: ?Sized + 'static> Collect for &'static T {
 
 unsafe impl<T: ?Sized + Collect> Collect for Box<T> {
     #[inline]
-    fn trace(&self, cc: CollectionContext) {
+    fn trace(&self, cc: &Collection) {
         (**self).trace(cc)
     }
 }
@@ -122,7 +122,7 @@ unsafe impl<T: Collect> Collect for [T] {
     }
 
     #[inline]
-    fn trace(&self, cc: CollectionContext) {
+    fn trace(&self, cc: &Collection) {
         for t in self.iter() {
             t.trace(cc)
         }
@@ -136,7 +136,7 @@ unsafe impl<T: Collect> Collect for Option<T> {
     }
 
     #[inline]
-    fn trace(&self, cc: CollectionContext) {
+    fn trace(&self, cc: &Collection) {
         if let Some(t) = self.as_ref() {
             t.trace(cc)
         }
@@ -150,7 +150,7 @@ unsafe impl<T: Collect, E: Collect> Collect for Result<T, E> {
     }
 
     #[inline]
-    fn trace(&self, cc: CollectionContext) {
+    fn trace(&self, cc: &Collection) {
         match self {
             Ok(r) => r.trace(cc),
             Err(e) => e.trace(cc),
@@ -165,7 +165,7 @@ unsafe impl<T: Collect> Collect for Vec<T> {
     }
 
     #[inline]
-    fn trace(&self, cc: CollectionContext) {
+    fn trace(&self, cc: &Collection) {
         for t in self {
             t.trace(cc)
         }
@@ -179,7 +179,7 @@ unsafe impl<T: Collect> Collect for VecDeque<T> {
     }
 
     #[inline]
-    fn trace(&self, cc: CollectionContext) {
+    fn trace(&self, cc: &Collection) {
         for t in self {
             t.trace(cc)
         }
@@ -199,7 +199,7 @@ where
     }
 
     #[inline]
-    fn trace(&self, cc: CollectionContext) {
+    fn trace(&self, cc: &Collection) {
         for (k, v) in self {
             k.trace(cc);
             v.trace(cc);
@@ -219,7 +219,7 @@ where
     }
 
     #[inline]
-    fn trace(&self, cc: CollectionContext) {
+    fn trace(&self, cc: &Collection) {
         for v in self {
             v.trace(cc);
         }
@@ -237,7 +237,7 @@ where
     }
 
     #[inline]
-    fn trace(&self, cc: CollectionContext) {
+    fn trace(&self, cc: &Collection) {
         for (k, v) in self {
             k.trace(cc);
             v.trace(cc);
@@ -255,7 +255,7 @@ where
     }
 
     #[inline]
-    fn trace(&self, cc: CollectionContext) {
+    fn trace(&self, cc: &Collection) {
         for v in self {
             v.trace(cc);
         }
@@ -267,7 +267,7 @@ where
     T: ?Sized + Collect,
 {
     #[inline]
-    fn trace(&self, cc: CollectionContext) {
+    fn trace(&self, cc: &Collection) {
         (**self).trace(cc);
     }
 }
@@ -277,7 +277,7 @@ where
     T: ?Sized + Collect,
 {
     #[inline]
-    fn trace(&self, cc: CollectionContext) {
+    fn trace(&self, cc: &Collection) {
         (**self).trace(cc);
     }
 }
@@ -317,7 +317,7 @@ unsafe impl<T: Collect, const N: usize> Collect for [T; N] {
     }
 
     #[inline]
-    fn trace(&self, cc: CollectionContext) {
+    fn trace(&self, cc: &Collection) {
         for t in self {
             t.trace(cc)
         }
@@ -345,7 +345,7 @@ macro_rules! impl_tuple {
 
             #[allow(non_snake_case)]
             #[inline]
-            fn trace(&self, cc: CollectionContext) {
+            fn trace(&self, cc: &Collection) {
                 let ($($name,)*) = self;
                 $($name.trace(cc);)*
             }

--- a/src/gc-arena/src/gc_weak.rs
+++ b/src/gc-arena/src/gc_weak.rs
@@ -1,7 +1,7 @@
 use crate::collect::Collect;
 use crate::gc::Gc;
 use crate::types::GcBox;
-use crate::{CollectionContext, MutationContext};
+use crate::{Collection, Mutation};
 
 use core::fmt::{self, Debug};
 
@@ -26,7 +26,7 @@ impl<'gc, T: ?Sized + 'gc> Debug for GcWeak<'gc, T> {
 
 unsafe impl<'gc, T: ?Sized + 'gc> Collect for GcWeak<'gc, T> {
     #[inline]
-    fn trace(&self, cc: CollectionContext) {
+    fn trace(&self, cc: &Collection) {
         unsafe {
             cc.trace_weak(GcBox::erase(self.inner.ptr));
         }
@@ -35,7 +35,7 @@ unsafe impl<'gc, T: ?Sized + 'gc> Collect for GcWeak<'gc, T> {
 
 impl<'gc, T: ?Sized + 'gc> GcWeak<'gc, T> {
     #[inline]
-    pub fn upgrade(self, mc: MutationContext<'gc, '_>) -> Option<Gc<'gc, T>> {
+    pub fn upgrade(self, mc: &Mutation<'gc>) -> Option<Gc<'gc, T>> {
         unsafe {
             let ptr = GcBox::erase(self.inner.ptr);
             mc.upgrade(ptr).then(|| self.inner)

--- a/src/gc-arena/src/lib.rs
+++ b/src/gc-arena/src/lib.rs
@@ -28,7 +28,7 @@ pub use self::{arena::__DynRootable, no_drop::__MustNotImplDrop, unsize::__Coerc
 pub use self::{
     arena::{rootless_arena, Arena, ArenaParameters, Root, Rootable},
     collect::Collect,
-    context::{CollectionContext, MutationContext},
+    context::{Collection, Mutation},
     dynamic_roots::{DynamicRoot, DynamicRootSet},
     gc::Gc,
     gc_weak::GcWeak,

--- a/src/gc-arena/src/types.rs
+++ b/src/gc-arena/src/types.rs
@@ -47,7 +47,7 @@ impl GcBox {
     ///
     /// **SAFETY**: `Self::drop_in_place` must not have been called.
     #[inline(always)]
-    pub(crate) unsafe fn trace_value(&self, cc: crate::CollectionContext) {
+    pub(crate) unsafe fn trace_value(&self, cc: &crate::Collection) {
         (self.header().vtable().trace_value)(*self, cc)
     }
 
@@ -193,7 +193,7 @@ struct CollectVtable {
     /// Drops the value stored in the given `GcBox` (without deallocating the box).
     drop_value: unsafe fn(GcBox),
     /// Traces the value stored in the given `GcBox`.
-    trace_value: unsafe fn(GcBox, crate::CollectionContext<'_>),
+    trace_value: unsafe fn(GcBox, &crate::Collection),
 }
 
 impl CollectVtable {

--- a/src/gc-arena/tests/tests.rs
+++ b/src/gc-arena/tests/tests.rs
@@ -566,7 +566,7 @@ fn okay_panic() {
     }
 
     unsafe impl<'gc> Collect for Test<'gc> {
-        fn trace(&self, cc: gc_arena::CollectionContext) {
+        fn trace(&self, cc: &gc_arena::Collection) {
             let panics = self.panic_count.get();
             if panics > 0 {
                 self.panic_count.set(panics - 1);


### PR DESCRIPTION
Renames CollectionContext -> Collection and MutationContext -> Mutation.

Gets rid of the explicit extra 'a lifetime on Mutation in favor of an easier to deal with ``&Mutation<'gc>``, and the same change to Collection, the Collection parameter becomes `&Collection`.

Mutation and Collection are now `#[repr(transparent)]` newtypes of the Context, and they are produced through transmute.

The methods on Arena require a callback that accepts `&'gc MutationContext<'gc>`. This does not give any extra powers per se and is not dangerous, but it *does* enable wrapper types around `&'gc MutationContext<'gc>` to have one less lifetime in play.

As a related fix, also changes `Arena::mutate` like methods to again forbid returning internal root object references, as it can be used to place Gc pointers from `Box::leak`'ed arenas into other arenas. This is currently sound by sheer luck, but it is *incredibly* sketchy and should be disallowed.