### PR TITLE
Provide a few nice convenience methods on Gc

### DIFF
--- a/src/static_collect.rs
+++ b/src/static_collect.rs
@@ -1,4 +1,5 @@
 use crate::collect::Collect;
+use crate::Rootable;
 
 use alloc::borrow::{Borrow, BorrowMut};
 use core::convert::{AsMut, AsRef};
@@ -9,6 +10,10 @@ use core::ops::{Deref, DerefMut};
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
 #[repr(transparent)]
 pub struct StaticCollect<T>(pub T);
+
+impl<'a, T: 'static> Rootable<'a> for StaticCollect<T> {
+    type Root = StaticCollect<T>;
+}
 
 unsafe impl<T: 'static> Collect for StaticCollect<T> {
     #[inline]


### PR DESCRIPTION
Adds `Gc::new_static` and `Gc::erase`.

`Gc::new_static` allows for creating a Gc from any 'static type without bothering with a `Collect` impl. Uses the transparent `StaticCollect` wrapper internally to provide an empty `Collect` impl and casts the resulting pointer.

`Gc::erase` is simply a safe version of `Gc::cast` that casts to `()`, which we know is always safe.

As a drive-by change, also provides a `for<'a> Rootable<'a>` impl for `StaticCollect`, since it's easy to do and sometimes useful (there is an identical type in `piccolo` that exists only because the impl didn't exist on `StaticCollect`)