### PR TITLE
Tracked external allocations

### DIFF
--- a/src/gc-arena/src/arena.rs
+++ b/src/gc-arena/src/arena.rs
@@ -1,64 +1,11 @@
 use alloc::boxed::Box;
-use core::{f64, marker::PhantomData, usize};
+use core::{f64, marker::PhantomData};
 
 use crate::{
-    context::{Allocation, Context, Mutation},
+    context::{Context, Mutation},
+    metrics::Metrics,
     Collect,
 };
-
-/// Tuning parameters for a given garbage collected [`Arena`].
-#[derive(Debug, Clone)]
-pub struct ArenaParameters {
-    pub(crate) pause_factor: f64,
-    pub(crate) timing_factor: f64,
-    pub(crate) min_sleep: usize,
-}
-
-/// Creates a default ArenaParameters with `pause_factor` set to 0.5, `timing_factor` set to 1.5,
-/// and `min_sleep` set to 4096.
-impl Default for ArenaParameters {
-    fn default() -> ArenaParameters {
-        const PAUSE_FACTOR: f64 = 0.5;
-        const TIMING_FACTOR: f64 = 1.5;
-        const MIN_SLEEP: usize = 4096;
-
-        ArenaParameters {
-            pause_factor: PAUSE_FACTOR,
-            timing_factor: TIMING_FACTOR,
-            min_sleep: MIN_SLEEP,
-        }
-    }
-}
-
-impl ArenaParameters {
-    /// The garbage collector will wait until the live size reaches `<current heap size> + <previous
-    /// retained size> * pause_multiplier` before beginning a new collection. Must be >= 0.0,
-    /// setting this to 0.0 causes the collector to never sleep longer than `min_sleep` before
-    /// beginning a new collection.
-    pub fn set_pause_factor(mut self, pause_factor: f64) -> ArenaParameters {
-        assert!(pause_factor >= 0.0);
-        self.pause_factor = pause_factor;
-        self
-    }
-
-    /// The garbage collector will try and finish a collection by the time `<current heap size> *
-    /// timing_factor` additional bytes are allocated. For example, if the collection is started
-    /// when the arena has 100KB live data, and the timing_multiplier is 1.0, the collector should
-    /// finish its final phase of this collection after another 100KB has been allocated. Must be >=
-    /// 0.0, setting this to 0.0 causes the collector to behave like a stop-the-world collector.
-    pub fn set_timing_factor(mut self, timing_factor: f64) -> ArenaParameters {
-        assert!(timing_factor >= 0.0);
-        self.timing_factor = timing_factor;
-        self
-    }
-
-    /// The minimum allocation amount during sleep before the arena starts collecting again. This is
-    /// mostly useful when the heap is very small to prevent rapidly restarting collections.
-    pub fn set_min_sleep(mut self, min_sleep: usize) -> ArenaParameters {
-        self.min_sleep = min_sleep;
-        self
-    }
-}
 
 /// A trait that produces a [`Collect`]-able type for the given lifetime. This is used to produce
 /// the root [`Collect`] instance in an [`Arena`].
@@ -161,12 +108,12 @@ pub struct Arena<R: for<'a> Rootable<'a>> {
 impl<R: for<'a> Rootable<'a>> Arena<R> {
     /// Create a new arena with the given garbage collector tuning parameters. You must provide a
     /// closure that accepts a `&Mutation<'gc>` and returns the appropriate root.
-    pub fn new<F>(arena_parameters: ArenaParameters, f: F) -> Arena<R>
+    pub fn new<F>(f: F) -> Arena<R>
     where
         F: for<'gc> FnOnce(&'gc Mutation<'gc>) -> Root<'gc, R>,
     {
         unsafe {
-            let context = Box::new(Context::new(arena_parameters));
+            let context = Box::new(Context::new());
             // Note - we cast the `&Mutation` to a `'static` lifetime here,
             // instead of transmuting the root type returned by `f`. Transmuting the root
             // type is allowed in nightly versions of rust
@@ -181,12 +128,12 @@ impl<R: for<'a> Rootable<'a>> Arena<R> {
     }
 
     /// Similar to `new`, but allows for constructor that can fail.
-    pub fn try_new<F, E>(arena_parameters: ArenaParameters, f: F) -> Result<Arena<R>, E>
+    pub fn try_new<F, E>(f: F) -> Result<Arena<R>, E>
     where
         F: for<'gc> FnOnce(&'gc Mutation<'gc>) -> Result<Root<'gc, R>, E>,
     {
         unsafe {
-            let context = Box::new(Context::new(arena_parameters));
+            let context = Box::new(Context::new());
             let mc: &'static Mutation<'_> = &*(context.mutation_context() as *const _);
             let root: Root<'static, R> = f(mc)?;
             Ok(Arena { context, root })
@@ -257,8 +204,8 @@ impl<R: for<'a> Rootable<'a>> Arena<R> {
     }
 
     #[inline]
-    pub fn allocation(&self) -> &Allocation {
-        self.context.allocation()
+    pub fn metrics(&self) -> &Metrics {
+        self.context.metrics()
     }
 
     /// Run the incremental garbage collector until the allocation debt is <= 0.0. There is no
@@ -267,7 +214,7 @@ impl<R: for<'a> Rootable<'a>> Arena<R> {
     #[inline]
     pub fn collect_debt(&mut self) {
         unsafe {
-            let debt = self.context.allocation().allocation_debt();
+            let debt = self.context.metrics().allocation_debt();
             if debt > 0.0 {
                 self.context.do_collection(&self.root, debt);
             }
@@ -292,7 +239,7 @@ where
     F: for<'gc> FnOnce(&'gc Mutation<'gc>) -> R,
 {
     unsafe {
-        let context = Context::new(ArenaParameters::default());
+        let context = Context::new();
         f(context.mutation_context())
     }
 }

--- a/src/gc-arena/src/context.rs
+++ b/src/gc-arena/src/context.rs
@@ -290,7 +290,7 @@ impl Context {
                         self.sweep_prev.set(None);
                         self.phase.set(Phase::Propagate);
                         self.root_needs_trace.set(true);
-                        self.metrics.start_propagation();
+                        self.metrics.start_cycle();
                         break;
                     }
                 }

--- a/src/gc-arena/src/lib.rs
+++ b/src/gc-arena/src/lib.rs
@@ -15,6 +15,7 @@ mod dynamic_roots;
 mod gc;
 mod gc_weak;
 pub mod lock;
+pub mod metrics;
 mod no_drop;
 mod static_collect;
 mod types;
@@ -27,7 +28,7 @@ pub use gc_arena_derive::*;
 pub use self::{arena::__DynRootable, no_drop::__MustNotImplDrop, unsize::__CoercePtrInternal};
 
 pub use self::{
-    arena::{rootless_arena, Arena, ArenaParameters, Root, Rootable},
+    arena::{rootless_arena, Arena, Root, Rootable},
     collect::Collect,
     context::{Collection, Mutation},
     dynamic_roots::{DynamicRoot, DynamicRootSet, MismatchedRootSet},

--- a/src/gc-arena/src/metrics.rs
+++ b/src/gc-arena/src/metrics.rs
@@ -1,0 +1,178 @@
+use alloc::rc::Rc;
+use core::cell::Cell;
+
+/// Tuning parameters for a given garbage collected [`Arena`].
+#[derive(Debug, Copy, Clone)]
+pub struct Pacing {
+    pub(crate) pause_factor: f64,
+    pub(crate) timing_factor: f64,
+    pub(crate) min_sleep: usize,
+}
+
+/// Creates a default `Pacing` with `pause_factor` set to 0.5, `timing_factor` set to 1.5,
+/// and `min_sleep` set to 4096.
+impl Default for Pacing {
+    fn default() -> Pacing {
+        const PAUSE_FACTOR: f64 = 0.5;
+        const TIMING_FACTOR: f64 = 1.5;
+        const MIN_SLEEP: usize = 4096;
+
+        Pacing {
+            pause_factor: PAUSE_FACTOR,
+            timing_factor: TIMING_FACTOR,
+            min_sleep: MIN_SLEEP,
+        }
+    }
+}
+
+impl Pacing {
+    /// The garbage collector will wait until the live size reaches `<current heap size> + <previous
+    /// retained size> * pause_multiplier` before beginning a new collection. Must be >= 0.0,
+    /// setting this to 0.0 causes the collector to never sleep longer than `min_sleep` before
+    /// beginning a new collection.
+    pub fn set_pause_factor(mut self, pause_factor: f64) -> Pacing {
+        assert!(pause_factor >= 0.0);
+        self.pause_factor = pause_factor;
+        self
+    }
+
+    /// The garbage collector will try and finish a collection by the time `<current heap size> *
+    /// timing_factor` additional bytes are allocated. For example, if the collection is started
+    /// when the arena has 100KB live data, and the timing_multiplier is 1.0, the collector should
+    /// finish its final phase of this collection after another 100KB has been allocated. Must be >=
+    /// 0.0, setting this to 0.0 causes the collector to behave like a stop-the-world collector.
+    pub fn set_timing_factor(mut self, timing_factor: f64) -> Pacing {
+        assert!(timing_factor >= 0.0);
+        self.timing_factor = timing_factor;
+        self
+    }
+
+    /// The minimum allocation amount during sleep before the arena starts collecting again. This is
+    /// mostly useful when the heap is very small to prevent rapidly restarting collections.
+    pub fn set_min_sleep(mut self, min_sleep: usize) -> Pacing {
+        self.min_sleep = min_sleep;
+        self
+    }
+}
+
+#[derive(Debug, Default)]
+struct MetricsInner {
+    pacing: Cell<Pacing>,
+
+    total_gc_bytes: Cell<usize>,
+    total_gcs: Cell<usize>,
+    traced_gcs: Cell<usize>,
+
+    remembered_gcs: Cell<usize>,
+    remembered_gc_bytes: Cell<usize>,
+
+    total_external_bytes: Cell<usize>,
+
+    gc_debt: Cell<f64>,
+    external_debt: Cell<f64>,
+    wakeup_debt: Cell<f64>,
+}
+
+#[derive(Clone)]
+pub struct Metrics(Rc<MetricsInner>);
+
+impl Metrics {
+    pub(crate) fn new() -> Self {
+        let this = Self(Default::default());
+        this.start_propagation();
+        this
+    }
+
+    pub fn set_pacing(&self, pacing: Pacing) {
+        self.0.pacing.set(pacing);
+    }
+
+    pub fn total_gc_allocation(&self) -> usize {
+        self.0.total_gc_bytes.get()
+    }
+
+    pub fn total_external_allocation(&self) -> usize {
+        self.0.total_external_bytes.get()
+    }
+
+    pub fn total_allocation(&self) -> usize {
+        self.0
+            .total_gc_bytes
+            .get()
+            .saturating_add(self.0.total_external_bytes.get())
+    }
+
+    /// All arena allocation causes the arena to accumulate "allocation debt". This debt is then
+    /// used to time incremental garbage collection based on the tuning parameters set in `Pacing`.
+    /// The allocation debt is measured in bytes, but will generally increase at a rate faster than
+    /// that of allocation so that collection will always complete.
+    pub fn allocation_debt(&self) -> f64 {
+        let traced_external_estimate = self.0.traced_gcs.get() as f64
+            / self.0.total_gcs.get() as f64
+            * self.0.total_external_bytes.get() as f64;
+        let debt_estimate =
+            self.0.gc_debt.get() + self.0.external_debt.get() - traced_external_estimate;
+        (debt_estimate - self.0.wakeup_debt.get()).max(0.0)
+    }
+
+    pub fn mark_external_allocation(&self, bytes: usize) {
+        cell_update(&self.0.total_external_bytes, |b| b.saturating_add(bytes));
+        cell_update(&self.0.external_debt, |d| {
+            d + bytes as f64 + bytes as f64 / self.0.pacing.get().timing_factor
+        });
+    }
+
+    pub fn mark_external_deallocation(&self, bytes: usize) {
+        cell_update(&self.0.total_external_bytes, |b| b.saturating_sub(bytes));
+        cell_update(&self.0.external_debt, |d| d - bytes as f64);
+    }
+
+    pub(crate) fn start_propagation(&self) {
+        let remembered_size_estimate = self.0.remembered_gc_bytes.get() as f64
+            + self.0.remembered_gcs.get() as f64 / self.0.total_gcs.get() as f64
+                * self.0.total_external_bytes.get() as f64;
+
+        let pacing = self.0.pacing.get();
+        let wakeup_amount =
+            (remembered_size_estimate * pacing.pause_factor).max(pacing.min_sleep as f64);
+        let wakeup_debt = wakeup_amount + wakeup_amount / pacing.timing_factor;
+
+        self.0.traced_gcs.set(0);
+        self.0.remembered_gcs.set(0);
+        self.0.remembered_gc_bytes.set(0);
+        self.0.gc_debt.set(0.0);
+        self.0.external_debt.set(0.0);
+        self.0.wakeup_debt.set(wakeup_debt);
+    }
+
+    pub(crate) fn mark_gc_allocated(&self, bytes: usize) {
+        cell_update(&self.0.total_gc_bytes, |b| b + bytes);
+        cell_update(&self.0.total_gcs, |c| c + 1);
+        cell_update(&self.0.gc_debt, |d| {
+            d + bytes as f64 + bytes as f64 / self.0.pacing.get().timing_factor
+        });
+    }
+
+    pub(crate) fn mark_gc_traced(&self, bytes: usize) {
+        cell_update(&self.0.traced_gcs, |c| c + 1);
+        cell_update(&self.0.gc_debt, |d| d - bytes as f64);
+    }
+
+    pub(crate) fn mark_gc_deallocated(&self, bytes: usize) {
+        cell_update(&self.0.total_gc_bytes, |b| b - bytes);
+        cell_update(&self.0.total_gcs, |c| c - 1);
+        cell_update(&self.0.gc_debt, |d| d - bytes as f64);
+    }
+
+    pub(crate) fn mark_gc_remembered(&self, bytes: usize) {
+        cell_update(&self.0.remembered_gcs, |c| c + 1);
+        cell_update(&self.0.remembered_gc_bytes, |b| b + bytes);
+    }
+}
+
+// TODO: Use `Cell::update` when it is available, see:
+// https://github.com/rust-lang/rust/issues/50186
+#[inline]
+fn cell_update<T: Copy>(c: &Cell<T>, f: impl FnOnce(T) -> T) {
+    c.set(f(c.get()))
+}

--- a/src/gc-arena/src/metrics.rs
+++ b/src/gc-arena/src/metrics.rs
@@ -12,6 +12,7 @@ pub struct Pacing {
 /// Creates a default `Pacing` with `pause_factor` set to 0.5, `timing_factor` set to 1.5,
 /// and `min_sleep` set to 4096.
 impl Default for Pacing {
+    #[inline]
     fn default() -> Pacing {
         const PAUSE_FACTOR: f64 = 0.5;
         const TIMING_FACTOR: f64 = 1.5;
@@ -30,6 +31,7 @@ impl Pacing {
     /// retained size> * pause_multiplier` before beginning a new collection. Must be >= 0.0,
     /// setting this to 0.0 causes the collector to never sleep longer than `min_sleep` before
     /// beginning a new collection.
+    #[inline]
     pub fn set_pause_factor(mut self, pause_factor: f64) -> Pacing {
         assert!(pause_factor >= 0.0);
         self.pause_factor = pause_factor;
@@ -41,6 +43,7 @@ impl Pacing {
     /// when the arena has 100KB live data, and the timing_multiplier is 1.0, the collector should
     /// finish its final phase of this collection after another 100KB has been allocated. Must be >=
     /// 0.0, setting this to 0.0 causes the collector to behave like a stop-the-world collector.
+    #[inline]
     pub fn set_timing_factor(mut self, timing_factor: f64) -> Pacing {
         assert!(timing_factor >= 0.0);
         self.timing_factor = timing_factor;
@@ -49,6 +52,7 @@ impl Pacing {
 
     /// The minimum allocation amount during sleep before the arena starts collecting again. This is
     /// mostly useful when the heap is very small to prevent rapidly restarting collections.
+    #[inline]
     pub fn set_min_sleep(mut self, min_sleep: usize) -> Pacing {
         self.min_sleep = min_sleep;
         self
@@ -87,12 +91,14 @@ impl Metrics {
     ///
     /// The factors that affect the gc pause time will not take effect until the start of the next
     /// collection.
+    #[inline]
     pub fn set_pacing(&self, pacing: Pacing) {
         self.0.pacing.set(pacing);
     }
 
     /// Returns the total bytes allocated by the arena itself, used as the backing storage for `Gc`
     /// pointers.
+    #[inline]
     pub fn total_gc_allocation(&self) -> usize {
         self.0.total_gc_bytes.get()
     }
@@ -101,12 +107,14 @@ impl Metrics {
     ///
     /// A call to `Metrics::mark_external_allocation` will increase this count, and a call to
     /// `Metrics::mark_external_deallocation` will decrease it.
+    #[inline]
     pub fn total_external_allocation(&self) -> usize {
         self.0.total_external_bytes.get()
     }
 
     /// Returns the sum of `Metrics::total_gc_allocation()` and
     /// `Metrics::total_external_allocation()`.
+    #[inline]
     pub fn total_allocation(&self) -> usize {
         self.0
             .total_gc_bytes
@@ -118,6 +126,7 @@ impl Metrics {
     /// used to time incremental garbage collection based on the tuning parameters in the current
     /// `Pacing`. The allocation debt is measured in bytes, but will generally increase at a rate
     /// faster than that of allocation so that collection will always complete.
+    #[inline]
     pub fn allocation_debt(&self) -> f64 {
         // Estimate the amount of external memory that has been traced assuming that each Gc owns an
         // even share of the external memory.
@@ -137,6 +146,7 @@ impl Metrics {
     ///
     /// This affects the GC pacing, marking external bytes as allocated will trigger allocation
     /// debt.
+    #[inline]
     pub fn mark_external_allocation(&self, bytes: usize) {
         cell_update(&self.0.total_external_bytes, |b| b.saturating_add(bytes));
         cell_update(&self.0.external_debt, |d| {
@@ -153,6 +163,7 @@ impl Metrics {
     /// It is safe, but may result in unspecified behavior (such as very weird or non-existent gc
     /// pacing), if the amount of bytes marked for deallocation is greater than the number of bytes
     /// marked for allocation.
+    #[inline]
     pub fn mark_external_deallocation(&self, bytes: usize) {
         cell_update(&self.0.total_external_bytes, |b| b.saturating_sub(bytes));
         cell_update(&self.0.external_debt, |d| d - bytes as f64);
@@ -179,6 +190,7 @@ impl Metrics {
         self.0.wakeup_amount.set(wakeup_amount);
     }
 
+    #[inline]
     pub(crate) fn mark_gc_allocated(&self, bytes: usize) {
         cell_update(&self.0.total_gc_bytes, |b| b + bytes);
         cell_update(&self.0.total_gcs, |c| c + 1);
@@ -187,17 +199,20 @@ impl Metrics {
         });
     }
 
+    #[inline]
     pub(crate) fn mark_gc_traced(&self, bytes: usize) {
         cell_update(&self.0.traced_gcs, |c| c + 1);
         cell_update(&self.0.gc_debt, |d| d - bytes as f64);
     }
 
+    #[inline]
     pub(crate) fn mark_gc_deallocated(&self, bytes: usize) {
         cell_update(&self.0.total_gc_bytes, |b| b - bytes);
         cell_update(&self.0.total_gcs, |c| c - 1);
         cell_update(&self.0.gc_debt, |d| d - bytes as f64);
     }
 
+    #[inline]
     pub(crate) fn mark_gc_remembered(&self, bytes: usize) {
         cell_update(&self.0.remembered_gcs, |c| c + 1);
         cell_update(&self.0.remembered_gc_bytes, |b| b + bytes);

--- a/src/gc-arena/src/metrics.rs
+++ b/src/gc-arena/src/metrics.rs
@@ -32,7 +32,7 @@ impl Pacing {
     /// setting this to 0.0 causes the collector to never sleep longer than `min_sleep` before
     /// beginning a new collection.
     #[inline]
-    pub fn set_pause_factor(mut self, pause_factor: f64) -> Pacing {
+    pub fn with_pause_factor(mut self, pause_factor: f64) -> Pacing {
         assert!(pause_factor >= 0.0);
         self.pause_factor = pause_factor;
         self
@@ -44,7 +44,7 @@ impl Pacing {
     /// finish its final phase of this collection after another 100KB has been allocated. Must be >=
     /// 0.0, setting this to 0.0 causes the collector to behave like a stop-the-world collector.
     #[inline]
-    pub fn set_timing_factor(mut self, timing_factor: f64) -> Pacing {
+    pub fn with_timing_factor(mut self, timing_factor: f64) -> Pacing {
         assert!(timing_factor >= 0.0);
         self.timing_factor = timing_factor;
         self
@@ -53,7 +53,7 @@ impl Pacing {
     /// The minimum allocation amount during sleep before the arena starts collecting again. This is
     /// mostly useful when the heap is very small to prevent rapidly restarting collections.
     #[inline]
-    pub fn set_min_sleep(mut self, min_sleep: usize) -> Pacing {
+    pub fn with_min_sleep(mut self, min_sleep: usize) -> Pacing {
         self.min_sleep = min_sleep;
         self
     }

--- a/src/gc-arena/tests/tests.rs
+++ b/src/gc-arena/tests/tests.rs
@@ -485,9 +485,9 @@ fn test_collection_bounded() {
 
     arena.metrics().set_pacing(
         Pacing::default()
-            .set_pause_factor(1.0)
-            .set_timing_factor(1.0)
-            .set_min_sleep(256),
+            .with_pause_factor(1.0)
+            .with_timing_factor(1.0)
+            .with_min_sleep(256),
     );
     // Finish the current collection cycle so that the new min_sleep is used.
     arena.collect_all();
@@ -679,9 +679,9 @@ fn gc_pause_actually_pauses() {
 
     arena.metrics().set_pacing(
         Pacing::default()
-            .set_pause_factor(1.0)
-            .set_timing_factor(1.0)
-            .set_min_sleep(1024),
+            .with_pause_factor(1.0)
+            .with_timing_factor(1.0)
+            .with_min_sleep(1024),
     );
     // Finish the current collection cycle so that the new min_sleep is used. We should be asleep
     // for exactly min_sleep, since the pause factor is 1.0 and 2x 256 bytes is 512 which is less
@@ -725,9 +725,9 @@ fn gc_external_allocation_affects_timing() {
 
     arena.metrics().set_pacing(
         Pacing::default()
-            .set_pause_factor(1.0)
-            .set_timing_factor(1.0)
-            .set_min_sleep(1024),
+            .with_pause_factor(1.0)
+            .with_timing_factor(1.0)
+            .with_min_sleep(1024),
     );
     // Finish the current collection cycle so that the new min_sleep is used. We should be asleep
     // for exactly min_sleep, since the pause factor is 1.0 and 2x 256 bytes is 512 which is less


### PR DESCRIPTION
Extremely simplistic design, tracks external allocations as a bytecount, increasing the total external allocations speeds up collection, decreasing it slows down collection, both occur the same as if memory was allocated in the "normal" fashion.

External memory owned per gcbox is not tracked, instead, for the purposes of pacing calls to `trace`, each gcbox is assumed to own an equal fraction of the total external bytecount.