### PR TITLE
Add `Gc::as_ref` to get a `&'gc T` from a `Gc<'gc, T>`

### DIFF
--- a/src/gc-arena/src/gc.rs
+++ b/src/gc-arena/src/gc.rs
@@ -126,10 +126,10 @@ impl<'gc, T: 'gc> Gc<'gc, T> {
 impl<'gc, T: Unlock + ?Sized + 'gc> Gc<'gc, T> {
     /// Unlock the contents of this `Gc` safely by ensuring that the write barrier is called.
     #[inline]
-    pub fn unlock(&self, mc: MutationContext<'gc, '_>) -> &T::Unlocked {
-        Gc::write_barrier(mc, *self);
+    pub fn unlock(self, mc: MutationContext<'gc, '_>) -> &'gc T::Unlocked {
+        Gc::write_barrier(mc, self);
         // SAFETY: see doc-comment.
-        unsafe { self.unlock_unchecked() }
+        unsafe { self.as_ref().unlock_unchecked() }
     }
 }
 

--- a/src/gc-arena/src/gc_weak.rs
+++ b/src/gc-arena/src/gc_weak.rs
@@ -35,7 +35,7 @@ unsafe impl<'gc, T: ?Sized + 'gc> Collect for GcWeak<'gc, T> {
 
 impl<'gc, T: ?Sized + 'gc> GcWeak<'gc, T> {
     #[inline]
-    pub fn upgrade(&self, mc: MutationContext<'gc, '_>) -> Option<Gc<'gc, T>> {
+    pub fn upgrade(self, mc: MutationContext<'gc, '_>) -> Option<Gc<'gc, T>> {
         unsafe {
             let ptr = GcBox::erase(self.inner.ptr);
             mc.upgrade(ptr).then(|| self.inner)

--- a/src/gc-arena/src/lock.rs
+++ b/src/gc-arena/src/lock.rs
@@ -157,12 +157,12 @@ impl<T: Copy + fmt::Debug> fmt::Debug for Lock<T> {
 
 impl<'gc, T: Copy + 'gc> Gc<'gc, Lock<T>> {
     #[inline]
-    pub fn get(&self) -> T {
+    pub fn get(self) -> T {
         self.cell.get()
     }
 
     #[inline]
-    pub fn set(&self, mc: MutationContext<'gc, '_>, t: T) {
+    pub fn set(self, mc: MutationContext<'gc, '_>, t: T) {
         self.unlock(mc).set(t);
     }
 }
@@ -281,26 +281,26 @@ impl<T: fmt::Debug + ?Sized> fmt::Debug for RefLock<T> {
 impl<'gc, T: ?Sized + 'gc> Gc<'gc, RefLock<T>> {
     #[track_caller]
     #[inline]
-    pub fn borrow<'a>(&'a self) -> Ref<'a, T> {
-        RefLock::borrow(self)
+    pub fn borrow(self) -> Ref<'gc, T> {
+        RefLock::borrow(self.as_ref())
     }
 
     #[inline]
-    pub fn try_borrow<'a>(&'a self) -> Result<Ref<'a, T>, BorrowError> {
-        RefLock::try_borrow(self)
+    pub fn try_borrow(self) -> Result<Ref<'gc, T>, BorrowError> {
+        RefLock::try_borrow(self.as_ref())
     }
 
     #[track_caller]
     #[inline]
-    pub fn borrow_mut<'a>(&'a self, mc: MutationContext<'gc, '_>) -> RefMut<'a, T> {
+    pub fn borrow_mut(self, mc: MutationContext<'gc, '_>) -> RefMut<'gc, T> {
         self.unlock(mc).borrow_mut()
     }
 
     #[inline]
-    pub fn try_borrow_mut<'a>(
-        &'a self,
+    pub fn try_borrow_mut(
+        self,
         mc: MutationContext<'gc, '_>,
-    ) -> Result<RefMut<'a, T>, BorrowMutError> {
+    ) -> Result<RefMut<'gc, T>, BorrowMutError> {
         self.unlock(mc).try_borrow_mut()
     }
 }


### PR DESCRIPTION
(also, add `impl AsRef` for `Gc`, and remove extra borrows from other `Gc`-taking methods)

This is sound, as `&'gc T` doesn't implement `Collect` (unless `'gc` ends up being `'static`, which will be impossible once #63 is merged) and so cannot escape the current arena callback by being stored in the GC root.