### PR TITLE
Fix building on platforms without Arc

### DIFF
--- a/src/gc-arena/src/collect_impl.rs
+++ b/src/gc-arena/src/collect_impl.rs
@@ -3,7 +3,6 @@ use alloc::collections::VecDeque;
 use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::rc::Rc;
 use alloc::string::String;
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::cell::{Cell, RefCell};
 use core::marker::PhantomData;
@@ -270,7 +269,8 @@ where
     }
 }
 
-unsafe impl<T> Collect for Arc<T>
+#[cfg(target_has_atomic = "ptr")]
+unsafe impl<T> Collect for alloc::sync::Arc<T>
 where
     T: ?Sized + Collect,
 {


### PR DESCRIPTION
`alloc::sync::Arc` only exists on platforms with atomic pointer-size operations. Our inclusion of `Collect` for `Arc<T>` was unconditional, so this was causing compile errors on platforms that don't have such atomic operations. I just added a cfg so we can keep it on all platforms that allow it.