### PR TITLE
Use elided lifetimes instead of `'gc` for the short form of `Rootable!`

### DIFF
--- a/src/gc-arena-derive/Cargo.toml
+++ b/src/gc-arena-derive/Cargo.toml
@@ -14,5 +14,5 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.56"
 quote = "1.0.26"
-syn = "2.0.13"
+syn = { version = "2.0.17", features = ["default", "visit-mut"] }
 synstructure = "0.13"


### PR DESCRIPTION
This allows using the short form even when a `'gc` lifetime is already in scope.

For ease of future maintenance, the lifetime substitution is done by a procedural macro instead of a recursive tt-muncher.