### PR TITLE
Remove `Collect + Sized` on `Rootable::Root` type.

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -13,7 +13,7 @@ use crate::{
 /// In order to use an implementation of this trait in an [`Arena`], it must implement
 /// `Rootable<'a>` for *any* possible `'a`. This is necessary so that the `Root` types can be
 /// branded by the unique, invariant lifetimes that makes an `Arena` sound.
-pub trait Rootable<'a>: 'static {
+pub trait Rootable<'a> {
     type Root: ?Sized + 'a;
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -229,7 +229,7 @@ impl Context {
     // reachable from the given root object.
     //
     // If we are currently in `Phase::Sleep`, this will transition the collector to `Phase::Mark`.
-    pub(crate) unsafe fn do_collection<R: Collect>(
+    pub(crate) unsafe fn do_collection<R: Collect + ?Sized>(
         &self,
         root: &R,
         target_debt: f64,
@@ -238,7 +238,7 @@ impl Context {
         self.do_collection_inner(root, target_debt, early_stop)
     }
 
-    fn do_collection_inner<R: Collect>(
+    fn do_collection_inner<R: Collect + ?Sized>(
         &self,
         root: &R,
         mut target_debt: f64,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -394,7 +394,7 @@ fn test_dynamic_roots() {
     let rc_a = Rc::new(12);
     let rc_b = Rc::new("hello".to_owned());
 
-    let mut arena: Arena<Rootable![DynamicRootSet<'_>]> = Arena::new(|mc| DynamicRootSet::new(mc));
+    let mut arena = Arena::<Rootable![DynamicRootSet<'_>]>::new(|mc| DynamicRootSet::new(mc));
 
     let root_a = arena
         .mutate(|mc, root_set| root_set.stash::<Rootable![Rc<i32>]>(mc, Gc::new(mc, rc_a.clone())));
@@ -456,9 +456,8 @@ fn test_dynamic_roots() {
 #[test]
 #[should_panic]
 fn test_dynamic_bad_set() {
-    let arena1: Arena<Rootable![DynamicRootSet<'_>]> = Arena::new(|mc| DynamicRootSet::new(mc));
-
-    let arena2: Arena<Rootable![DynamicRootSet<'_>]> = Arena::new(|mc| DynamicRootSet::new(mc));
+    let arena1 = Arena::<Rootable![DynamicRootSet<'_>]>::new(|mc| DynamicRootSet::new(mc));
+    let arena2 = Arena::<Rootable![DynamicRootSet<'_>]>::new(|mc| DynamicRootSet::new(mc));
 
     let dyn_root = arena1.mutate(|mc, root| root.stash::<Rootable![i32]>(mc, Gc::new(mc, 44)));
 


### PR DESCRIPTION
Since we are using `Gc` pointers for `DynamicRootSet` again, we need to relax the way the `Rootable` macro works so that it can work for `Gc<dyn Trait>` and `Gc` pointers which have been cast to other types.

This is a breaking change (ofc), but hopefully it should not cause too much churn?

We could add a trait alias for `Sized + Collect` Root types to make things much easier, but I think the only way to have an actually *helpful* trait alias is to use the very recently stable [associated type bounds](https://github.com/rust-lang/rust/pull/122055/).

I think it's probably just not a big deal unless you do deep tricks with `Rootable` (like `piccolo`'s `Any`).

This also removes the `'static` bound on `Rootable` because absolutely nothing was using it (`piccolo` does, but it can add it itself).