### PR TITLE
Rework `DynamicRootSet` to amortize allocation.

### DIFF
--- a/src/dynamic_roots.rs
+++ b/src/dynamic_roots.rs
@@ -1,29 +1,27 @@
+use core::{cell::RefCell, fmt, mem};
+
 use alloc::{
     rc::{Rc, Weak},
     vec::Vec,
 };
-use core::{fmt, mem};
 
-use crate::lock::RefLock;
-use crate::{
-    barrier::{unlock, Write},
-    metrics::Metrics,
-};
-use crate::{Collect, Gc, Mutation, Root, Rootable};
+use crate::{metrics::Metrics, unsize, Collect, Gc, Mutation, Root, Rootable};
 
 /// A way of registering GC roots dynamically.
 ///
 /// Use this type as (a part of) an [`Arena`](crate::Arena) root to enable dynamic rooting of
 /// GC'd objects through [`DynamicRoot`] handles.
-// SAFETY: Allows us to conert `Gc<'gc>` pointers to `Gc<'static>` and back, and this is VERY
+//
+// SAFETY: This allows us to convert `Gc<'gc>` pointers to `Gc<'static>` and back, and this is VERY
 // sketchy. We know it is safe because:
 //   1) The `DynamicRootSet` must be created inside an arena and is branded with an invariant `'gc`
 //      lifetime.
-//   2) The inner `id` inside the `DynamicRootSet` is unique for as long as the `DynamicRootSet` or
-//      any `DynamicRoot` still references it.
-//   3) The `id` is stored inside each `DynamicRoot` and checked against the one in the set, and
-//      a match lets us know that this `Gc` must have originated from *this* set, so it is safe to
-//      cast it back to whatever our current `'gc` lifetime is.
+//   2) When stashing a `Gc<'gc, R>` pointer, the invariant `'gc` lifetimes must match.
+//   3) When fetching, we make sure that the `DynamicRoot` `slots` field points to the same object
+//      as the `slots` field in the `DynamicRootSet`. We never drop this `Rc` or change the `Weak`
+//      held in any `DynamicRoot`, so if they both point to the same object, the original `Gc`
+//      pointer *must* have originally been stashed using *this* set. Therefore, it is safe to cast
+//      it back to whatever our current `'gc` lifetime is.
 #[derive(Copy, Clone)]
 pub struct DynamicRootSet<'gc>(Gc<'gc, Inner<'gc>>);
 
@@ -39,34 +37,35 @@ impl<'gc> DynamicRootSet<'gc> {
         DynamicRootSet(Gc::new(
             mc,
             Inner {
-                handles: RefLock::new(Vec::new()),
-                metrics: mc.metrics().clone(),
-                set_id: Rc::new(SetId {}),
+                slots: Rc::new(RefCell::new(Slots::new(mc.metrics().clone()))),
             },
         ))
     }
 
     /// Puts a root inside this root set.
     ///
-    /// The returned handle can be freely stored outside the current arena,
-    /// and will keep the root alive across garbage collections.
+    /// The returned handle can be freely stored outside the current arena, and will keep the root
+    /// alive across garbage collections.
     pub fn stash<R: for<'a> Rootable<'a>>(
         &self,
         mc: &Mutation<'gc>,
-        root: Root<'gc, R>,
+        root: Gc<'gc, Root<'gc, R>>,
     ) -> DynamicRoot<R> {
-        let handle = Rc::new(Handle {
-            set_id: self.0.set_id.clone(),
-            root,
-        });
+        // SAFETY: We are adopting a new `Gc` pointer, so we must invoke a write barrier.
+        Gc::write(mc, self.0);
 
-        Inner::adopt_handle(&Gc::write(mc, self.0), &handle);
+        let mut slots = self.0.slots.borrow_mut();
+        let index = slots.add(unsize!(root => dyn Collect));
 
-        DynamicRoot {
-            handle: unsafe {
-                mem::transmute::<Rc<Handle<Root<'gc, R>>>, Rc<Handle<Root<'static, R>>>>(handle)
-            },
-        }
+        let ptr =
+            unsafe { mem::transmute::<Gc<'gc, Root<'gc, R>>, Gc<'static, Root<'static, R>>>(root) };
+        let slots = unsafe {
+            mem::transmute::<Weak<RefCell<Slots<'gc>>>, Weak<RefCell<Slots<'static>>>>(
+                Rc::downgrade(&self.0.slots),
+            )
+        };
+
+        DynamicRoot { ptr, slots, index }
     }
 
     /// Gets immutable access to the given root.
@@ -76,9 +75,11 @@ impl<'gc> DynamicRootSet<'gc> {
     /// Panics if the handle doesn't belong to this root set. For the non-panicking variant, use
     /// [`try_fetch`](Self::try_fetch).
     #[inline]
-    pub fn fetch<'a, R: for<'r> Rootable<'r>>(&self, root: &'a DynamicRoot<R>) -> &'a Root<'gc, R> {
+    pub fn fetch<R: for<'r> Rootable<'r>>(&self, root: &DynamicRoot<R>) -> Gc<'gc, Root<'gc, R>> {
         if self.contains(root) {
-            unsafe { &*root.as_ptr() }
+            unsafe {
+                mem::transmute::<Gc<'static, Root<'static, R>>, Gc<'gc, Root<'gc, R>>>(root.ptr)
+            }
         } else {
             panic!("mismatched root set")
         }
@@ -87,12 +88,14 @@ impl<'gc> DynamicRootSet<'gc> {
     /// Gets immutable access to the given root, or returns an error if the handle doesn't belong
     /// to this root set.
     #[inline]
-    pub fn try_fetch<'a, R: for<'r> Rootable<'r>>(
+    pub fn try_fetch<R: for<'r> Rootable<'r>>(
         &self,
-        root: &'a DynamicRoot<R>,
-    ) -> Result<&'a Root<'gc, R>, MismatchedRootSet> {
+        root: &DynamicRoot<R>,
+    ) -> Result<Gc<'gc, Root<'gc, R>>, MismatchedRootSet> {
         if self.contains(root) {
-            unsafe { Ok(&*root.as_ptr()) }
+            Ok(unsafe {
+                mem::transmute::<Gc<'static, Root<'static, R>>, Gc<'gc, Root<'gc, R>>>(root.ptr)
+            })
         } else {
             Err(MismatchedRootSet(()))
         }
@@ -101,48 +104,46 @@ impl<'gc> DynamicRootSet<'gc> {
     /// Tests if the given handle belongs to this root set.
     #[inline]
     pub fn contains<R: for<'r> Rootable<'r>>(&self, root: &DynamicRoot<R>) -> bool {
-        let ours = Rc::as_ptr(&self.0.set_id);
-        let theirs = Rc::as_ptr(&root.handle.set_id);
+        // NOTE: We are making an assumption about how `Weak` works that is currently true and
+        // surely MUST continue to be true, but is possibly under-specified in the stdlib. We are
+        // assuming that if the `Weak` pointer held in the given `DynamicRoot` points to a *dropped*
+        // root set, that `Weak::as_ptr` will return a pointer that cannot possibly belong to a
+        // live `Rc`.
+        let ours = unsafe {
+            mem::transmute::<*const RefCell<Slots<'gc>>, *const RefCell<Slots<'static>>>(
+                Rc::as_ptr(&self.0.slots),
+            )
+        };
+        let theirs = Weak::as_ptr(&root.slots);
         ours == theirs
     }
 }
 
-/// An unbranded, reference-counted handle to a GC root held in some [`DynamicRootSet`].
-///
-/// A `DynamicRoot` can freely be stored outside GC arenas; in exchange, all accesses to the held
-/// object must go through the [`DynamicRootSet`] from which it was created.
-///
-/// This handle is cheaply clonable: all clones will refer to the *same* object, which will be
-/// dropped when the last surviving handle goes out of scope.
 pub struct DynamicRoot<R: for<'gc> Rootable<'gc>> {
-    handle: Rc<Handle<Root<'static, R>>>,
+    ptr: Gc<'static, Root<'static, R>>,
+    slots: Weak<RefCell<Slots<'static>>>,
+    index: Index,
 }
 
-impl<R: for<'gc> Rootable<'gc>> Clone for DynamicRoot<R> {
-    fn clone(&self) -> Self {
-        Self {
-            handle: self.handle.clone(),
+impl<R: for<'gc> Rootable<'gc>> Drop for DynamicRoot<R> {
+    fn drop(&mut self) {
+        if let Some(slots) = self.slots.upgrade() {
+            slots.borrow_mut().dec(self.index);
         }
     }
 }
 
-impl<R: for<'gc> Rootable<'gc>> DynamicRoot<R> {
-    /// Get a pointer to the held object.
-    ///
-    /// # Safety
-    ///
-    /// The pointer will never be dangling as long as at least one `DynamicRoot` is alive, but
-    /// using the object behind this pointer is extremely dangerous.
-    ///
-    /// Firstly, the `'gc` lifetime returned here is unbound, so it is meaningless and can allow
-    /// improper mixing of objects across arenas.
-    ///
-    /// Secondly, though the pointer to the object *itself* will not be dangling, any garbage
-    /// collected pointers the object holds *will* be dangling if the [`DynamicRootSet`] backing
-    /// this root has been collected.
-    #[inline]
-    pub fn as_ptr<'gc>(&self) -> *const Root<'gc, R> {
-        unsafe { mem::transmute::<&Root<'static, R>, &Root<'gc, R>>(&self.handle.root) as *const _ }
+impl<R: for<'gc> Rootable<'gc>> Clone for DynamicRoot<R> {
+    fn clone(&self) -> Self {
+        if let Some(slots) = self.slots.upgrade() {
+            slots.borrow_mut().inc(self.index);
+        }
+
+        Self {
+            ptr: self.ptr,
+            slots: self.slots.clone(),
+            index: self.index,
+        }
     }
 }
 
@@ -159,81 +160,105 @@ impl fmt::Display for MismatchedRootSet {
 #[cfg(feature = "std")]
 impl std::error::Error for MismatchedRootSet {}
 
-// The address of an allocated `SetId` type uniquely identifies a single `DynamicRootSet`.
-struct SetId {}
-
-struct HandleStore<'gc> {
-    handle: Weak<Handle<dyn Collect + 'gc>>,
-    root_size: usize,
-}
-
 struct Inner<'gc> {
-    handles: RefLock<Vec<HandleStore<'gc>>>,
-    metrics: Metrics,
-    set_id: Rc<SetId>,
-}
-
-fn size_of_handle_list<'gc>(list: &Vec<HandleStore<'gc>>) -> usize {
-    list.capacity() * mem::size_of::<Weak<Handle<dyn Collect + 'gc>>>()
-}
-
-impl<'gc> Inner<'gc> {
-    fn adopt_handle<T: Collect + 'gc>(this: &Write<Self>, handle: &Rc<Handle<T>>) {
-        // We count size_of::<T>() as part of the arena heap to encourage collection of the handle
-        // list. *Technically* this doesn't include the full size of the Rc allocation (strong and
-        // weak counts) but this does not matter very much.
-        let root_size = mem::size_of::<T>();
-        this.metrics.mark_external_allocation(root_size);
-
-        let handles = unlock!(this, Inner, handles);
-        let mut handles = handles.borrow_mut();
-        let old_size = size_of_handle_list(&handles);
-        handles.push(HandleStore {
-            handle: Rc::<Handle<T>>::downgrade(handle),
-            root_size,
-        });
-        let new_size = size_of_handle_list(&handles);
-
-        if new_size > old_size {
-            this.metrics.mark_external_allocation(new_size - old_size);
-        } else if old_size > new_size {
-            this.metrics.mark_external_deallocation(old_size - new_size);
-        }
-    }
-}
-
-impl<'gc> Drop for Inner<'gc> {
-    fn drop(&mut self) {
-        let handles = self.handles.borrow();
-        self.metrics
-            .mark_external_deallocation(handles.iter().map(|s| s.root_size).sum());
-        self.metrics
-            .mark_external_deallocation(size_of_handle_list(&self.handles.borrow()));
-    }
+    slots: Rc<RefCell<Slots<'gc>>>,
 }
 
 unsafe impl<'gc> Collect for Inner<'gc> {
     fn trace(&self, cc: &crate::Collection) {
-        // SAFETY: We do not adopt any new pointers so we don't need a write barrier.
-        // We cheat horribly and filter out dead handles during tracing. Since we have to go
-        // through the entire list of roots anyway, this is cheaper than filtering on e.g.
-        // stashing new roots.
-        let handles = unsafe { self.handles.as_ref_cell() };
-        handles.borrow_mut().retain(|store| {
-            if let Some(handle) = store.handle.upgrade() {
-                handle.root.trace(cc);
-                true
-            } else {
-                cc.metrics().mark_external_deallocation(store.root_size);
-                false
-            }
-        });
+        let slots = self.slots.borrow();
+        slots.trace(cc);
     }
 }
 
-struct Handle<T: ?Sized> {
-    // Store a clone of `Rc<SetId>` so that we ensure the `Rc<SetId>` lives as long as any extant
-    // handle.
-    set_id: Rc<SetId>,
-    root: T,
+type Slot<'gc> = (Option<Gc<'gc, dyn Collect + 'gc>>, usize);
+type Index = usize;
+
+struct Slots<'gc> {
+    metrics: Metrics,
+    slots: Vec<Slot<'gc>>,
+    free_slots: Vec<Index>,
+}
+
+impl<'gc> Drop for Slots<'gc> {
+    fn drop(&mut self) {
+        self.metrics
+            .mark_external_deallocation(self.slots.capacity() * mem::size_of::<Slot>());
+        self.metrics
+            .mark_external_deallocation(self.free_slots.capacity() * mem::size_of::<Index>());
+    }
+}
+
+unsafe impl<'gc> Collect for Slots<'gc> {
+    fn trace(&self, cc: &crate::Collection) {
+        self.slots.trace(cc);
+    }
+}
+
+impl<'gc> Slots<'gc> {
+    fn new(metrics: Metrics) -> Self {
+        Self {
+            metrics,
+            slots: Vec::new(),
+            free_slots: Vec::new(),
+        }
+    }
+
+    fn add(&mut self, p: Gc<'gc, dyn Collect + 'gc>) -> Index {
+        let idx = if let Some(free) = self.free_slots.pop() {
+            free
+        } else {
+            let idx = self.slots.len();
+
+            let old_capacity = self.slots.capacity();
+            self.slots.push((None, 0));
+            let new_capacity = self.slots.capacity();
+
+            debug_assert!(new_capacity >= old_capacity);
+            if new_capacity > old_capacity {
+                self.metrics.mark_external_allocation(
+                    (new_capacity - old_capacity) * mem::size_of::<Slot>(),
+                );
+            }
+
+            idx
+        };
+
+        let slot = &mut self.slots[idx];
+        debug_assert!(slot.0.is_none());
+        // The refcount starts at 0. A refcount of 0 and a set ptr implies that there is *one* live
+        // reference.
+        *slot = (Some(p), 0);
+
+        idx
+    }
+
+    fn inc(&mut self, idx: Index) {
+        let slot = &mut self.slots[idx];
+        slot.1 = slot
+            .1
+            .checked_add(1)
+            .expect("DynamicRoot refcount overflow!");
+    }
+
+    fn dec(&mut self, idx: Index) {
+        let slot = &mut self.slots[idx];
+        if slot.1 == 0 {
+            debug_assert!(slot.0.is_some());
+            slot.0 = None;
+
+            let old_capacity = self.slots.capacity();
+            self.free_slots.push(idx);
+            let new_capacity = self.slots.capacity();
+
+            debug_assert!(new_capacity >= old_capacity);
+            if new_capacity > old_capacity {
+                self.metrics.mark_external_allocation(
+                    (new_capacity - old_capacity) * mem::size_of::<Index>(),
+                );
+            }
+        } else {
+            slot.1 = slot.1 - 1;
+        }
+    }
 }


### PR DESCRIPTION
Downsides:

1) Stashed values must be `Gc<'gc, T>`, which is less flexible.
2) `DynamicRoot` types are larger, 2 pointers and a usize instead of 1 pointer.

Upsides:

1) Amortized allocation. Dropping and recreating a `DynamicRoot` does not allocate. Previously, always allocated an `Rc` *and* pushed to an internal `Vec`, now only pushes to an internal `Vec`.
2) Single allocation block. All reference counts and root pointers kept in a single `Vec`.
3) No double indirection during `DynamicRootSet::fetch`. `DynamicRootSet::fetch` now checks one pointer field for equality (the `slots` field) and returns another pointer field (the `root` field) without dereferencing anything.
4) Not really any more complicated, and handling the allocation metrics is much simpler.