### PR TITLE
API compatibility breaks

### DIFF
--- a/examples/linked_list.rs
+++ b/examples/linked_list.rs
@@ -1,4 +1,4 @@
-use gc_arena::{lock::RefLock, Arena, Collect, Gc, Mutation, Rootable};
+use gc_arena::{Arena, Collect, Gc, Mutation, RefLock, Rootable};
 
 // We define a node of a doubly-linked list data structure.
 //

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -380,10 +380,14 @@ where
     }
 }
 
-/// Create a temporary arena without a root object and perform the given operation on it. No garbage
-/// collection will be done until the very end of the call, at which point all allocations will
-/// be collected.
-pub fn rootless_arena<F, R>(f: F) -> R
+/// Create a temporary arena without a root object and perform the given operation on it.
+///
+/// No garbage collection will be done until the very end of the call, at which point all
+/// allocations will be collected.
+///
+/// This is a convenience function that makes it a little easier to quickly test code that uses
+/// `gc-arena`, it is not very useful on its own.
+pub fn rootless_mutate<F, R>(f: F) -> R
 where
     F: for<'gc> FnOnce(&'gc Mutation<'gc>) -> R,
 {

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -54,13 +54,13 @@ impl<'a, T: ?Sized + Rootable<'a>> Rootable<'a> for __DynRootable<T> {
 /// parameters, though in complex cases it may be better to implement `Rootable` directly.
 ///
 /// ```
-/// # use gc_arena::{Arena, Collect, Gc, Rootable, StaticCollect};
+/// # use gc_arena::{Arena, Collect, Gc, Rootable};
 /// #
 /// # fn main() {
 /// #[derive(Collect)]
 /// #[collect(no_drop)]
-/// struct MyGenericRoot<'gc, T: 'static> {
-///     ptr: Gc<'gc, StaticCollect<T>>,
+/// struct MyGenericRoot<'gc, T> {
+///     ptr: Gc<'gc, T>,
 /// }
 ///
 /// type MyGenericArena<T> = Arena<Rootable![MyGenericRoot<'_, T>]>;
@@ -90,10 +90,9 @@ pub enum CollectionPhase {
     /// The arena has finished tracing, all reachable objects are marked. This may transition
     /// back to `Marking` if write barriers occur.
     Marked,
-    /// The arena has determined a set of unreachable objects and has started collecting them.
-    /// At this point, marking is no longer taking place so the root may have reachable, unmarked
-    /// pointers
-    Collecting,
+    /// The arena has determined a set of unreachable objects and has started freeing them. At this
+    /// point, marking is no longer taking place so the root may have reachable, unmarked pointers.
+    Sweeping,
 }
 
 /// A generic, garbage collected arena.
@@ -253,7 +252,7 @@ where
                     CollectionPhase::Marked
                 }
             }
-            Phase::Sweep => CollectionPhase::Collecting,
+            Phase::Sweep => CollectionPhase::Sweeping,
             Phase::Sleep => CollectionPhase::Sleeping,
             Phase::Drop => unreachable!(),
         }
@@ -271,7 +270,7 @@ where
     /// when the allocation debt is above some threshold.
     ///
     /// This method will always return at least once when collection enters the `Sleeping` phase,
-    /// i.e. it will never transition from the `Collecting` phase to the `Marking` phase without
+    /// i.e. it will never transition from the `Sweeping` phase to the `Marking` phase without
     /// returning in-between.
     #[inline]
     pub fn collect_debt(&mut self) {
@@ -284,7 +283,7 @@ where
     /// <= 0.0.
     ///
     /// This does *not* transition collection past the `Marked` phase. Does nothing if the
-    /// collection phase is `Marked` or `Collecting`, otherwise acts like `Arena::collect_debt`.
+    /// collection phase is `Marked` or `Sweeping`, otherwise acts like `Arena::collect_debt`.
     #[inline]
     pub fn mark_debt(&mut self) -> Option<MarkedArena<'_, R>> {
         if matches!(self.context.phase(), Phase::Mark | Phase::Sleep) {
@@ -317,7 +316,7 @@ where
     ///
     /// Similarly to `Arena::mark_debt`, this does not transition collection  past the `Marked`
     /// phase, and does nothing if the collector is currently in the `Marked` phase or the
-    /// `Collecting` phase.
+    /// `Sweeping` phase.
     #[inline]
     pub fn mark_all(&mut self) -> Option<MarkedArena<'_, R>> {
         if matches!(self.context.phase(), Phase::Mark | Phase::Sleep) {
@@ -366,8 +365,8 @@ where
         }
     }
 
-    /// Immediately transition the arena out of `CollectionPhase::Marked` to
-    /// `CollectionPhase::Collecting`.
+    /// Immediately transition the arena out of [`CollectionPhase::Marked`] to
+    /// [`CollectionPhase::Sweeping`].
     #[inline]
     pub fn start_collecting(self) {
         unsafe {

--- a/src/collect_impl.rs
+++ b/src/collect_impl.rs
@@ -12,20 +12,6 @@ use std::collections::{HashMap, HashSet};
 use crate::collect::Collect;
 use crate::context::Collection;
 
-/// If a type will never hold `Gc` pointers, you can use this macro to provide a simple empty
-/// `Collect` implementation.
-#[macro_export]
-macro_rules! unsafe_empty_collect {
-    ($type:ty) => {
-        unsafe impl Collect for $type {
-            #[inline]
-            fn needs_trace() -> bool {
-                false
-            }
-        }
-    };
-}
-
 /// If a type is static, we know that it can never hold `Gc` pointers, so it is safe to provide a
 /// simple empty `Collect` implementation.
 #[macro_export]

--- a/src/dynamic_roots.rs
+++ b/src/dynamic_roots.rs
@@ -5,7 +5,7 @@ use alloc::{
     vec::Vec,
 };
 
-use crate::{metrics::Metrics, Collect, Gc, Mutation, Root, Rootable};
+use crate::{arena::Root, metrics::Metrics, Collect, Gc, Mutation, Rootable};
 
 /// A way of registering GC roots dynamically.
 ///

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -12,7 +12,7 @@ use crate::{
     collect::Collect,
     context::{Collection, Mutation},
     gc_weak::GcWeak,
-    static_collect::StaticCollect,
+    static_collect::Static,
     types::{GcBox, GcBoxHeader, GcBoxInner, GcColor, Invariant},
     Finalization,
 };
@@ -92,25 +92,25 @@ impl<'gc, T: Collect + 'gc> Gc<'gc, T> {
 impl<'gc, T: 'static> Gc<'gc, T> {
     /// Create a new `Gc` pointer from a static value.
     ///
-    /// This method does not require that the type `T` implement `Collect`. This uses
-    /// `StaticCollect` internally to automatically provide a trivial `Collect` impl and is
-    /// equivalent to the following code:
+    /// This method does not require that the type `T` implement `Collect`. This uses [`Static`]
+    /// internally to automatically provide a trivial `Collect` impl and is equivalent to the
+    /// following code:
     ///
     /// ```rust
-    /// # use gc_arena::{Gc, StaticCollect};
+    /// # use gc_arena::{Gc, Static};
     /// # fn main() {
     /// # gc_arena::rootless_arena(|mc| {
     /// struct MyStaticStruct;
-    /// let p = Gc::new(mc, StaticCollect(MyStaticStruct));
-    /// // This is allowed because `StaticCollect` is `#[repr(transparent)]`
+    /// let p = Gc::new(mc, Static(MyStaticStruct));
+    /// // This is allowed because `Static` is `#[repr(transparent)]`
     /// let p: Gc<MyStaticStruct> = unsafe { Gc::cast(p) };
     /// # });
     /// # }
     /// ```
     #[inline]
     pub fn new_static(mc: &Mutation<'gc>, t: T) -> Gc<'gc, T> {
-        let p = Gc::new(mc, StaticCollect(t));
-        // SAFETY: `StaticCollect` is `#[repr(transparent)]`.
+        let p = Gc::new(mc, Static(t));
+        // SAFETY: `Static` is `#[repr(transparent)]`.
         unsafe { Gc::cast::<T>(p) }
     }
 }

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -99,7 +99,7 @@ impl<'gc, T: 'static> Gc<'gc, T> {
     /// ```rust
     /// # use gc_arena::{Gc, Static};
     /// # fn main() {
-    /// # gc_arena::rootless_arena(|mc| {
+    /// # gc_arena::arena::rootless_mutate(|mc| {
     /// struct MyStaticStruct;
     /// let p = Gc::new(mc, Static(MyStaticStruct));
     /// // This is allowed because `Static` is `#[repr(transparent)]`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,5 +40,5 @@ pub use self::{
     dynamic_roots::{DynamicRoot, DynamicRootSet, MismatchedRootSet},
     gc::Gc,
     gc_weak::GcWeak,
-    static_collect::StaticCollect,
+    static_collect::Static,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub mod barrier;
 mod collect;
 mod collect_impl;
 mod context;
-mod dynamic_roots;
+pub mod dynamic_roots;
 mod gc;
 mod gc_weak;
 pub mod lock;
@@ -34,11 +34,12 @@ pub use gc_arena_derive::*;
 pub use self::{arena::__DynRootable, no_drop::__MustNotImplDrop, unsize::__CoercePtrInternal};
 
 pub use self::{
-    arena::{rootless_arena, Arena, CollectionPhase, Root, Rootable},
+    arena::{Arena, Rootable},
     collect::Collect,
     context::{Collection, Finalization, Mutation},
-    dynamic_roots::{DynamicRoot, DynamicRootSet, MismatchedRootSet},
+    dynamic_roots::{DynamicRoot, DynamicRootSet},
     gc::Gc,
     gc_weak::GcWeak,
+    lock::{GcLock, GcRefLock, Lock, RefLock},
     static_collect::Static,
 };

--- a/src/static_collect.rs
+++ b/src/static_collect.rs
@@ -9,57 +9,57 @@ use core::ops::{Deref, DerefMut};
 /// generic contexts
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
 #[repr(transparent)]
-pub struct StaticCollect<T: ?Sized>(pub T);
+pub struct Static<T: ?Sized>(pub T);
 
-impl<'a, T: ?Sized + 'static> Rootable<'a> for StaticCollect<T> {
-    type Root = StaticCollect<T>;
+impl<'a, T: ?Sized + 'static> Rootable<'a> for Static<T> {
+    type Root = Static<T>;
 }
 
-unsafe impl<T: ?Sized + 'static> Collect for StaticCollect<T> {
+unsafe impl<T: ?Sized + 'static> Collect for Static<T> {
     #[inline]
     fn needs_trace() -> bool {
         false
     }
 }
 
-impl<T> From<T> for StaticCollect<T> {
+impl<T> From<T> for Static<T> {
     fn from(value: T) -> Self {
         Self(value)
     }
 }
 
-impl<T: ?Sized> AsRef<T> for StaticCollect<T> {
+impl<T: ?Sized> AsRef<T> for Static<T> {
     fn as_ref(&self) -> &T {
         &self.0
     }
 }
 
-impl<T: ?Sized> AsMut<T> for StaticCollect<T> {
+impl<T: ?Sized> AsMut<T> for Static<T> {
     fn as_mut(&mut self) -> &mut T {
         &mut self.0
     }
 }
 
-impl<T: ?Sized> Deref for StaticCollect<T> {
+impl<T: ?Sized> Deref for Static<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<T: ?Sized> DerefMut for StaticCollect<T> {
+impl<T: ?Sized> DerefMut for Static<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl<T: ?Sized> Borrow<T> for StaticCollect<T> {
+impl<T: ?Sized> Borrow<T> for Static<T> {
     fn borrow(&self) -> &T {
         &self.0
     }
 }
 
-impl<T: ?Sized> BorrowMut<T> for StaticCollect<T> {
+impl<T: ?Sized> BorrowMut<T> for Static<T> {
     fn borrow_mut(&mut self) -> &mut T {
         &mut self.0
     }

--- a/src/unsize.rs
+++ b/src/unsize.rs
@@ -16,7 +16,7 @@ use crate::{
 /// # use std::fmt::Display;
 /// # use gc_arena::{Gc, unsize};
 /// # fn main() {
-/// # gc_arena::rootless_arena(|mc| {
+/// # gc_arena::arena::rootless_mutate(|mc| {
 /// // Unsizing arrays to slices.
 /// let mut slice;
 /// slice = unsize!(Gc::new(mc, [1, 2]) => [u8]);
@@ -40,7 +40,7 @@ use crate::{
 /// # use std::error::Error;
 /// # use gc_arena::{Gc, unsize};
 /// # fn main() {
-/// # gc_arena::rootless_arena(|mc| {
+/// # gc_arena::arena::rootless_mutate(|mc| {
 /// // Error: `Option<char>` doesn't implement `Error`.
 /// let _ = unsize!(Gc::new(mc, Some('💥')) => dyn Error);
 /// # })

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -5,7 +5,7 @@ use rand::distributions::Distribution;
 use std::{collections::HashMap, rc::Rc};
 
 use gc_arena::{
-    lock::RefLock, metrics::Pacing, unsafe_empty_collect, unsize, Arena, Collect, CollectionPhase,
+    lock::RefLock, metrics::Pacing, static_collect, unsize, Arena, Collect, CollectionPhase,
     DynamicRootSet, Gc, GcWeak, Rootable,
 };
 
@@ -74,7 +74,7 @@ fn weak_allocation() {
 fn dyn_sized_allocation() {
     #[derive(Clone)]
     struct RefCounter(Rc<()>);
-    unsafe_empty_collect!(RefCounter);
+    static_collect!(RefCounter);
 
     #[derive(Collect)]
     #[collect(no_drop)]
@@ -112,7 +112,7 @@ fn dyn_sized_allocation() {
 fn repeated_allocation_deallocation() {
     #[derive(Clone)]
     struct RefCounter(Rc<()>);
-    unsafe_empty_collect!(RefCounter);
+    static_collect!(RefCounter);
 
     #[derive(Collect)]
     #[collect(no_drop)]
@@ -159,7 +159,7 @@ fn repeated_allocation_deallocation() {
 fn all_dropped() {
     #[derive(Clone)]
     struct RefCounter(Rc<()>);
-    unsafe_empty_collect!(RefCounter);
+    static_collect!(RefCounter);
 
     #[derive(Collect)]
     #[collect(no_drop)]
@@ -184,7 +184,7 @@ fn all_dropped() {
 fn all_garbage_collected() {
     #[derive(Clone)]
     struct RefCounter(Rc<()>);
-    unsafe_empty_collect!(RefCounter);
+    static_collect!(RefCounter);
 
     #[derive(Collect)]
     #[collect(no_drop)]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -964,26 +964,25 @@ fn test_phases() {
         });
 
         if let Some(marked) = arena.mark_debt() {
-            // Manually transition to the Collecting phase.
+            // Manually transition to the Sweeping phase.
             marked.start_collecting();
-            assert!(arena.collection_phase() == CollectionPhase::Collecting);
+            assert!(arena.collection_phase() == CollectionPhase::Sweeping);
             break;
         }
     }
 
-    if arena.collection_phase() == CollectionPhase::Collecting {
-        // Assert that mark_debt() and mark_all() do nothing while in the Collecting phase.
+    if arena.collection_phase() == CollectionPhase::Sweeping {
+        // Assert that mark_debt() and mark_all() do nothing while in the Sweeping phase.
         assert!(arena.mark_debt().is_none());
         assert!(arena.mark_all().is_none());
     }
 
-    while arena.collection_phase() == CollectionPhase::Collecting {
+    while arena.collection_phase() == CollectionPhase::Sweeping {
         // Keep accumulating debt to keep the collector moving.
         arena.mutate(|mc, _| {
             Gc::new(mc, 0);
         });
-        // This should not move from Collecting to Marking in one call, it must pass through
-        // Sleeping.
+        // This should not move from Sweeping to Marking in one call, it must pass through Sleeping.
         arena.collect_debt();
     }
 


### PR DESCRIPTION
* Renames `CollectionPhase::Collecting` -> `CollectionPhase::Sweeping`
* Renames `StaticCollect` -> `Static`