### PR TITLE
Change bounds on `Arc` and `Rc` to require 'static instead of `Collect`

### DIFF
--- a/src/gc-arena/src/collect_impl.rs
+++ b/src/gc-arena/src/collect_impl.rs
@@ -261,22 +261,22 @@ where
 
 unsafe impl<T> Collect for Rc<T>
 where
-    T: ?Sized + Collect,
+    T: ?Sized + 'static,
 {
     #[inline]
-    fn trace(&self, cc: &Collection) {
-        (**self).trace(cc);
+    fn needs_trace() -> bool {
+        false
     }
 }
 
 #[cfg(target_has_atomic = "ptr")]
 unsafe impl<T> Collect for alloc::sync::Arc<T>
 where
-    T: ?Sized + Collect,
+    T: ?Sized + 'static,
 {
     #[inline]
-    fn trace(&self, cc: &Collection) {
-        (**self).trace(cc);
+    fn needs_trace() -> bool {
+        false
     }
 }
 


### PR DESCRIPTION
There is *no* reason to ever place Collect types inside of Arc or Rc, and this prevents needing an extra `#[collect(require_static)]`.