### PR TITLE
make Gc::ptr_eq and GcWeak::ptr_eq match stdlib smart pointer ptr_eq

### DIFF
--- a/src/gc-arena/src/gc.rs
+++ b/src/gc-arena/src/gc.rs
@@ -163,9 +163,15 @@ impl<'gc, T: ?Sized + 'gc> Gc<'gc, T> {
         }
     }
 
+    /// Returns true if two `Gc`s point to the same allocation.
+    ///
+    /// Similarly to `Rc::ptr_eq` and `Arc::ptr_eq`, this function ignores the metadata of `dyn`
+    /// pointers.
     #[inline]
     pub fn ptr_eq(this: Gc<'gc, T>, other: Gc<'gc, T>) -> bool {
-        Gc::as_ptr(this) == Gc::as_ptr(other)
+        // TODO: Equivalent to `core::ptr::addr_eq`:
+        // https://github.com/rust-lang/rust/issues/116324
+        Gc::as_ptr(this) as *const () == Gc::as_ptr(other) as *const ()
     }
 
     #[inline]

--- a/src/gc-arena/src/gc_weak.rs
+++ b/src/gc-arena/src/gc_weak.rs
@@ -88,9 +88,15 @@ impl<'gc, T: ?Sized + 'gc> GcWeak<'gc, T> {
         }
     }
 
+    /// Returns true if two `GcWeak`s point to the same allocation.
+    ///
+    /// Similarly to `Rc::ptr_eq` and `Arc::ptr_eq`, this function ignores the metadata of `dyn`
+    /// pointers.
     #[inline]
     pub fn ptr_eq(this: GcWeak<'gc, T>, other: GcWeak<'gc, T>) -> bool {
-        this.as_ptr() == other.as_ptr()
+        // TODO: Equivalent to `core::ptr::addr_eq`:
+        // https://github.com/rust-lang/rust/issues/116324
+        this.as_ptr() as *const () == other.as_ptr() as *const ()
     }
 
     #[inline]


### PR DESCRIPTION
Also fixes upcoming lint.

Should use https://github.com/rust-lang/rust/issues/116324 when it is available.