### PR TITLE
Collect for allocator-api2 and hashbrown, also Metrics allocator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
               cargo fmt --all -- --check --color=auto
       - run:
           name: Build all targets
-          command: cargo build --workspace --all-targets
+          command: cargo build --all --all-targets
       - run:
           name: Build no_std targets
           command: |
@@ -42,19 +42,25 @@ jobs:
           name: Check with combinations of optional features
           command: |
               cargo check --all --features tracing
+              cargo check --all --features allocator-api2
+              cargo check --all --features hashbrown
+              cargo check --all --features tracing,allocator-api2
+              cargo check --all --features tracing,hashbrown
+              cargo check --all --features allocator-api2,hashbrown
+              cargo check --all --features tracing,allocator-api2,hashbrown
       - run:
           name: Run all tests
-          command: cargo test --workspace
+          command: cargo test --all
       - run:
           name: Run all tests under miri
           command: |
-            cargo +nightly miri test --workspace --tests --all-features -- --skip ui
+            cargo +nightly miri test --all --tests --all-features -- --skip ui
       - run:
           name: Run all tests under sanitizers
           command: |
-            RUSTFLAGS="-Z sanitizer=address" cargo +nightly test --workspace --tests -Z build-std --target x86_64-unknown-linux-gnu --all-features -- --skip ui
-            RUSTFLAGS="-Z sanitizer=leak" cargo +nightly test --workspace --tests -Z build-std --target x86_64-unknown-linux-gnu --all-features -- --skip ui
-            RUSTFLAGS="-Z sanitizer=memory" cargo +nightly test --workspace --tests -Z build-std --target x86_64-unknown-linux-gnu --all-features -- --skip ui
+            RUSTFLAGS="-Z sanitizer=address" cargo +nightly test --all --tests -Z build-std --target x86_64-unknown-linux-gnu --all-features -- --skip ui
+            RUSTFLAGS="-Z sanitizer=leak" cargo +nightly test --all --tests -Z build-std --target x86_64-unknown-linux-gnu --all-features -- --skip ui
+            RUSTFLAGS="-Z sanitizer=memory" cargo +nightly test --all --tests -Z build-std --target x86_64-unknown-linux-gnu --all-features -- --skip ui
       - save_cache:
           paths:
             - /usr/local/cargo/registry

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,6 @@ jobs:
               cargo check --all --features tracing
               cargo check --all --features allocator-api2
               cargo check --all --features hashbrown
-              cargo check --all --features tracing,allocator-api2
-              cargo check --all --features tracing,hashbrown
-              cargo check --all --features allocator-api2,hashbrown
               cargo check --all --features tracing,allocator-api2,hashbrown
       - run:
           name: Run all tests

--- a/src/gc-arena/Cargo.toml
+++ b/src/gc-arena/Cargo.toml
@@ -12,9 +12,12 @@ repository.workspace = true
 default = ["std"]
 std = []
 tracing = ["dep:tracing"]
+allocator-api2 = ["dep:allocator-api2", "hashbrown?/allocator-api2"]
 
 [dependencies]
+allocator-api2 = { version = "0.2", optional = true, default-features = false, features = ["alloc"] }
 gc-arena-derive = { path = "../gc-arena-derive", version = "0.3.3"}
+hashbrown = { version = "0.14", optional = true, default-features = false }
 sptr = "0.3.2"
 tracing = { version = "0.1.37", optional = true, default-features = false }
 

--- a/src/gc-arena/src/allocator_api.rs
+++ b/src/gc-arena/src/allocator_api.rs
@@ -104,12 +104,7 @@ unsafe impl Collect for Global {
     }
 }
 
-unsafe impl<T: Collect, A: Collect + Allocator> Collect for boxed::Box<T, A> {
-    #[inline]
-    fn needs_trace() -> bool {
-        T::needs_trace() || A::needs_trace()
-    }
-
+unsafe impl<T: Collect + ?Sized, A: Collect + Allocator> Collect for boxed::Box<T, A> {
     #[inline]
     fn trace(&self, cc: &Collection) {
         boxed::Box::allocator(self).trace(cc);

--- a/src/gc-arena/src/allocator_api.rs
+++ b/src/gc-arena/src/allocator_api.rs
@@ -20,12 +20,14 @@ pub struct MetricsAlloc<'gc, A = Global> {
 }
 
 impl<'gc> MetricsAlloc<'gc> {
+    #[inline]
     pub fn new(mc: &Mutation<'gc>) -> Self {
         Self::new_in(mc, Global)
     }
 }
 
 impl<'gc, A> MetricsAlloc<'gc, A> {
+    #[inline]
     pub fn new_in(mc: &Mutation<'gc>, allocator: A) -> Self {
         Self {
             metrics: mc.metrics().clone(),
@@ -36,23 +38,27 @@ impl<'gc, A> MetricsAlloc<'gc, A> {
 }
 
 unsafe impl<'gc, A: Allocator> Allocator for MetricsAlloc<'gc, A> {
+    #[inline]
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
         let ptr = self.allocator.allocate(layout)?;
         self.metrics.mark_external_allocation(layout.size());
         Ok(ptr)
     }
 
+    #[inline]
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
         self.metrics.mark_external_deallocation(layout.size());
         self.allocator.deallocate(ptr, layout);
     }
 
+    #[inline]
     fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
         let ptr = self.allocator.allocate_zeroed(layout)?;
         self.metrics.mark_external_allocation(layout.size());
         Ok(ptr)
     }
 
+    #[inline]
     unsafe fn grow(
         &self,
         ptr: NonNull<u8>,
@@ -65,6 +71,7 @@ unsafe impl<'gc, A: Allocator> Allocator for MetricsAlloc<'gc, A> {
         Ok(ptr)
     }
 
+    #[inline]
     unsafe fn grow_zeroed(
         &self,
         ptr: NonNull<u8>,
@@ -77,6 +84,7 @@ unsafe impl<'gc, A: Allocator> Allocator for MetricsAlloc<'gc, A> {
         Ok(ptr)
     }
 
+    #[inline]
     unsafe fn shrink(
         &self,
         ptr: NonNull<u8>,

--- a/src/gc-arena/src/allocator_api.rs
+++ b/src/gc-arena/src/allocator_api.rs
@@ -1,0 +1,133 @@
+use std::{alloc::Layout, marker::PhantomData, ptr::NonNull};
+
+use allocator_api2::{
+    alloc::{AllocError, Allocator, Global},
+    boxed, vec,
+};
+
+use crate::{
+    collect::Collect,
+    context::{Collection, Mutation},
+    metrics::Metrics,
+    types::Invariant,
+};
+
+#[derive(Clone)]
+pub struct MetricsAlloc<'gc, A = Global> {
+    metrics: Metrics,
+    allocator: A,
+    _marker: Invariant<'gc>,
+}
+
+impl<'gc> MetricsAlloc<'gc> {
+    pub fn new(mc: &Mutation<'gc>) -> Self {
+        Self::new_in(mc, Global)
+    }
+}
+
+impl<'gc, A> MetricsAlloc<'gc, A> {
+    pub fn new_in(mc: &Mutation<'gc>, allocator: A) -> Self {
+        Self {
+            metrics: mc.metrics().clone(),
+            allocator,
+            _marker: PhantomData,
+        }
+    }
+}
+
+unsafe impl<'gc, A: Allocator> Allocator for MetricsAlloc<'gc, A> {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        let ptr = self.allocator.allocate(layout)?;
+        self.metrics.mark_external_allocation(layout.size());
+        Ok(ptr)
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        self.metrics.mark_external_deallocation(layout.size());
+        self.allocator.deallocate(ptr, layout);
+    }
+
+    fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        let ptr = self.allocator.allocate_zeroed(layout)?;
+        self.metrics.mark_external_allocation(layout.size());
+        Ok(ptr)
+    }
+
+    unsafe fn grow(
+        &self,
+        ptr: NonNull<u8>,
+        old_layout: Layout,
+        new_layout: Layout,
+    ) -> Result<NonNull<[u8]>, AllocError> {
+        let ptr = self.allocator.grow(ptr, old_layout, new_layout)?;
+        self.metrics
+            .mark_external_allocation(new_layout.size() - old_layout.size());
+        Ok(ptr)
+    }
+
+    unsafe fn grow_zeroed(
+        &self,
+        ptr: NonNull<u8>,
+        old_layout: Layout,
+        new_layout: Layout,
+    ) -> Result<NonNull<[u8]>, AllocError> {
+        let ptr = self.allocator.grow_zeroed(ptr, old_layout, new_layout)?;
+        self.metrics
+            .mark_external_allocation(new_layout.size() - old_layout.size());
+        Ok(ptr)
+    }
+
+    unsafe fn shrink(
+        &self,
+        ptr: NonNull<u8>,
+        old_layout: Layout,
+        new_layout: Layout,
+    ) -> Result<NonNull<[u8]>, AllocError> {
+        let ptr = self.allocator.shrink(ptr, old_layout, new_layout)?;
+        self.metrics
+            .mark_external_deallocation(old_layout.size() - new_layout.size());
+        Ok(ptr)
+    }
+}
+
+unsafe impl<'gc, A: 'static> Collect for MetricsAlloc<'gc, A> {
+    #[inline]
+    fn needs_trace() -> bool {
+        false
+    }
+}
+
+unsafe impl Collect for Global {
+    #[inline]
+    fn needs_trace() -> bool {
+        false
+    }
+}
+
+unsafe impl<T: Collect, A: Collect + Allocator> Collect for boxed::Box<T, A> {
+    #[inline]
+    fn needs_trace() -> bool {
+        T::needs_trace() || A::needs_trace()
+    }
+
+    #[inline]
+    fn trace(&self, cc: &Collection) {
+        boxed::Box::allocator(self).trace(cc);
+        (**self).trace(cc)
+    }
+}
+
+unsafe impl<T: Collect, A: Collect + Allocator> Collect for vec::Vec<T, A> {
+    #[inline]
+    fn needs_trace() -> bool {
+        T::needs_trace() || A::needs_trace()
+    }
+
+    #[inline]
+    fn trace(&self, cc: &Collection) {
+        self.allocator().trace(cc);
+        for v in self {
+            v.trace(cc);
+        }
+    }
+}

--- a/src/gc-arena/src/hashbrown.rs
+++ b/src/gc-arena/src/hashbrown.rs
@@ -1,0 +1,91 @@
+#[cfg(feature = "allocator-api2")]
+mod inner {
+    use allocator_api2::alloc::Allocator;
+
+    use crate::{collect::Collect, context::Collection};
+
+    unsafe impl<K, V, S, A> Collect for hashbrown::HashMap<K, V, S, A>
+    where
+        K: Collect,
+        V: Collect,
+        S: 'static,
+        A: Allocator + Clone + Collect,
+    {
+        #[inline]
+        fn needs_trace() -> bool {
+            K::needs_trace() || V::needs_trace() || A::needs_trace()
+        }
+
+        #[inline]
+        fn trace(&self, cc: &Collection) {
+            self.allocator().trace(cc);
+            for (k, v) in self {
+                k.trace(cc);
+                v.trace(cc);
+            }
+        }
+    }
+
+    unsafe impl<T, S, A> Collect for hashbrown::HashSet<T, S, A>
+    where
+        T: Collect,
+        S: 'static,
+        A: Allocator + Clone + Collect,
+    {
+        #[inline]
+        fn needs_trace() -> bool {
+            T::needs_trace() || A::needs_trace()
+        }
+
+        #[inline]
+        fn trace(&self, cc: &Collection) {
+            self.allocator().trace(cc);
+            for v in self {
+                v.trace(cc);
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "allocator-api2"))]
+mod inner {
+    use crate::{collect::Collect, context::Collection};
+
+    unsafe impl<K, V, S> Collect for hashbrown::HashMap<K, V, S>
+    where
+        K: Collect,
+        V: Collect,
+        S: 'static,
+    {
+        #[inline]
+        fn needs_trace() -> bool {
+            K::needs_trace() || V::needs_trace()
+        }
+
+        #[inline]
+        fn trace(&self, cc: &Collection) {
+            for (k, v) in self {
+                k.trace(cc);
+                v.trace(cc);
+            }
+        }
+    }
+
+    unsafe impl<T, S> Collect for hashbrown::HashSet<T, S>
+    where
+        T: Collect,
+        S: 'static,
+    {
+        #[inline]
+        fn needs_trace() -> bool {
+            T::needs_trace()
+        }
+
+        #[inline]
+        fn trace(&self, cc: &Collection) {
+            for v in self {
+                v.trace(cc);
+            }
+        }
+    }
+}

--- a/src/gc-arena/src/lib.rs
+++ b/src/gc-arena/src/lib.rs
@@ -21,6 +21,12 @@ mod static_collect;
 mod types;
 mod unsize;
 
+#[cfg(feature = "allocator-api2")]
+pub mod allocator_api;
+
+#[cfg(feature = "hashbrown")]
+mod hashbrown;
+
 #[doc(hidden)]
 pub use gc_arena_derive::*;
 


### PR DESCRIPTION
Implements `Collect` for HashMap and HashSet from hashbrown, also Vec and Box from allocator-api2. Also implements a custom `Allocator` trait wrapper that records allocations and deallocations from gc-arena's `Metrics` handle, and is branded with the branding lifetime so it cannot be mixed up with other arena types.

The implementation for hashbrown is slightly subtle because it is different depending on whether or not the "allocator-api2" feature is also enabled. Circle-CI now also checks all combinations of the features "allocator-api2" and "hashbrown" to make sure they all compile.

This also subsumes #73 as it it's hard to disentangle them 