### PR TITLE
Add GcWeak::trace_strong

### DIFF
--- a/src/gc-arena/src/context.rs
+++ b/src/gc-arena/src/context.rs
@@ -290,6 +290,7 @@ impl Context {
                         }
 
                         let guard = DropGuard { cx: self, gc_box };
+                        debug_assert!(gc_box.header().is_live());
                         unsafe { gc_box.trace_value(self.collection_context()) }
                         gc_box.header().set_color(GcColor::Black);
                         mem::forget(guard);
@@ -447,6 +448,7 @@ impl Context {
                     // A white traceable object is not in the gray queue, becomes gray and enters
                     // the normal gray queue.
                     header.set_color(GcColor::Gray);
+                    debug_assert!(header.is_live());
                     self.gray.borrow_mut().push(gc_box);
                 } else {
                     // A white object that doesn't need tracing simply becomes black.
@@ -516,6 +518,7 @@ impl Context {
     fn resurrect(&self, gc_box: GcBox) {
         let header = gc_box.header();
         debug_assert_eq!(self.phase.get(), Phase::Mark);
+        debug_assert!(header.is_live());
         if matches!(header.color(), GcColor::White | GcColor::WhiteWeak) {
             header.set_color(GcColor::Gray);
             self.gray.borrow_mut().push(gc_box);

--- a/src/gc-arena/tests/tests.rs
+++ b/src/gc-arena/tests/tests.rs
@@ -849,7 +849,7 @@ fn basic_finalization() {
     });
 
     arena.mark_all().unwrap().finalize(|fc, root| {
-        assert!(!root.c.is_dropped());
+        assert!(root.c.upgrade(&fc).is_some());
         assert!(root.c.is_dead(fc));
         assert!(!root.d.is_dead(fc));
         root.c.resurrect(fc);
@@ -863,7 +863,7 @@ fn basic_finalization() {
     arena.collect_all();
 
     arena.mark_all().unwrap().finalize(|fc, root| {
-        assert!(!root.c.is_dropped());
+        assert!(root.c.upgrade(&fc).is_some());
         assert!(root.c.is_dead(fc));
         assert!(!root.d.is_dead(fc));
     });
@@ -871,7 +871,7 @@ fn basic_finalization() {
     arena.collect_all();
 
     arena.mark_all().unwrap().finalize(|fc, root| {
-        assert!(root.c.is_dropped());
+        assert!(root.c.upgrade(&fc).is_none());
         assert!(root.c.is_dead(fc));
         assert!(!root.d.is_dead(fc));
     });


### PR DESCRIPTION
Allows someone to more easily decide at runtime whether a GcWeak should be treated as a strong pointer or a weak pointer during tracing.

This is not *strictly* required for `piccolo` to implement weak tables but it makes it a lot less obnoxious.

Includes a couple of drive by changes adding extra debug asserts, and a *very small* perf increase for GcWeak::resurrect.