### PR TITLE
Fix `Rootable!` not compiling if not directly imported

### DIFF
--- a/src/gc-arena/src/arena.rs
+++ b/src/gc-arena/src/arena.rs
@@ -124,7 +124,7 @@ macro_rules! Rootable {
         $crate::__DynRootable::<dyn for<$gc> $crate::Rootable<$gc, Root = $root>>
     };
     ($root:ty) => {
-        Rootable!['gc => $root]
+        $crate::Rootable!['gc => $root]
     };
 }
 


### PR DESCRIPTION
The missing `$crate` prefix was preventing `gc_arena::Rootable![Foo<'gc>]` from compiling.

-------

Relatedly, and following our discussion on Discord a few weeks ago, should I change the name of the "default lifetime" of the short form to `'__`, or `'_`? (the latter would be most natural, but would require a proc-macro) This would make the short form usable in most scenarios, when a `'gc` lifetime is already in scope.