### PR TITLE
add StaticCollect traits

### DIFF
--- a/src/gc-arena/src/static_collect.rs
+++ b/src/gc-arena/src/static_collect.rs
@@ -1,8 +1,8 @@
 use crate::collect::Collect;
 
 use alloc::borrow::{Borrow, BorrowMut};
+use core::convert::{AsMut, AsRef};
 use core::ops::{Deref, DerefMut};
-use core::convert::{AsRef, AsMut};
 
 /// A wrapper type that implements Collect whenever the contained T is 'static, which is useful in
 /// generic contexts

--- a/src/gc-arena/src/static_collect.rs
+++ b/src/gc-arena/src/static_collect.rs
@@ -1,5 +1,9 @@
 use crate::collect::Collect;
 
+use alloc::borrow::{Borrow, BorrowMut};
+use core::ops::{Deref, DerefMut};
+use core::convert::{AsRef, AsMut};
+
 /// A wrapper type that implements Collect whenever the contained T is 'static, which is useful in
 /// generic contexts
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
@@ -9,5 +13,45 @@ unsafe impl<T: 'static> Collect for StaticCollect<T> {
     #[inline]
     fn needs_trace() -> bool {
         false
+    }
+}
+
+impl<T> From<T> for StaticCollect<T> {
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}
+
+impl<T> AsRef<T> for StaticCollect<T> {
+    fn as_ref(&self) -> &T {
+        &self.0
+    }
+}
+impl<T> AsMut<T> for StaticCollect<T> {
+    fn as_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+impl<T> Deref for StaticCollect<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl<T> DerefMut for StaticCollect<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> Borrow<T> for StaticCollect<T> {
+    fn borrow(&self) -> &T {
+        &self.0
+    }
+}
+impl<T> BorrowMut<T> for StaticCollect<T> {
+    fn borrow_mut(&mut self) -> &mut T {
+        &mut self.0
     }
 }


### PR DESCRIPTION
Just adds a few trait impls to `StaticCollect`:
- `From<T>`
- `AsRef<T>`
- `AsMut<T>`
- `Deref<Target = T>`
- `DerefMut`
- `Borrow<T>`
- `BorrowMut<T>`

Originally I was wanting `Borrow<U> for StaticCollect<T> where T: Borrow<U>` for (efficient) use as the key type in a `BTreeMap`, but this seems to be impossible due to the std blanket implementation of `Borrow<T> for T`. Rust _really_ needs negative trait bounds... or at least a `NotSame<T, U>` trait or something... But I digress lol