### PR TITLE
Simplest possible forward write barriers.

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -10,6 +10,7 @@ use crate::{
     collect::Collect,
     metrics::Metrics,
     types::{GcBox, GcBoxHeader, GcBoxInner, GcColor, Invariant},
+    Gc,
 };
 
 /// Handle value given by arena callbacks during construction and mutation. Allows allocating new
@@ -26,14 +27,48 @@ impl<'gc> Mutation<'gc> {
         self.context.metrics()
     }
 
+    /// IF we are in the marking phase AND the `parent` pointer is colored black AND the `child` (if
+    /// given) is colored white, then change the `parent` color to gray and enqueue it for tracing.
+    ///
+    /// This operation is known as a "backwards write barrier". Calling this method is one of the
+    /// safe ways for the value in the `parent` pointer to use internal mutability to adopt the
+    /// `child` pointer without invalidating the color invariant.
+    ///
+    /// If the `child` parameter is given, then calling this method ensures that the `parent`
+    /// pointer may safely adopt the `child` pointer. If no `child` is given, then calling this
+    /// method is more general, and it ensures that the `parent` pointer may adopt *any* child
+    /// pointer(s) before collection is next triggered.
     #[inline]
-    pub(crate) fn allocate<T: 'gc + Collect>(&self, t: T) -> NonNull<GcBoxInner<T>> {
-        self.context.allocate(t)
+    pub fn backward_barrier(&self, parent: Gc<'gc, ()>, child: Option<Gc<'gc, ()>>) {
+        self.context.backward_barrier(
+            unsafe { GcBox::erase(parent.ptr) },
+            child.map(|p| unsafe { GcBox::erase(p.ptr) }),
+        )
+    }
+
+    /// IF we are in the marking phase AND the `parent` pointer (if given) is colored black, AND
+    /// the `child` is colored white, then immediately change the `child` to gray and enqueue it
+    /// for tracing.
+    ///
+    /// This operation is known as a "forwards write barrier". Calling this method is one of the
+    /// safe ways for the value in the `parent` pointer to use internal mutability to adopt the
+    /// `child` pointer without invalidating the color invariant.
+    ///
+    /// If the `parent` parameter is given, then calling this method ensures that the `parent`
+    /// pointer may safely adopt the `child` pointer. If no `parent` is given, then calling this
+    /// method is more general, and it ensures that the `child` pointer may be adopted by *any*
+    /// parent pointer(s) before collection is next triggered.
+    #[inline]
+    pub fn forward_barrier(&self, parent: Option<Gc<'gc, ()>>, child: Gc<'gc, ()>) {
+        self.context
+            .forward_barrier(parent.map(|p| unsafe { GcBox::erase(p.ptr) }), unsafe {
+                GcBox::erase(child.ptr)
+            })
     }
 
     #[inline]
-    pub(crate) fn write_barrier(&self, gc_box: GcBox) {
-        self.context.write_barrier(gc_box)
+    pub(crate) fn allocate<T: Collect + 'gc>(&self, t: T) -> NonNull<GcBoxInner<T>> {
+        self.context.allocate(t)
     }
 
     #[inline]
@@ -428,22 +463,46 @@ impl Context {
     }
 
     #[inline]
-    fn write_barrier(&self, gc_box: GcBox) {
+    fn backward_barrier(&self, parent: GcBox, child: Option<GcBox>) {
         // During the propagating phase, if we are mutating a black object, we may add a white
         // object to it and invalidate the invariant that black objects may not point to white
-        // objects. Turn black obejcts to gray to prevent this.
-        let header = gc_box.header();
-        if self.phase.get() == Phase::Mark && header.color() == GcColor::Black {
-            header.set_color(GcColor::Gray);
-
-            // Outline the actual enqueueing code (which is somewhat expensive and won't be
-            // executed often) to promote the inlining of the write barrier.
+        // objects. Turn the black parent object gray to prevent this.
+        if self.phase.get() == Phase::Mark
+            && parent.header().color() == GcColor::Black
+            && child
+                .map(|c| matches!(c.header().color(), GcColor::White | GcColor::WhiteWeak))
+                .unwrap_or(true)
+        {
+            // Outline the actual barrier code (which is somewhat expensive and won't be executed
+            // often) to promote the inlining of the write barrier.
             #[cold]
-            fn enqueue(this: &Context, gc_box: GcBox) {
-                this.gray_again.borrow_mut().push(gc_box);
+            fn barrier(this: &Context, parent: GcBox) {
+                parent.header().set_color(GcColor::Gray);
+                this.gray_again.borrow_mut().push(parent);
             }
+            barrier(&self, parent);
+        }
+    }
 
-            enqueue(&self, gc_box);
+    #[inline]
+    fn forward_barrier(&self, parent: Option<GcBox>, child: GcBox) {
+        // During the propagating phase, if we are mutating a black object, we may add a white
+        // object to it and invalidate the invariant that black objects may not point to white
+        // objects. Immediately trace the child white object to turn it gray (or black) to prevent
+        // this.
+        if self.phase.get() == Phase::Mark
+            && parent
+                .map(|p| p.header().color() == GcColor::Black)
+                .unwrap_or(true)
+            && matches!(child.header().color(), GcColor::White | GcColor::WhiteWeak)
+        {
+            // Outline the actual barrier code (which is somewhat expensive and won't be executed
+            // often) to promote the inlining of the write barrier.
+            #[cold]
+            fn barrier(this: &Context, child: GcBox) {
+                this.trace(child);
+            }
+            barrier(&self, child);
         }
     }
 

--- a/src/dynamic_roots.rs
+++ b/src/dynamic_roots.rs
@@ -52,7 +52,7 @@ impl<'gc> DynamicRootSet<'gc> {
         root: Gc<'gc, Root<'gc, R>>,
     ) -> DynamicRoot<R> {
         // SAFETY: We are adopting a new `Gc` pointer, so we must invoke a write barrier.
-        Gc::write(mc, self.0);
+        mc.backward_barrier(Gc::erase(self.0), Some(Gc::erase(root)));
 
         let mut slots = self.0.slots.borrow_mut();
         let index = slots.add(unsafe { Gc::cast(root) });


### PR DESCRIPTION
This has some additional drive-by cleanup to make things more
consistent. It adds two methods to `Mutation`, one for backwards write
barriers (previously the only kind) and one for forward write barriers.

Both backwards and forward write barriers are changed to take one or
optionally two pointers: the parent and the adopted child. If both
pointers are given, then the barriers check if the parent is black and
the child is white, and if so, invoke the barrier. The backwards write
barrier will turn the parent gray, and the forwards write barrier will
turn the child gray.

If the backwards write barrier is only given the parent pointer, then it
unconditionally turns it gray if it was black, allowing it to adopt any
pointers at all. If the forwards write barrier is only given the child
pointer, then it unconditionally turns it gray if it was white, allowing
it to be adopted by any possible pointer.

This is based on #103 because it requires `Gc::erase` to be less obnoxious to use.