### PR TITLE
Count all allocations used by `DynamicRootSet` as external bytes.

### DIFF
--- a/src/gc-arena/src/metrics.rs
+++ b/src/gc-arena/src/metrics.rs
@@ -87,6 +87,12 @@ impl Metrics {
         this
     }
 
+    pub(crate) fn ptr_eq(a: &Metrics, b: &Metrics) -> bool {
+        let a = Rc::as_ptr(&a.0);
+        let b = Rc::as_ptr(&b.0);
+        a == b
+    }
+
     /// Sets the pacing parameters used by the collection algorithm.
     ///
     /// The factors that affect the gc pause time will not take effect until the start of the next

--- a/src/gc-arena/src/metrics.rs
+++ b/src/gc-arena/src/metrics.rs
@@ -87,12 +87,6 @@ impl Metrics {
         this
     }
 
-    pub(crate) fn ptr_eq(a: &Metrics, b: &Metrics) -> bool {
-        let a = Rc::as_ptr(&a.0);
-        let b = Rc::as_ptr(&b.0);
-        a == b
-    }
-
     /// Sets the pacing parameters used by the collection algorithm.
     ///
     /// The factors that affect the gc pause time will not take effect until the start of the next


### PR DESCRIPTION
This includes bytes allocated by individual root handles.

When the API becomes "rootless" (which imo should happen before the next release), this will make gc-arena theoretically count the *total* memory used by the arena including all roots.