### PR TITLE
Finalization design #3

### DIFF
--- a/src/gc-arena/src/arena.rs
+++ b/src/gc-arena/src/arena.rs
@@ -319,7 +319,7 @@ pub struct MarkedArena<'a, R: for<'b> Rootable<'b>>(&'a Arena<R>);
 
 impl<'a, R: for<'b> Rootable<'b>> MarkedArena<'a, R> {
     #[inline]
-    pub fn finalize<F, T>(&self, f: F) -> T
+    pub fn finalize<F, T>(self, f: F) -> T
     where
         F: for<'gc> FnOnce(&'gc Finalization<'gc>, &'gc Root<'gc, R>) -> T,
     {

--- a/src/gc-arena/src/arena.rs
+++ b/src/gc-arena/src/arena.rs
@@ -2,9 +2,9 @@ use alloc::boxed::Box;
 use core::{f64, marker::PhantomData};
 
 use crate::{
-    context::{Context, Mutation},
+    context::{Context, Mutation, Phase},
     metrics::Metrics,
-    Collect,
+    Collect, Finalization,
 };
 
 /// A trait that produces a [`Collect`]-able type for the given lifetime. This is used to produce
@@ -80,6 +80,21 @@ macro_rules! Rootable {
 
 /// A helper type alias for a `Rootable::Root` for a specific lifetime.
 pub type Root<'a, R> = <R as Rootable<'a>>::Root;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum CollectorPhase {
+    /// The collector is done with a collection cycle and is waiting to be restarted.
+    Sleep,
+    /// The collector is currently tracing objects from the root to determine reachability.
+    Marking,
+    /// The collector has finished tracing, all reachable objects are marked. This may transition
+    /// back to `Marking` if write barriers occur.
+    Marked,
+    /// The collector has determined a set of unreachable objects and has started collecting them.
+    /// At this point, marking is no longer taking place so the root may have reachable, unmarked
+    /// pointers
+    Collection,
+}
 
 /// A generic, garbage collected arena.
 ///
@@ -208,22 +223,111 @@ impl<R: for<'a> Rootable<'a>> Arena<R> {
         self.context.metrics()
     }
 
-    /// Run the incremental garbage collector until the allocation debt is <= 0.0. There is no
-    /// minimum unit of work enforced here, so it may be faster to only call this method when the
-    /// allocation debt is above some threshold.
+    #[inline]
+    pub fn phase(&self) -> CollectorPhase {
+        match self.context.phase() {
+            Phase::Mark => {
+                if self.context.gray_remaining() {
+                    CollectorPhase::Marking
+                } else {
+                    CollectorPhase::Marked
+                }
+            }
+            Phase::Sweep => CollectorPhase::Collection,
+            Phase::Sleep => CollectorPhase::Sleep,
+            Phase::Drop => unreachable!(),
+        }
+    }
+
+    /// Run the incremental garbage collector until the allocation debt is <= 0.0.
+    ///
+    /// There is no minimum unit of work enforced here, so it may be faster to only call this method
+    /// when the allocation debt is above some threshold.
+    ///
+    /// This method will always return at least once when the collector enters the `Sleep` phase,
+    /// i.e. it will never transition from the `Collection` phase to the `Marking` phase without
+    /// returning.
     #[inline]
     pub fn collect_debt(&mut self) {
         unsafe {
-            self.context.do_collection(&self.root, 0.0);
+            self.context.do_collection(&self.root, 0.0, false);
+        }
+    }
+
+    /// Run only the *marking* part of the incremental garbage collector until allocation debt is
+    /// <= 0.0.
+    ///
+    /// This does *not* transition the collector past the `MarkFinished` phase. Does nothing
+    /// if the collector phase is `MarkFinished` or `Collecting`, otherwise acts like
+    /// `Arena::collect_debt`.
+    ///
+    /// If after collecting debt this arena is now fully marked, then a `MarkedArena` type will
+    /// be returned. This allows calling `MarkedArena::finalize` to examine the state of the fully
+    /// marked root.
+    #[inline]
+    pub fn mark_debt(&mut self) -> Option<MarkedArena<'_, R>> {
+        if matches!(self.context.phase(), Phase::Mark | Phase::Sleep) {
+            unsafe {
+                self.context.do_collection(&self.root, 0.0, true);
+            }
+        }
+
+        debug_assert!(self.context.phase() == Phase::Mark);
+        if !self.context.gray_remaining() {
+            Some(MarkedArena(self))
+        } else {
+            None
         }
     }
 
     /// Run the current garbage collection cycle to completion, stopping once the garbage collector
-    /// has finished the sweep phase.
+    /// has restarted in the sleep phase. If the collector is currently in the sleep phase, this
+    /// restarts the collection and performs a full collection before transitioning back to the
+    /// sleep phase.
     #[inline]
     pub fn collect_all(&mut self) {
         unsafe {
-            self.context.do_collection(&self.root, f64::NEG_INFINITY);
+            self.context
+                .do_collection(&self.root, f64::NEG_INFINITY, false);
+        }
+    }
+
+    /// Runs all of the remaining *marking* part of the current garbage collection cycle.
+    ///
+    /// Similarly to `Arena::mark_debt`, this does not transition the collector past the
+    /// `MarkFinished` phase, and does nothing if the collector is currently in the `MarkFinished`
+    /// phase or the `Collection` phase.
+    #[inline]
+    pub fn mark_all(&mut self) -> Option<MarkedArena<'_, R>> {
+        if matches!(self.context.phase(), Phase::Mark | Phase::Sleep) {
+            unsafe {
+                self.context
+                    .do_collection(&self.root, f64::NEG_INFINITY, true);
+            }
+        }
+
+        debug_assert!(self.context.phase() == Phase::Mark);
+        if !self.context.gray_remaining() {
+            Some(MarkedArena(self))
+        } else {
+            None
+        }
+    }
+}
+
+pub struct MarkedArena<'a, R: for<'b> Rootable<'b>>(&'a Arena<R>);
+
+impl<'a, R: for<'b> Rootable<'b>> MarkedArena<'a, R> {
+    #[inline]
+    pub fn finalize<F, T>(&self, f: F) -> T
+    where
+        F: for<'gc> FnOnce(&'gc Finalization<'gc>, &'gc Root<'gc, R>) -> T,
+    {
+        unsafe {
+            let mc: &'static Finalization<'_> =
+                &*(self.0.context.finalization_context() as *const _);
+            let root: &'static Root<'_, R> = &*(&self.0.root as *const _);
+            f(mc, root)
         }
     }
 }

--- a/src/gc-arena/src/gc_weak.rs
+++ b/src/gc-arena/src/gc_weak.rs
@@ -1,4 +1,5 @@
 use crate::collect::Collect;
+use crate::context::Finalization;
 use crate::gc::Gc;
 use crate::types::{GcBox, GcColor};
 use crate::{Collection, Mutation};
@@ -48,40 +49,43 @@ impl<'gc, T: ?Sized + 'gc> GcWeak<'gc, T> {
         !unsafe { self.inner.ptr.as_ref() }.header.is_live()
     }
 
-    /// Returns true if this pointer has been marked during this collection cycle and the held value
-    /// will not be dropped.
+    /// Returns true when a pointer is *dead* during finalization.
     ///
-    /// If this method returns `false`, it does not necessarily imply that the held value *will* be
-    /// dropped this cycle, only that it hasn't been marked *yet* as part of the `Marking` phase.
+    /// This is a weaker condition than being *dropped*, as the pointer *may* still be valid. Being
+    /// *dead* means that there were no strong pointers pointing to this weak pointer that were
+    /// found by the marking phase, and if it is not already dropped, it *will* be dropped as soon
+    /// as collection resumes.
     ///
-    /// This method is most useful when called when the arena is precisely in the `Marked` state. IF
-    /// the arena is fully marked AND this method returns `false` AND the arena does not transition
-    /// back to `Marking` due to a write barrier or `GcWeak::mark`, then you can know that the
-    /// object pointed to by this `GcWeak` is destined to be dropped during the current cycle's
-    /// `Collecting` phase.
+    /// If the pointer is still valid, it may be resurrected using `GcWeak::upgrade` or
+    /// GcWeak::resurrect`.
+    ///
+    /// NOTE: This returns true if the pointer was destined to be collected at the **start** of
+    /// the current finalization callback. Resurrecting one weak pointer can transitively resurrect
+    /// others, and this method does not reflect this from within the same finalization call! If
+    /// transitive resurrection is important, you may have to carefully call finalize multiple times
+    /// for one collection cycle with marking stages in-between, and in the precise order that you
+    /// want.
     #[inline]
-    pub fn is_marked(self) -> bool {
-        matches!(
-            unsafe { self.inner.ptr.as_ref() }.header.color(),
-            GcColor::Gray | GcColor::Black
-        )
+    pub fn is_dead(self, _: &Finalization<'gc>) -> bool {
+        let inner = unsafe { self.inner.ptr.as_ref() };
+        matches!(inner.header.color(), GcColor::White | GcColor::WhiteWeak)
     }
 
-    /// Manually mark a `GcWeak` during marking.
+    /// Resurrect a dead `GcWeak` and keep it alive.
     ///
-    /// If the pointer can be manually marked, marks it and returns a strong version of the pointer,
-    /// otherwise `None`.
-    ///
-    /// May return `None` if the arena is in the wrong phase of the collection cycle *or* if the
-    /// pointed-to value has already been dropped.
-    ///
-    /// Will mark pointers if called in the `Marking` *or* the `Marked` phase, but if called in the
-    /// `Marked` phase *and* the pointer was not already marked, it may transition the collection
-    /// phase back to `Marking` (for transitively held objects).
+    /// Acts like `GcWeak::upgrade` with one extra behavior. Even if the returned strong pointer is
+    /// not stored anywhere, this will still prevent this weak pointer from being freed during this
+    /// collection cycle.
     #[inline]
-    pub fn mark(self, mc: &Mutation<'gc>) -> Option<Gc<'gc, T>> {
-        let ptr = unsafe { GcBox::erase(self.inner.ptr) };
-        mc.mark(ptr).then(|| self.inner)
+    pub fn resurrect(self, fc: &Finalization<'gc>) -> Option<Gc<'gc, T>> {
+        if let Some(p) = self.upgrade(&fc) {
+            unsafe {
+                fc.resurrect(GcBox::erase(p.ptr));
+            }
+            Some(p)
+        } else {
+            None
+        }
     }
 
     #[inline]

--- a/src/gc-arena/src/lib.rs
+++ b/src/gc-arena/src/lib.rs
@@ -6,7 +6,7 @@ extern crate std;
 
 extern crate alloc;
 
-mod arena;
+pub mod arena;
 pub mod barrier;
 mod collect;
 mod collect_impl;
@@ -34,9 +34,9 @@ pub use gc_arena_derive::*;
 pub use self::{arena::__DynRootable, no_drop::__MustNotImplDrop, unsize::__CoercePtrInternal};
 
 pub use self::{
-    arena::{rootless_arena, Arena, Root, Rootable},
+    arena::{rootless_arena, Arena, CollectorPhase, Root, Rootable},
     collect::Collect,
-    context::{Collection, Mutation},
+    context::{Collection, Finalization, Mutation},
     dynamic_roots::{DynamicRoot, DynamicRootSet, MismatchedRootSet},
     gc::Gc,
     gc_weak::GcWeak,

--- a/src/gc-arena/src/lib.rs
+++ b/src/gc-arena/src/lib.rs
@@ -34,9 +34,9 @@ pub use gc_arena_derive::*;
 pub use self::{arena::__DynRootable, no_drop::__MustNotImplDrop, unsize::__CoercePtrInternal};
 
 pub use self::{
-    arena::{rootless_arena, Arena, CollectorPhase, Root, Rootable},
+    arena::{rootless_arena, Arena, CollectionPhase, Root, Rootable},
     collect::Collect,
-    context::{Collection, Finalization, Mutation},
+    context::{Collection, Mutation},
     dynamic_roots::{DynamicRoot, DynamicRootSet, MismatchedRootSet},
     gc::Gc,
     gc_weak::GcWeak,

--- a/src/gc-arena/src/types.rs
+++ b/src/gc-arena/src/types.rs
@@ -220,7 +220,7 @@ impl CollectVtable {
 /// user-facing `Gc`s to freely cast their pointer to it.
 #[repr(C)]
 pub(crate) struct GcBoxInner<T: ?Sized> {
-    header: GcBoxHeader,
+    pub(crate) header: GcBoxHeader,
     /// The typed value stored in this `GcBox`.
     pub(crate) value: mem::ManuallyDrop<T>,
 }

--- a/src/gc-arena/tests/tests.rs
+++ b/src/gc-arena/tests/tests.rs
@@ -5,8 +5,8 @@ use rand::distributions::Distribution;
 use std::{collections::HashMap, rc::Rc};
 
 use gc_arena::{
-    lock::RefLock, metrics::Pacing, unsafe_empty_collect, unsize, Arena, Collect, DynamicRootSet,
-    Gc, GcWeak, Rootable,
+    lock::RefLock, metrics::Pacing, unsafe_empty_collect, unsize, Arena, Collect, CollectionPhase,
+    DynamicRootSet, Gc, GcWeak, Rootable,
 };
 
 #[test]
@@ -848,32 +848,48 @@ fn basic_finalization() {
         root.a = Gc::new(mc, 3);
     });
 
-    arena.mark_all().unwrap().finalize(|fc, root| {
-        assert!(!root.c.is_dropped());
-        assert!(root.c.is_dead(fc));
-        assert!(!root.d.is_dead(fc));
-        root.c.resurrect(fc);
-    });
+    arena.mark_all();
+    assert_eq!(arena.collection_phase(), CollectionPhase::Marked);
 
-    arena
-        .mark_all()
-        .unwrap()
-        .finalize(|fc, root| root.c.resurrect(fc).is_some());
+    arena.mutate(|mc, root| {
+        assert!(!root.c.is_dropped());
+        assert!(!root.c.is_marked());
+        assert!(root.d.is_marked());
+        assert!(root.c.mark(mc).is_some());
+    });
+    // Will be in `CollectionPhase::Marked` because `Gc<u8>` does not need tracing, but either is
+    // legal.
+    assert!(matches!(
+        arena.collection_phase(),
+        CollectionPhase::Marking | CollectionPhase::Marked
+    ));
+
+    arena.mark_all();
+    assert_eq!(arena.collection_phase(), CollectionPhase::Marked);
+
+    arena.mutate(|mc, root| assert!(root.c.mark(mc).is_some()));
 
     arena.collect_all();
+    assert_eq!(arena.collection_phase(), CollectionPhase::Sleeping);
 
-    arena.mark_all().unwrap().finalize(|fc, root| {
+    arena.mark_all();
+    assert_eq!(arena.collection_phase(), CollectionPhase::Marked);
+
+    arena.mutate(|_, root| {
         assert!(!root.c.is_dropped());
-        assert!(root.c.is_dead(fc));
-        assert!(!root.d.is_dead(fc));
+        assert!(!root.c.is_marked());
+        assert!(root.d.is_marked());
     });
 
     arena.collect_all();
+    assert_eq!(arena.collection_phase(), CollectionPhase::Sleeping);
 
-    arena.mark_all().unwrap().finalize(|fc, root| {
+    arena.mark_all();
+
+    arena.mutate(|_, root| {
         assert!(root.c.is_dropped());
-        assert!(root.c.is_dead(fc));
-        assert!(!root.d.is_dead(fc));
+        assert!(!root.c.is_marked());
+        assert!(root.d.is_marked());
     });
 }
 


### PR DESCRIPTION
Makes as few decisions as possible and leaves everything up to the user.

Instead of having *any* direct finalization support, "simply" allows the user to stop collection at exactly the end of the marking phase and examine things.

Adds a `finalize` (indirect) method on `Arena`, and a new `Finalization` context which is currently `Mutation` but with two new powers:

* The ability to check whether a `GcWeak` was "dead" at the start of the current finalization call
* The ability to "resurrect" a `GcWeak` to preserve it this cycle (even without being upgraded and stored).

Entirely punts on ordering and queueing and leaves everything up to the user, BUT it is just powerful enough to implement finalizers and Java style ReferenceQueues and ephemeron tables and finalization ordering and many other things that parts 1 or 2 (or both) struggled with.