### PR TITLE
Reified `&Write<T>` barriers and `field!` projections.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/rust:1.67.0
+      - image: cimg/rust:1.69.0
     steps:
       - checkout
       - run:

--- a/src/gc-arena/src/barrier.rs
+++ b/src/gc-arena/src/barrier.rs
@@ -11,7 +11,7 @@ use crate::Gc;
 /// An (interiorly-)mutable reference inside a GC'd object graph.
 ///
 /// This type can only exist behind a reference; it is typically obtained by calling
-/// [`Gc::write_barrier`] on a [`Gc`] pointer or by using the [`field!`] projection macro
+/// [`Gc::write`] on a [`Gc`] pointer or by using the [`field!`] projection macro
 /// on a pre-existing `&Write<T>`.
 #[non_exhaustive]
 pub struct Write<T: ?Sized> {
@@ -43,7 +43,7 @@ impl<T: ?Sized> Write<T> {
     /// # Safety
     /// In order to maintain the invariants of the garbage collector, no new [`Gc`] pointers
     /// may be adopted by the referenced value as a result of the interior mutability enabled
-    /// by this wrapper, unless [`Gc::write_barrier`] is invoked manually on the parent [`Gc`]
+    /// by this wrapper, unless [`Gc::write`] is invoked manually on the parent [`Gc`]
     /// pointer during the current arena callback.
     #[inline(always)]
     pub unsafe fn assume(v: &T) -> &Self {

--- a/src/gc-arena/src/barrier.rs
+++ b/src/gc-arena/src/barrier.rs
@@ -1,0 +1,147 @@
+//! Write barrier management.
+
+use core::mem;
+use core::ops::{Deref, DerefMut};
+
+use crate::lock::Unlock;
+
+#[cfg(doc)]
+use crate::Gc;
+
+/// An (interiorly-)mutable reference inside a GC'd object graph.
+///
+/// This type can only exist behind a reference; it is typically obtained by calling
+/// [`Gc::write_barrier`] on a [`Gc`] pointer or by using the [`field!`] projection macro
+/// on a pre-existing `&Write<T>`.
+#[non_exhaustive]
+pub struct Write<T: ?Sized> {
+    // Public so that the `field!` macro can pattern-match on it; the `non_exhaustive` attribute
+    // prevents 3rd-party code from instanciating the struct directly.
+    #[doc(hidden)]
+    pub __inner: T,
+}
+
+impl<T: ?Sized> Deref for Write<T> {
+    type Target = T;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        &self.__inner
+    }
+}
+
+impl<T: ?Sized> DerefMut for Write<T> {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.__inner
+    }
+}
+
+impl<T: ?Sized> Write<T> {
+    /// Asserts that the given reference can be safely written to.
+    ///
+    /// # Safety
+    /// In order to maintain the invariants of the garbage collector, no new [`Gc`] pointers
+    /// may be adopted by the referenced value as a result of the interior mutability enabled
+    /// by this wrapper, unless [`Gc::write_barrier`] is invoked manually on the parent [`Gc`]
+    /// pointer during the current arena callback.
+    #[inline(always)]
+    pub unsafe fn assume(v: &T) -> &Self {
+        // SAFETY: `Self` is `repr(transparent)`.
+        mem::transmute(v)
+    }
+
+    /// Gets a writable reference to non-GC'd data.
+    ///
+    /// This is safe, as `'static` types can never hold [`Gc`] pointers.
+    #[inline]
+    pub fn from_static(v: &T) -> &Self
+    where
+        T: 'static,
+    {
+        // SAFETY: `Self` is `repr(transparent)`.
+        unsafe { mem::transmute(v) }
+    }
+
+    /// Gets a writable reference from a `&mut T`.
+    ///
+    /// This is safe, as exclusive access already implies writability.
+    #[inline]
+    pub fn from_mut(v: &mut T) -> &mut Self {
+        // SAFETY: `Self` is `repr(transparent)`.
+        unsafe { mem::transmute(v) }
+    }
+
+    /// Implementation detail of `write_field!`; same safety requirements as `assume`.
+    #[inline(always)]
+    #[doc(hidden)]
+    pub unsafe fn __from_ref_and_ptr(v: &T, _: *const T) -> &Self {
+        // SAFETY: `Self` is `repr(transparent)`.
+        mem::transmute(v)
+    }
+
+    /// Unlocks the referenced value, providing full interior mutability.
+    #[inline]
+    pub fn unlock(&self) -> &T::Unlocked
+    where
+        T: Unlock,
+    {
+        // SAFETY: a `&Write<T>` implies that a write barrier was triggered on the parent `Gc`.
+        unsafe { self.__inner.unlock_unchecked() }
+    }
+}
+
+/// Macro for named field projection behind [`Write`] references.
+///
+/// # Usage
+///
+/// ```
+/// # use gc_arena::barrier::{field, Write};
+/// struct Container<T> {
+///     field: T,
+/// }
+///
+/// fn project<T>(v: &Write<Container<T>>) -> &Write<T> {
+///     field!(v, Container, field)
+/// }
+/// ```
+///
+/// # Limitations
+///
+/// This macro only support structs with named fields; tuples and enums aren't supported.
+#[doc(inline)]
+pub use crate::__field as field;
+
+// Actual macro item, hidden so that it doesn't show at the crate root.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __field {
+    ($value:expr, $type:path, $field:ident) => {
+        // SAFETY:
+        // For this to be sound, we need to prevent deref coercions from happening, as they may
+        // access nested `Gc` pointers, which would violate the write barrier invariant. This is
+        // guaranteed as follows:
+        // - the destructuring pattern, unlike a simple field access, cannot call `Deref`;
+        // - similarly, the `__from_ref_and_ptr` method takes both a reference (for the lifetime)
+        //   and a pointer, causing a compilation failure if the first argument was coerced.
+        match $value {
+            $crate::barrier::Write {
+                __inner: $type { ref $field, .. },
+                ..
+            } => unsafe { $crate::barrier::Write::__from_ref_and_ptr($field, $field as *const _) },
+        }
+    };
+}
+
+/// Shorthand for [`field!`]`(...).`[`unlock()`](Write::unlock).
+#[doc(inline)]
+pub use crate::__unlock as unlock;
+
+// Actual macro item, hidden so that it doesn't show at the crate root.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __unlock {
+    ($value:expr, $type:path, $field:ident) => {
+        $crate::barrier::field!($value, $type, $field).unlock()
+    };
+}

--- a/src/gc-arena/src/gc.rs
+++ b/src/gc-arena/src/gc.rs
@@ -7,11 +7,10 @@ use core::{
 };
 
 use crate::{
-    barrier::Write,
+    barrier::{Unlock, Write},
     collect::Collect,
     context::{Collection, Mutation},
     gc_weak::GcWeak,
-    lock::Unlock,
     types::{GcBox, GcBoxInner, Invariant},
 };
 

--- a/src/gc-arena/src/gc.rs
+++ b/src/gc-arena/src/gc.rs
@@ -125,10 +125,10 @@ impl<'gc, T: 'gc> Gc<'gc, T> {
 }
 
 impl<'gc, T: Unlock + ?Sized + 'gc> Gc<'gc, T> {
-    /// Shorthand for [`Gc::write_barrier`]`(mc, self).`[`unlock()`](Write::unlock).
+    /// Shorthand for [`Gc::write`]`(mc, self).`[`unlock()`](Write::unlock).
     #[inline]
     pub fn unlock(self, mc: &Mutation<'gc>) -> &'gc T::Unlocked {
-        Gc::write_barrier(mc, self);
+        Gc::write(mc, self);
         // SAFETY: see doc-comment.
         unsafe { self.as_ref().unlock_unchecked() }
     }
@@ -154,7 +154,7 @@ impl<'gc, T: ?Sized + 'gc> Gc<'gc, T> {
 
     /// Triggers a write barrier on this `Gc`, allowing for further safe mutation.
     #[inline]
-    pub fn write_barrier(mc: &Mutation<'gc>, gc: Self) -> &'gc Write<T> {
+    pub fn write(mc: &Mutation<'gc>, gc: Self) -> &'gc Write<T> {
         unsafe {
             mc.write_barrier(GcBox::erase(gc.ptr));
             // SAFETY: the write barrier stays valid until the end of the current callback.

--- a/src/gc-arena/src/lib.rs
+++ b/src/gc-arena/src/lib.rs
@@ -7,6 +7,7 @@ extern crate std;
 extern crate alloc;
 
 mod arena;
+pub mod barrier;
 mod collect;
 mod collect_impl;
 mod context;

--- a/src/gc-arena/src/lock.rs
+++ b/src/gc-arena/src/lock.rs
@@ -6,23 +6,7 @@ use core::{
     fmt,
 };
 
-use crate::{Collect, Collection, Gc, Mutation};
-
-/// Types that support additional operations (typically, mutation) when behind a write barrier.
-pub trait Unlock {
-    /// This will typically be a cell-like type providing some sort of interior mutability.
-    type Unlocked: ?Sized;
-
-    /// Provides unsafe access to the unlocked type, *without* triggering a write barrier.
-    ///
-    /// # Safety
-    ///
-    /// In order to maintain the invariants of the garbage collector, no new `Gc` pointers
-    /// may be adopted by as a result of the interior mutability afforded by the unlocked value,
-    /// unless the write barrier for the containing `Gc` pointer is invoked manually before
-    /// collection is triggered.
-    unsafe fn unlock_unchecked(&self) -> &Self::Unlocked;
-}
+use crate::{barrier::Unlock, Collect, Collection, Gc, Mutation};
 
 // Helper macro to factor out the common parts of locks types.
 macro_rules! make_lock_wrapper {

--- a/src/gc-arena/tests/ui/bad_write_field_projections.rs
+++ b/src/gc-arena/tests/ui/bad_write_field_projections.rs
@@ -1,0 +1,24 @@
+
+
+use gc_arena::Gc;
+use gc_arena::barrier::{Write, field};
+
+struct Foo<'gc> {
+    foo: i32,
+    bar: Gc<'gc, u32>,
+    baz: f64,
+}
+
+fn projection_prederef<'a, 'gc>(v: &'a Write<Gc<'gc, Foo<'gc>>>) -> &'a Write<i32> {
+    field!(v, Foo, foo)
+}
+
+fn projection_postderef<'a, 'gc>(v: &'a Write<Foo<'gc>>) -> &'a Write<u32> {
+    field!(v, Foo, bar)
+}
+
+fn projection_wrong_type<'a, 'gc>(v: &'a Write<Foo<'gc>>) -> &'a Write<i64> {
+    field!(v, Foo, baz)
+}
+
+fn main() {}

--- a/src/gc-arena/tests/ui/bad_write_field_projections.stderr
+++ b/src/gc-arena/tests/ui/bad_write_field_projections.stderr
@@ -1,0 +1,46 @@
+error[E0308]: mismatched types
+  --> tests/ui/bad_write_field_projections.rs:13:5
+   |
+13 |     field!(v, Foo, foo)
+   |     ^^^^^^^-^^^^^^^^^^^
+   |     |      |
+   |     |      this expression has type `&'a gc_arena::barrier::Write<Gc<'gc, Foo<'gc>>>`
+   |     expected `Gc<'_, Foo<'_>>`, found `Foo<'_>`
+   |
+   = note: expected struct `Gc<'gc, Foo<'gc>, >`
+              found struct `Foo<'_>`
+   = note: this error originates in the macro `field` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0606]: casting `&Gc<'_, u32>` as `*const u32` is invalid
+  --> tests/ui/bad_write_field_projections.rs:17:5
+   |
+17 |     field!(v, Foo, bar)
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `field` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui/bad_write_field_projections.rs:21:5
+   |
+21 |     field!(v, Foo, baz)
+   |     ^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     expected `&i64`, found `&f64`
+   |     arguments to this function are incorrect
+   |
+   = note: expected reference `&i64`
+              found reference `&f64`
+note: associated function defined here
+  --> src/barrier.rs
+   |
+   |     pub unsafe fn __from_ref_and_ptr(v: &T, _: *const T) -> &Self {
+   |                   ^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `field` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0606]: casting `&f64` as `*const i64` is invalid
+  --> tests/ui/bad_write_field_projections.rs:21:5
+   |
+21 |     field!(v, Foo, baz)
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `field` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This adds new APIs for safe field-level mutation:
- Add `barrier` module, with `Write`, `field!`, `unlock!`;
- Move `Unlock` into the `barrier` module;
- Rename `Gc::write_barrier` to `Gc::write` and make it return a `&'gc Write<T>`.

See the `field_locks` test for a simple example.
