### PR TITLE
`FinalizeQueue` to monitor for about-to-be-freed values.

### DIFF
--- a/src/gc-arena/src/finalize_queue.rs
+++ b/src/gc-arena/src/finalize_queue.rs
@@ -1,0 +1,103 @@
+use core::cell::RefCell;
+
+use alloc::{collections::VecDeque, vec::Vec};
+
+use crate::{
+    barrier::Unlock, context::Finalizer, lock::RefLock, types::GcColor, Collect, Gc, GcWeak,
+    Mutation,
+};
+
+/// Monitor for objects that are about to be freed by the garbage collector.
+///
+/// Allows you to register any `Gc<'gc, T>` pointer. Once registered, if that object was *going* to
+/// be freed otherwise, it will instead be placed into this queue.
+pub struct FinalizeQueue<'gc, T>(Gc<'gc, FinalizeQueueInner<'gc, T>>);
+
+unsafe impl<'gc, T: Collect> Collect for FinalizeQueue<'gc, T> {
+    fn trace(&self, cc: &crate::Collection) {
+        self.0.trace(cc);
+    }
+}
+
+impl<'gc, T: Collect> FinalizeQueue<'gc, T> {
+    pub fn new(mc: &Mutation<'gc>) -> Self {
+        let inner = Gc::new(
+            mc,
+            FinalizeQueueInner {
+                registered: RefCell::new(Vec::new()),
+                finalized: Gc::new(mc, RefLock::new(VecDeque::new())),
+            },
+        );
+
+        mc.register_finalizer(inner.ptr);
+
+        Self(inner)
+    }
+
+    /// Register a pointer to be placed into the `FinalizeQueue` if it would otherwise be freed.
+    ///
+    /// A pointer registered here will enter the queue *once per registration*. Once it enters the
+    /// queue, it remains alive and can be pulled from the queue. If an object pulled from the queue
+    /// is then lost, it will simply be freed unless it is again registered into a `FinalizeQueue`.
+    ///
+    /// Objects can be registered into multiple queues. There is a defined priority for objects to
+    /// enter a `FinalizationQueue`: the object will enter queues created later before it enters
+    /// queues created earlier.
+    pub fn register(&self, item: Gc<'gc, T>) {
+        self.0.registered.borrow_mut().push(Gc::downgrade(item));
+    }
+
+    pub fn poll(&self) -> Option<Gc<'gc, T>> {
+        // SAFETY: No new pointers are adopted
+        unsafe { self.0.finalized.unlock_unchecked() }
+            .borrow_mut()
+            .pop_front()
+    }
+}
+
+struct FinalizeQueueInner<'gc, T> {
+    registered: RefCell<Vec<GcWeak<'gc, T>>>,
+    finalized: Gc<'gc, RefLock<VecDeque<Gc<'gc, T>>>>,
+}
+
+unsafe impl<'gc, T: Collect> Collect for FinalizeQueueInner<'gc, T> {
+    fn trace(&self, cc: &crate::Collection) {
+        // SAFETY:
+        //
+        // The `registered` list is not traced at all, because we know that only otherwise live
+        // values are ever inside the registered list.
+        //
+        // We know that objects are live when they are added to the `registered` list. We also
+        // know that `FinalizeQueueInner::finalize` will be called at the end of the mark phase,
+        // and that that method will take every object that is not already black and place it into
+        // the `finalized` list. Therefore, no value in the `registered` list can ever be freed,
+        // a white object cannot be freed until it lives *past* the end of one Mark phase, and no
+        // white object can be in the `registered` list when the the mark phase ends.
+        //
+        // TODO: Soundness relies on the fact that it is impossible to call
+        // `FinalizeQueue::register` from *another* finalizer, therefore putting a dead pointer in
+        // the `registered` list after `FinalizeQueueInner::finalize` is called but before the end
+        // of the Mark phase. This is impossible currently because the finalizer API is not public.
+        // If it is made public, this will not necessarily be sound and may need to be changed.
+
+        self.finalized.trace(cc);
+    }
+}
+
+impl<'gc, T: Collect> Finalizer<'gc> for FinalizeQueueInner<'gc, T> {
+    fn finalize(&self, mc: &Mutation<'gc>) {
+        self.registered.borrow_mut().retain(|p| {
+            let p = p.upgrade(mc).unwrap();
+            let color = unsafe { p.ptr.as_ref() }.header.color();
+            debug_assert!(color != GcColor::Gray);
+            // Since we are at the end of the mark cycle, if the color of the object is not black,
+            // then we know the object *would* have been collected.
+            if color != GcColor::Black {
+                self.finalized.borrow_mut(mc).push_back(p);
+                false
+            } else {
+                true
+            }
+        });
+    }
+}

--- a/src/gc-arena/src/finalize_queue.rs
+++ b/src/gc-arena/src/finalize_queue.rs
@@ -1,17 +1,17 @@
-use core::cell::RefCell;
+use core::{cell::RefCell, mem};
 
 use alloc::{collections::VecDeque, vec::Vec};
 
 use crate::{
-    barrier::Unlock, context::Finalizer, lock::RefLock, types::GcColor, Collect, Gc, GcWeak,
-    Mutation,
+    barrier::Unlock, context::Finalizer, lock::RefLock, metrics::Metrics, types::GcColor, Collect,
+    Gc, GcWeak, Mutation,
 };
 
 /// Monitor for objects that are about to be freed by the garbage collector.
 ///
 /// Allows you to register any `Gc<'gc, T>` pointer. Once registered, if that object was *going* to
 /// be freed otherwise, it will instead be placed into this queue.
-pub struct FinalizeQueue<'gc, T>(Gc<'gc, FinalizeQueueInner<'gc, T>>);
+pub struct FinalizeQueue<'gc, T>(Gc<'gc, InnerQueue<'gc, T>>);
 
 unsafe impl<'gc, T: Collect> Collect for FinalizeQueue<'gc, T> {
     fn trace(&self, cc: &crate::Collection) {
@@ -23,9 +23,16 @@ impl<'gc, T: Collect> FinalizeQueue<'gc, T> {
     pub fn new(mc: &Mutation<'gc>) -> Self {
         let inner = Gc::new(
             mc,
-            FinalizeQueueInner {
+            InnerQueue {
+                metrics: mc.metrics().clone(),
                 registered: RefCell::new(Vec::new()),
-                finalized: Gc::new(mc, RefLock::new(VecDeque::new())),
+                finalized: Gc::new(
+                    mc,
+                    RefLock::new(Finalized {
+                        metrics: mc.metrics().clone(),
+                        finalized: VecDeque::new(),
+                    }),
+                ),
             },
         );
 
@@ -44,47 +51,46 @@ impl<'gc, T: Collect> FinalizeQueue<'gc, T> {
     /// enter a `FinalizationQueue`: the object will enter queues created later before it enters
     /// queues created earlier.
     pub fn register(&self, item: Gc<'gc, T>) {
-        self.0.registered.borrow_mut().push(Gc::downgrade(item));
+        self.0.register(item);
     }
 
+    /// Returns an object from the queue if one is queued.
     pub fn poll(&self) -> Option<Gc<'gc, T>> {
-        // SAFETY: No new pointers are adopted
-        unsafe { self.0.finalized.unlock_unchecked() }
-            .borrow_mut()
-            .pop_front()
+        self.0.poll()
     }
 }
 
-struct FinalizeQueueInner<'gc, T> {
+struct InnerQueue<'gc, T> {
+    metrics: Metrics,
     registered: RefCell<Vec<GcWeak<'gc, T>>>,
-    finalized: Gc<'gc, RefLock<VecDeque<Gc<'gc, T>>>>,
+    finalized: Gc<'gc, RefLock<Finalized<'gc, T>>>,
 }
 
-unsafe impl<'gc, T: Collect> Collect for FinalizeQueueInner<'gc, T> {
+unsafe impl<'gc, T: Collect> Collect for InnerQueue<'gc, T> {
     fn trace(&self, cc: &crate::Collection) {
         // SAFETY:
         //
         // The `registered` list is not traced at all, because we know that only otherwise live
         // values are ever inside the registered list.
         //
-        // We know that objects are live when they are added to the `registered` list. We also
-        // know that `FinalizeQueueInner::finalize` will be called at the end of the mark phase,
-        // and that that method will take every object that is not already black and place it into
-        // the `finalized` list. Therefore, no value in the `registered` list can ever be freed,
-        // a white object cannot be freed until it lives *past* the end of one Mark phase, and no
-        // white object can be in the `registered` list when the the mark phase ends.
+        // We know that objects are live when they are added to the `registered` list. We also know
+        // that `InnerQueue::finalize` will be called at the end of the mark phase, and that that
+        // method will take every object that is not already black and place it into the `finalized`
+        // list. Therefore, no value in the `registered` list can ever be freed, a white object
+        // cannot be freed until it lives *past* the end of one Mark phase, and no white object can
+        // be in the `registered` list when the the mark phase ends.
         //
         // TODO: Soundness relies on the fact that it is impossible to call
         // `FinalizeQueue::register` from *another* finalizer, therefore putting a dead pointer in
-        // the `registered` list after `FinalizeQueueInner::finalize` is called but before the end
-        // of the Mark phase. This is impossible currently because the finalizer API is not public.
-        // If it is made public, this will not necessarily be sound and may need to be changed.
+        // the `registered` list after `InnerQueue::finalize` is called but before the end of the
+        // Mark phase. This is impossible currently because the finalizer API is not public. If it
+        // is made public, this will not necessarily be sound and may need to be changed.
 
         self.finalized.trace(cc);
     }
 }
 
-impl<'gc, T: Collect> Finalizer<'gc> for FinalizeQueueInner<'gc, T> {
+impl<'gc, T: Collect> Finalizer<'gc> for InnerQueue<'gc, T> {
     fn finalize(&self, mc: &Mutation<'gc>) {
         self.registered.borrow_mut().retain(|p| {
             let p = p.upgrade(mc).unwrap();
@@ -99,5 +105,77 @@ impl<'gc, T: Collect> Finalizer<'gc> for FinalizeQueueInner<'gc, T> {
                 true
             }
         });
+    }
+}
+
+impl<'gc, T> InnerQueue<'gc, T> {
+    fn register(&self, item: Gc<'gc, T>) {
+        let old_size = self.allocation_size();
+        self.registered.borrow_mut().push(Gc::downgrade(item));
+        let new_size = self.allocation_size();
+
+        mark_size_change(&self.metrics, old_size, new_size);
+    }
+
+    fn poll(&self) -> Option<Gc<'gc, T>> {
+        // SAFETY: No new pointers are adopted
+        unsafe { self.finalized.unlock_unchecked() }
+            .borrow_mut()
+            .pop_front()
+    }
+
+    fn allocation_size(&self) -> usize {
+        self.registered.borrow().capacity() * mem::size_of::<GcWeak<'gc, T>>()
+    }
+}
+
+impl<'gc, T> Drop for InnerQueue<'gc, T> {
+    fn drop(&mut self) {
+        self.metrics
+            .mark_external_deallocation(self.allocation_size());
+    }
+}
+
+struct Finalized<'gc, T> {
+    metrics: Metrics,
+    finalized: VecDeque<Gc<'gc, T>>,
+}
+
+unsafe impl<'gc, T: Collect> Collect for Finalized<'gc, T> {
+    fn trace(&self, cc: &crate::Collection) {
+        self.finalized.trace(cc);
+    }
+}
+
+impl<'gc, T> Drop for Finalized<'gc, T> {
+    fn drop(&mut self) {
+        self.metrics
+            .mark_external_deallocation(self.allocation_size());
+    }
+}
+
+impl<'gc, T> Finalized<'gc, T> {
+    fn allocation_size(&self) -> usize {
+        self.finalized.capacity() * mem::size_of::<Gc<'gc, T>>()
+    }
+
+    fn push_back(&mut self, ptr: Gc<'gc, T>) {
+        let old_size = self.allocation_size();
+        self.finalized.push_back(ptr);
+        let new_size = self.allocation_size();
+
+        mark_size_change(&self.metrics, old_size, new_size);
+    }
+
+    fn pop_front(&mut self) -> Option<Gc<'gc, T>> {
+        self.finalized.pop_front()
+    }
+}
+
+fn mark_size_change(metrics: &Metrics, old_size: usize, new_size: usize) {
+    if new_size > old_size {
+        metrics.mark_external_allocation(new_size - old_size);
+    } else if old_size > new_size {
+        metrics.mark_external_deallocation(old_size - new_size);
     }
 }

--- a/src/gc-arena/src/gc_weak.rs
+++ b/src/gc-arena/src/gc_weak.rs
@@ -47,8 +47,7 @@ impl<'gc, T: ?Sized + 'gc> GcWeak<'gc, T> {
     /// Note that calling `upgrade` may still fail even when this method returns `false`.
     #[inline]
     pub fn is_dropped(self) -> bool {
-        let ptr = unsafe { GcBox::erase(self.inner.ptr) };
-        !ptr.header().is_live()
+        !unsafe { self.inner.ptr.as_ref() }.header.is_live()
     }
 
     #[inline]

--- a/src/gc-arena/src/lib.rs
+++ b/src/gc-arena/src/lib.rs
@@ -12,6 +12,7 @@ mod collect;
 mod collect_impl;
 mod context;
 mod dynamic_roots;
+pub mod finalize_queue;
 mod gc;
 mod gc_weak;
 pub mod lock;

--- a/src/gc-arena/src/types.rs
+++ b/src/gc-arena/src/types.rs
@@ -220,7 +220,7 @@ impl CollectVtable {
 /// user-facing `Gc`s to freely cast their pointer to it.
 #[repr(C)]
 pub(crate) struct GcBoxInner<T: ?Sized> {
-    header: GcBoxHeader,
+    pub(crate) header: GcBoxHeader,
     /// The typed value stored in this `GcBox`.
     pub(crate) value: mem::ManuallyDrop<T>,
 }

--- a/src/gc-arena/tests/tests.rs
+++ b/src/gc-arena/tests/tests.rs
@@ -1,13 +1,13 @@
 use core::{cell::Cell, mem};
+use gc_arena::finalize_queue::FinalizeQueue;
 #[cfg(feature = "std")]
 use rand::distributions::Distribution;
 #[cfg(feature = "std")]
 use std::{collections::HashMap, rc::Rc};
 
-use gc_arena::lock::RefLock;
 use gc_arena::{
-    metrics::Pacing, unsafe_empty_collect, unsize, Arena, Collect, DynamicRootSet, Gc, GcWeak,
-    Rootable,
+    lock::RefLock, metrics::Pacing, unsafe_empty_collect, unsize, Arena, Collect, DynamicRootSet,
+    Gc, GcWeak, Rootable,
 };
 
 #[test]
@@ -764,6 +764,54 @@ fn gc_external_allocation_affects_timing() {
 
     // This should have payed off some debt.
     assert!(arena.metrics().allocation_debt() < debt_high_mark);
+}
+
+#[test]
+fn finalize_queue() {
+    #[derive(Collect)]
+    #[collect(no_drop)]
+    struct TestRoot<'gc> {
+        finalize_queue: FinalizeQueue<'gc, u8>,
+        test: Gc<'gc, u8>,
+    }
+
+    let mut arena = Arena::<Rootable![TestRoot<'_>]>::new(|mc| TestRoot {
+        finalize_queue: FinalizeQueue::new(mc),
+        test: Gc::new(mc, 4),
+    });
+
+    arena.mutate(|mc, root| {
+        root.finalize_queue.register(Gc::new(mc, 1));
+        root.finalize_queue.register(Gc::new(mc, 2));
+        root.finalize_queue.register(Gc::new(mc, 3));
+        root.finalize_queue.register(root.test);
+        root.finalize_queue.register(Gc::new(mc, 5));
+        root.finalize_queue.register(Gc::new(mc, 6));
+    });
+
+    arena.collect_all();
+
+    arena.mutate_root(|mc, root| {
+        let mut v = Vec::new();
+        while let Some(p) = root.finalize_queue.poll() {
+            v.push(*p);
+        }
+        v.sort();
+        assert_eq!(v, &[1, 2, 3, 5, 6]);
+        root.test = Gc::new(mc, 7);
+        root.finalize_queue.register(root.test);
+    });
+
+    arena.collect_all();
+
+    arena.mutate_root(|_, root| {
+        let mut v = Vec::new();
+        while let Some(p) = root.finalize_queue.poll() {
+            v.push(*p);
+        }
+        v.sort();
+        assert_eq!(v, &[4]);
+    });
 }
 
 #[test]


### PR DESCRIPTION
Works a bit like <https://docs.oracle.com/javase/8/docs/api/java/lang/ref/ReferenceQueue.html>.

I believe I have nailed down all of the edge and corner case behavior of the `FinalizeQueue` in this PR, but there is admittedly a lot, and it's not all covered by comments or documentation.

One thing not covered by the comments is what precisely happens when one `FinalizeQueue` is placed into another. If a later constructed `FinalizeQueue` is registered into an earlier one and otherwise lost, then the later queue will receive any about-to-be-freed objects, and then the earlier queue will *also* receive any duplicate registered objects (because the later queue is not yet black so none of its children are either). In the other case, where an earlier constructed `FinalizeQueue` is placed into a later one, then the later queue receives any soon-to-be-freed objects but the earlier one does *not*.

This seems inconsistent to me but any other behavior I can come up with is just as strange. In the later-in-earlier situation, if objects weren't placed into the earlier queue, then the earlier queue would miss freed objects if the later queue wasn't resurrected. In the earlier-in-later situation, if the earlier queue received objects and was resurrected then it would have received objects incorrectly.

This is the most consistent behavior I could come up with, and the algorithm that the collector is doing is simple.