### PR TITLE
`Collect` trait breaking changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/rust:1.77.2
+      - image: cimg/rust:1.79.0
     steps:
       - checkout
       - run:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ allocator-api2 = ["dep:allocator-api2", "hashbrown?/allocator-api2"]
 [dependencies]
 allocator-api2 = { version = "0.2", optional = true, default-features = false, features = ["alloc"] }
 gc-arena-derive = { path = "./derive", version = "0.5.3"}
-hashbrown = { version = "0.14", optional = true, default-features = false }
+hashbrown = { version = "0.14.2", optional = true, default-features = false }
 sptr = "0.3.2"
 tracing = { version = "0.1.37", optional = true, default-features = false }
 

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -163,7 +163,7 @@ where
 
     #[inline]
     pub fn map_root<R2>(
-        self,
+        mut self,
         f: impl for<'gc> FnOnce(&'gc Mutation<'gc>, Root<'gc, R>) -> Root<'gc, R2>,
     ) -> Arena<R2>
     where
@@ -183,7 +183,7 @@ where
 
     #[inline]
     pub fn try_map_root<R2, E>(
-        self,
+        mut self,
         f: impl for<'gc> FnOnce(&'gc Mutation<'gc>, Root<'gc, R>) -> Result<Root<'gc, R2>, E>,
     ) -> Result<Arena<R2>, E>
     where

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -21,19 +21,15 @@ use crate::context::Collection;
 /// while ensuring that the write barrier is always executed.
 pub unsafe trait Collect {
     /// As an optimization, if this type can never hold a `Gc` pointer and `trace` is unnecessary
-    /// to call, you may implement this method and return false. The default implementation returns
-    /// true, signaling that `Collect::trace` must be called.
-    #[inline]
-    fn needs_trace() -> bool
-    where
-        Self: Sized,
-    {
-        true
-    }
+    /// to call, you may set this to `false`. The default value is `true`, signaling that
+    /// `Collect::trace` must be called.
+    const NEEDS_TRACE: bool = true;
 
-    /// *Must* call `Collect::trace` on all held `Gc` pointers. If this type holds inner types that
-    /// implement `Collect`, a valid implementation would simply call `Collect::trace` on all the
-    /// held values to ensure this.
+    /// *Must* call [`Collection::trace_gc`] (resp. [`Collection::trace_gc_weak`]) on all held
+    /// [`Gc`] (resp. [`GcWeak`]) pointers. If this type holds inner types that implement
+    /// `Collect`, a valid implementation would simply call `Collection::trace` on all the held
+    /// values to ensure this.
     #[inline]
-    fn trace(&self, _cc: &Collection) {}
+    #[allow(unused_variables, unused_mut)]
+    fn trace(&self, mut cc: Collection<'_>) {}
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -117,12 +117,14 @@ impl Collection {
     }
 
     #[inline]
-    pub(crate) fn trace(&self, gc_box: GcBox) {
+    pub fn trace_gc(&self, gc: Gc<'_, ()>) {
+        let gc_box = unsafe { GcBox::erase(gc.ptr) };
         self.context.trace(gc_box)
-    }
+    }  
 
     #[inline]
-    pub(crate) fn trace_weak(&self, gc_box: GcBox) {
+    pub fn trace_gc_weak(&self, gc: GcWeak<'_, ()>) {
+        let gc_box = unsafe { GcBox::erase(gc.inner.ptr) };
         self.context.trace_weak(gc_box)
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -10,7 +10,7 @@ use crate::{
     collect::Collect,
     metrics::Metrics,
     types::{GcBox, GcBoxHeader, GcBoxInner, GcColor, Invariant},
-    Gc,
+    Gc, GcWeak,
 };
 
 /// Handle value given by arena callbacks during construction and mutation. Allows allocating new

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,7 +3,7 @@ use core::{
     cell::{Cell, RefCell},
     marker::PhantomData,
     mem,
-    ops::Deref,
+    ops::{ControlFlow, Deref, DerefMut},
     ptr::NonNull,
 };
 
@@ -108,28 +108,28 @@ impl<'gc> Finalization<'gc> {
 /// `Collect::trace` implementations.
 #[repr(transparent)]
 pub struct Collection<'a> {
-    context: &'a Context,
+    mark: &'a mut MarkState,
     _invariant: Invariant<'a>,
 }
 
 impl<'a> Collection<'a> {
     #[inline]
-    fn from_context(context: &'a Context) -> Self {
+    fn from_state(mark: &'a mut MarkState) -> Self {
         Self {
-            context,
+            mark,
             _invariant: PhantomData,
         }
     }
 
     #[inline]
     pub fn metrics(&self) -> &Metrics {
-        self.context.metrics()
+        &self.mark.metrics
     }
 
     #[inline]
     pub fn trace<T: Collect + ?Sized>(&mut self, value: &T) {
         if T::NEEDS_TRACE {
-            let cc = Self { ..*self };
+            let cc = Collection::from_state(self.mark);
             value.trace(cc);
         }
     }
@@ -137,13 +137,13 @@ impl<'a> Collection<'a> {
     #[inline]
     pub fn trace_gc(&mut self, gc: Gc<'_, ()>) {
         let gc_box = unsafe { GcBox::erase(gc.ptr) };
-        self.context.trace(gc_box)
+        self.mark.trace(gc_box)
     }
 
     #[inline]
     pub fn trace_gc_weak(&mut self, gc: GcWeak<'_, ()>) {
         let gc_box = unsafe { GcBox::erase(gc.inner.ptr) };
-        self.context.trace_weak(gc_box)
+        self.mark.trace_weak(gc_box)
     }
 }
 
@@ -163,11 +163,12 @@ pub(crate) enum EarlyStop {
 
 pub(crate) struct Context {
     metrics: Metrics,
-    phase: Cell<Phase>,
+    phase: Phase,
     #[cfg(feature = "tracing")]
     phase_span: Cell<tracing::Span>,
 
-    root_needs_trace: Cell<bool>,
+    // The queues used during marking.
+    mark: RefCell<MarkState>,
 
     // A linked list of all allocated `GcBox`es.
     all: Cell<Option<GcBox>>,
@@ -183,15 +184,23 @@ pub(crate) struct Context {
     // When we free objects, we update this `GcBox.next` to remove them from
     // the linked list.
     sweep_prev: Cell<Option<GcBox>>,
+}
+
+struct MarkState {
+    // Duplicated so that `Collection` can access it.
+    metrics: Metrics,
+
+    /// Does the root needs to be traced?
+    /// This should be `true` at the beginning of `Phase::Mark`.
+    root_needs_trace: bool,
 
     /// A queue of gray objects, used during `Phase::Mark`.
     /// This holds traceable objects that have yet to be traced.
-    /// When we enter `Phase::Mark`, we push `root` to this queue.
-    gray: RefCell<Vec<GcBox>>,
+    gray: Vec<GcBox>,
 
     // A queue of gray objects that became gray as a result
     // of a write barrier.
-    gray_again: RefCell<Vec<GcBox>>,
+    gray_again: Vec<GcBox>,
 }
 
 impl Drop for Context {
@@ -213,8 +222,8 @@ impl Drop for Context {
             }
         }
 
-        let _guard = PhaseGuard::enter(&self, Some(Phase::Drop));
-        DropAll(&self.metrics, self.all.get());
+        let cx = PhaseGuard::enter(self, Some(Phase::Drop));
+        DropAll(&cx.metrics, cx.all.get());
     }
 }
 
@@ -222,16 +231,14 @@ impl Context {
     pub(crate) unsafe fn new() -> Context {
         let metrics = Metrics::new();
         Context {
-            phase: Cell::new(Phase::Sleep),
+            phase: Phase::Sleep,
             #[cfg(feature = "tracing")]
             phase_span: Cell::new(PhaseGuard::span_for(&metrics, Phase::Sleep)),
-            metrics,
-            root_needs_trace: Cell::new(true),
+            metrics: metrics.clone(),
+            mark: RefCell::new(MarkState::new(metrics)),
             all: Cell::new(None),
             sweep: Cell::new(None),
             sweep_prev: Cell::new(None),
-            gray: RefCell::new(Vec::new()),
-            gray_again: RefCell::new(Vec::new()),
         }
     }
 
@@ -251,22 +258,20 @@ impl Context {
     }
 
     #[inline]
-    pub(crate) fn root_barrier(&self) {
-        if self.phase.get() == Phase::Mark {
-            self.root_needs_trace.set(true);
+    pub(crate) fn root_barrier(&mut self) {
+        if self.phase == Phase::Mark {
+            self.mark.get_mut().root_needs_trace = true;
         }
     }
 
     #[inline]
     pub(crate) fn phase(&self) -> Phase {
-        self.phase.get()
+        self.phase
     }
 
     #[inline]
     pub(crate) fn gray_remaining(&self) -> bool {
-        !self.gray.borrow().is_empty()
-            || !self.gray_again.borrow().is_empty()
-            || self.root_needs_trace.get()
+        self.mark.borrow().gray_remaining()
     }
 
     // Do some collection work until either the debt goes down below the target amount or we have
@@ -279,7 +284,7 @@ impl Context {
     //
     // If we are currently in `Phase::Sleep`, this will transition the collector to `Phase::Mark`.
     pub(crate) unsafe fn do_collection<R: Collect + ?Sized>(
-        &self,
+        &mut self,
         root: &R,
         target_debt: f64,
         early_stop: Option<EarlyStop>,
@@ -288,85 +293,38 @@ impl Context {
     }
 
     fn do_collection_inner<R: Collect + ?Sized>(
-        &self,
+        &mut self,
         root: &R,
         mut target_debt: f64,
         early_stop: Option<EarlyStop>,
     ) {
-        let mut entered = PhaseGuard::enter(self, None);
+        let mut cx = PhaseGuard::enter(self, None);
 
-        if !(self.metrics.allocation_debt() > target_debt) {
-            entered.log_progress("GC: paused");
+        if !(cx.metrics.allocation_debt() > target_debt) {
+            cx.log_progress("GC: paused");
             return;
         }
 
         loop {
-            match self.phase.get() {
+            match cx.phase {
                 Phase::Sleep => {
                     // Immediately enter the mark phase; no need to update metrics here.
-                    entered.switch(Phase::Mark);
+                    cx.switch(Phase::Mark);
                     continue;
                 }
                 Phase::Mark => {
-                    // We look for an object first in the normal gray queue, then the "gray again"
-                    // queue. Objects from the normal gray queue count as regular work, but objects
-                    // which are gray a second time have already been counted as work, so we don't
-                    // double count them. Processing "gray again" objects later also gives them more
-                    // time to be mutated again without triggering another write barrier.
-                    let next_gray = if let Some(gc_box) = self.gray.borrow_mut().pop() {
-                        self.metrics.mark_gc_traced(gc_box.header().size_of_box());
-                        Some(gc_box)
-                    } else if let Some(gc_box) = self.gray_again.borrow_mut().pop() {
-                        Some(gc_box)
-                    } else {
-                        None
-                    };
-
-                    if let Some(gc_box) = next_gray {
-                        // If we have an object in the gray queue, take one, trace it, and turn it
-                        // black.
-
-                        // Our `Collect::trace` call may panic, and if it does the object will be
-                        // lost from the gray queue but potentially incompletely traced. By catching
-                        // a panic during `Arena::collect()`, this could lead to memory unsafety.
-                        //
-                        // So, if the `Collect::trace` call panics, we need to add the popped object
-                        // back to the `gray_again` queue. If the panic is caught, this will maybe
-                        // give it some time to not panic before attempting to collect it again, and
-                        // also this doesn't invalidate the collection debt math.
-                        struct DropGuard<'a> {
-                            cx: &'a Context,
-                            gc_box: GcBox,
-                        }
-
-                        impl<'a> Drop for DropGuard<'a> {
-                            fn drop(&mut self) {
-                                self.cx.gray_again.borrow_mut().push(self.gc_box);
-                            }
-                        }
-
-                        let guard = DropGuard { cx: self, gc_box };
-                        debug_assert!(gc_box.header().is_live());
-                        unsafe { gc_box.trace_value(Collection::from_context(self)) }
-                        gc_box.header().set_color(GcColor::Black);
-                        mem::forget(guard);
-                    } else if self.root_needs_trace.get() {
-                        // We treat the root object as gray if `root_needs_trace` is set, and we
-                        // process it at the end of the gray queue for the same reason as the "gray
-                        // again" objects.
-                        root.trace(Collection::from_context(self));
-                        self.root_needs_trace.set(false);
-                    } else {
+                    let ctrl = cx.mark.get_mut().mark_one(root);
+                    if ctrl.is_break() {
                         if early_stop == Some(EarlyStop::BeforeSweep) {
                             target_debt = f64::INFINITY;
                         } else {
                             // If we have no gray objects left, we enter the sweep phase.
-                            entered.switch(Phase::Sweep);
+                            cx.switch(Phase::Sweep);
 
                             // Set `sweep to the current head of our `all` linked list. Any new
                             // allocations during the newly-entered `Phase:Sweep` will update `all`,
                             // but will *not* be reachable from `this.sweep`.
-                            self.sweep.set(self.all.get());
+                            cx.sweep.set(cx.all.get());
 
                             // No need to update metrics here.
                             continue;
@@ -376,74 +334,21 @@ impl Context {
                 Phase::Sweep => {
                     if early_stop == Some(EarlyStop::AfterSweep) {
                         target_debt = f64::INFINITY;
-                    } else if let Some(mut sweep) = self.sweep.get() {
-                        let sweep_header = sweep.header();
-
-                        let next_box = sweep_header.next();
-                        self.sweep.set(next_box);
-
-                        match sweep_header.color() {
-                            // If the next object in the sweep portion of the main list is white, we
-                            // need to remove it from the main object list and destruct it.
-                            GcColor::White => {
-                                if let Some(sweep_prev) = self.sweep_prev.get() {
-                                    sweep_prev.header().set_next(next_box);
-                                } else {
-                                    // If `sweep_prev` is None, then the sweep pointer is also the
-                                    // beginning of the main object list, so we need to adjust it.
-                                    debug_assert_eq!(self.all.get(), Some(sweep));
-                                    self.all.set(next_box);
-                                }
-                                self.metrics.mark_gc_deallocated(sweep_header.size_of_box());
-
-                                // SAFETY: this object is white, and wasn't traced by a `GcWeak`
-                                // during this cycle, meaning it cannot have either strong or weak
-                                // pointers, so we can drop the whole object.
-                                unsafe { free_gc_box(sweep) }
-                            }
-                            // Keep the `GcBox` as part of the linked list if we traced a weak
-                            // pointer to it. The weak pointer still needs access to the `GcBox` to
-                            // be able to check if the object is still alive. We can only deallocate
-                            // the `GcBox`, once there are no weak pointers left.
-                            GcColor::WhiteWeak => {
-                                self.sweep_prev.set(Some(sweep));
-                                sweep_header.set_color(GcColor::White);
-                                if sweep_header.is_live() {
-                                    sweep_header.set_live(false);
-                                    // SAFETY: Since this object is white, that means there are no
-                                    // more strong pointers to this object, only weak pointers, so
-                                    // we can safely drop its contents.
-                                    unsafe { sweep.drop_in_place() }
-                                }
-                            }
-                            // If the next object in the sweep portion of the main list is black, we
-                            // need to keep it but turn it back white.
-                            GcColor::Black => {
-                                self.sweep_prev.set(Some(sweep));
-                                self.metrics.mark_gc_remembered(sweep_header.size_of_box());
-                                sweep_header.set_color(GcColor::White);
-                            }
-                            // No gray objects should be in this part of the main list, they should
-                            // be added to the beginning of the list before the sweep pointer, so it
-                            // should not be possible for us to encounter them here.
-                            GcColor::Gray => {
-                                debug_assert!(false, "unexpected gray object in sweep list")
-                            }
-                        }
-                    } else {
-                        self.sweep_prev.set(None);
-                        self.root_needs_trace.set(true);
-                        entered.switch(Phase::Sleep);
-                        self.metrics.start_cycle();
+                    } else if cx.sweep_one().is_break() {
                         // Collection is done, forcibly exit the loop.
                         target_debt = f64::INFINITY;
+
+                        // Begin a new cycle.
+                        cx.mark.get_mut().root_needs_trace = true;
+                        cx.switch(Phase::Sleep);
+                        cx.metrics.start_cycle();
                     }
                 }
                 Phase::Drop => unreachable!(),
             }
 
-            if !(self.metrics.allocation_debt() > target_debt) {
-                entered.log_progress("GC: yielding...");
+            if !(cx.metrics.allocation_debt() > target_debt) {
+                cx.log_progress("GC: yielding...");
                 return;
             }
         }
@@ -469,7 +374,7 @@ impl Context {
         };
 
         self.all.set(Some(gc_box));
-        if self.phase.get() == Phase::Sweep && self.sweep_prev.get().is_none() {
+        if self.phase == Phase::Sweep && self.sweep_prev.get().is_none() {
             self.sweep_prev.set(self.all.get());
         }
 
@@ -485,7 +390,7 @@ impl Context {
         // NOTE: This also adds the pointer to the gray_again queue even if `header.needs_trace()`
         // is false, but this is not harmful (just wasteful). There's no reason to call a barrier on
         // a pointer that can't adopt other pointers, so we skip the check.
-        if self.phase.get() == Phase::Mark
+        if self.phase == Phase::Mark
             && parent.header().color() == GcColor::Black
             && child
                 .map(|c| matches!(c.header().color(), GcColor::White | GcColor::WhiteWeak))
@@ -496,7 +401,8 @@ impl Context {
             #[cold]
             fn barrier(this: &Context, parent: GcBox) {
                 parent.header().set_color(GcColor::Gray);
-                this.gray_again.borrow_mut().push(parent);
+                let mut mark = this.mark.borrow_mut();
+                mark.gray_again.push(parent);
             }
             barrier(&self, parent);
         }
@@ -507,41 +413,12 @@ impl Context {
         // During the marking phase, if we are mutating a black object, we may add a white object
         // to it and invalidate the invariant that black objects may not point to white objects.
         // Immediately trace the child white object to turn it gray (or black) to prevent this.
-        if self.phase.get() == Phase::Mark
+        if self.phase == Phase::Mark
             && parent
                 .map(|p| p.header().color() == GcColor::Black)
                 .unwrap_or(true)
         {
-            self.trace(child);
-        }
-    }
-
-    #[inline]
-    fn trace(&self, gc_box: GcBox) {
-        let header = gc_box.header();
-        match header.color() {
-            GcColor::Black | GcColor::Gray => {}
-            GcColor::White | GcColor::WhiteWeak => {
-                if header.needs_trace() {
-                    // A white traceable object is not in the gray queue, becomes gray and enters
-                    // the normal gray queue.
-                    header.set_color(GcColor::Gray);
-                    debug_assert!(header.is_live());
-                    self.gray.borrow_mut().push(gc_box);
-                } else {
-                    // A white object that doesn't need tracing simply becomes black.
-                    header.set_color(GcColor::Black);
-                    self.metrics.mark_gc_traced(header.size_of_box());
-                }
-            }
-        }
-    }
-
-    #[inline]
-    fn trace_weak(&self, gc_box: GcBox) {
-        let header = gc_box.header();
-        if header.color() == GcColor::White {
-            header.set_color(GcColor::WhiteWeak);
+            self.mark.borrow_mut().trace(child)
         }
     }
 
@@ -587,7 +464,7 @@ impl Context {
         //   must have been unreachable, which means that the user wouldn't have been able to call
         //   `downgrade`. Therefore, we can safely upgrade, knowing that the object will not be
         //   freed during this phase, despite being white.
-        if self.phase.get() == Phase::Sweep && header.color() == GcColor::WhiteWeak {
+        if self.phase == Phase::Sweep && header.color() == GcColor::WhiteWeak {
             return false;
         }
         true
@@ -596,11 +473,177 @@ impl Context {
     #[inline]
     fn resurrect(&self, gc_box: GcBox) {
         let header = gc_box.header();
-        debug_assert_eq!(self.phase.get(), Phase::Mark);
+        debug_assert_eq!(self.phase, Phase::Mark);
         debug_assert!(header.is_live());
         if matches!(header.color(), GcColor::White | GcColor::WhiteWeak) {
             header.set_color(GcColor::Gray);
-            self.gray.borrow_mut().push(gc_box);
+            let mut mark = self.mark.borrow_mut();
+            mark.gray.push(gc_box);
+        }
+    }
+
+    fn sweep_one(&self) -> ControlFlow<()> {
+        let Some(mut sweep) = self.sweep.get() else {
+            self.sweep_prev.set(None);
+            return ControlFlow::Break(());
+        };
+
+        let sweep_header = sweep.header();
+
+        let next_box = sweep_header.next();
+        self.sweep.set(next_box);
+
+        match sweep_header.color() {
+            // If the next object in the sweep portion of the main list is white, we
+            // need to remove it from the main object list and destruct it.
+            GcColor::White => {
+                if let Some(sweep_prev) = self.sweep_prev.get() {
+                    sweep_prev.header().set_next(next_box);
+                } else {
+                    // If `sweep_prev` is None, then the sweep pointer is also the
+                    // beginning of the main object list, so we need to adjust it.
+                    debug_assert_eq!(self.all.get(), Some(sweep));
+                    self.all.set(next_box);
+                }
+                self.metrics.mark_gc_deallocated(sweep_header.size_of_box());
+
+                // SAFETY: this object is white, and wasn't traced by a `GcWeak`
+                // during this cycle, meaning it cannot have either strong or weak
+                // pointers, so we can drop the whole object.
+                unsafe { free_gc_box(sweep) }
+            }
+            // Keep the `GcBox` as part of the linked list if we traced a weak
+            // pointer to it. The weak pointer still needs access to the `GcBox` to
+            // be able to check if the object is still alive. We can only deallocate
+            // the `GcBox`, once there are no weak pointers left.
+            GcColor::WhiteWeak => {
+                self.sweep_prev.set(Some(sweep));
+                sweep_header.set_color(GcColor::White);
+                if sweep_header.is_live() {
+                    sweep_header.set_live(false);
+                    // SAFETY: Since this object is white, that means there are no
+                    // more strong pointers to this object, only weak pointers, so
+                    // we can safely drop its contents.
+                    unsafe { sweep.drop_in_place() }
+                }
+            }
+            // If the next object in the sweep portion of the main list is black, we
+            // need to keep it but turn it back white.
+            GcColor::Black => {
+                self.sweep_prev.set(Some(sweep));
+                self.metrics.mark_gc_remembered(sweep_header.size_of_box());
+                sweep_header.set_color(GcColor::White);
+            }
+            // No gray objects should be in this part of the main list, they should
+            // be added to the beginning of the list before the sweep pointer, so it
+            // should not be possible for us to encounter them here.
+            GcColor::Gray => {
+                debug_assert!(false, "unexpected gray object in sweep list")
+            }
+        }
+
+        ControlFlow::Continue(())
+    }
+}
+
+impl MarkState {
+    fn new(metrics: Metrics) -> Self {
+        Self {
+            metrics,
+            root_needs_trace: true,
+            gray: Vec::new(),
+            gray_again: Vec::new(),
+        }
+    }
+
+    #[inline]
+    fn gray_remaining(&self) -> bool {
+        !self.gray.is_empty() || !self.gray_again.is_empty() || self.root_needs_trace
+    }
+
+    #[inline]
+    fn trace(&mut self, gc_box: GcBox) {
+        let header = gc_box.header();
+        match header.color() {
+            GcColor::Black | GcColor::Gray => {}
+            GcColor::White | GcColor::WhiteWeak => {
+                if header.needs_trace() {
+                    // A white traceable object is not in the gray queue, becomes gray and enters
+                    // the normal gray queue.
+                    header.set_color(GcColor::Gray);
+                    debug_assert!(header.is_live());
+                    self.gray.push(gc_box);
+                } else {
+                    // A white object that doesn't need tracing simply becomes black.
+                    header.set_color(GcColor::Black);
+                    self.metrics.mark_gc_traced(header.size_of_box());
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn trace_weak(&mut self, gc_box: GcBox) {
+        let header = gc_box.header();
+        if header.color() == GcColor::White {
+            header.set_color(GcColor::WhiteWeak);
+        }
+    }
+
+    fn mark_one<R: Collect + ?Sized>(&mut self, root: &R) -> ControlFlow<()> {
+        // We look for an object first in the normal gray queue, then the "gray again"
+        // queue. Objects from the normal gray queue count as regular work, but objects
+        // which are gray a second time have already been counted as work, so we don't
+        // double count them. Processing "gray again" objects later also gives them more
+        // time to be mutated again without triggering another write barrier.
+        let next_gray = if let Some(gc_box) = self.gray.pop() {
+            self.metrics.mark_gc_traced(gc_box.header().size_of_box());
+            Some(gc_box)
+        } else if let Some(gc_box) = self.gray_again.pop() {
+            Some(gc_box)
+        } else {
+            None
+        };
+
+        if let Some(gc_box) = next_gray {
+            // If we have an object in the gray queue, take one, trace it, and turn it
+            // black.
+
+            // Our `Collect::trace` call may panic, and if it does the object will be
+            // lost from the gray queue but potentially incompletely traced. By catching
+            // a panic during `Arena::collect()`, this could lead to memory unsafety.
+            //
+            // So, if the `Collect::trace` call panics, we need to add the popped object
+            // back to the `gray_again` queue. If the panic is caught, this will maybe
+            // give it some time to not panic before attempting to collect it again, and
+            // also this doesn't invalidate the collection debt math.
+            struct DropGuard<'a> {
+                mark: &'a mut MarkState,
+                gc_box: GcBox,
+            }
+
+            impl<'a> Drop for DropGuard<'a> {
+                fn drop(&mut self) {
+                    self.mark.gray_again.push(self.gc_box);
+                }
+            }
+
+            let guard = DropGuard { mark: self, gc_box };
+            debug_assert!(gc_box.header().is_live());
+            unsafe { gc_box.trace_value(Collection::from_state(guard.mark)) }
+            gc_box.header().set_color(GcColor::Black);
+            mem::forget(guard);
+
+            ControlFlow::Continue(())
+        } else if self.root_needs_trace {
+            // We treat the root object as gray if `root_needs_trace` is set, and we
+            // process it at the end of the gray queue for the same reason as the "gray
+            // again" objects.
+            root.trace(Collection::from_state(self));
+            self.root_needs_trace = false;
+            ControlFlow::Continue(())
+        } else {
+            ControlFlow::Break(())
         }
     }
 }
@@ -616,7 +659,7 @@ unsafe fn free_gc_box<'gc>(mut gc_box: GcBox) {
 
 /// Helper type for managing phase transitions.
 struct PhaseGuard<'a> {
-    cx: &'a Context,
+    cx: &'a mut Context,
     #[cfg(feature = "tracing")]
     span: tracing::span::EnteredSpan,
 }
@@ -631,14 +674,29 @@ impl<'a> Drop for PhaseGuard<'a> {
     }
 }
 
+impl<'a> Deref for PhaseGuard<'a> {
+    type Target = Context;
+
+    #[inline(always)]
+    fn deref(&self) -> &Context {
+        &self.cx
+    }
+}
+
+impl<'a> DerefMut for PhaseGuard<'a> {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut Context {
+        &mut self.cx
+    }
+}
+
 impl<'a> PhaseGuard<'a> {
-    fn enter(cx: &'a Context, phase: Option<Phase>) -> Self {
+    fn enter(cx: &'a mut Context, phase: Option<Phase>) -> Self {
         if let Some(phase) = phase {
-            cx.phase.set(phase);
+            cx.phase = phase;
         }
 
         Self {
-            cx,
             #[cfg(feature = "tracing")]
             span: {
                 let mut span = cx.phase_span.replace(tracing::Span::none());
@@ -647,11 +705,12 @@ impl<'a> PhaseGuard<'a> {
                 }
                 span.entered()
             },
+            cx,
         }
     }
 
     fn switch(&mut self, phase: Phase) {
-        self.cx.phase.set(phase);
+        self.cx.phase = phase;
 
         #[cfg(feature = "tracing")]
         {
@@ -667,7 +726,7 @@ impl<'a> PhaseGuard<'a> {
             target: "gc_arena",
             parent: &self.span,
             message,
-            phase = tracing::field::debug(self.cx.phase.get()),
+            phase = tracing::field::debug(self.cx.phase),
             allocated = self.cx.metrics.total_allocation(),
         );
     }

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -56,7 +56,7 @@ impl<'gc, T: ?Sized + 'gc> Clone for Gc<'gc, T> {
 
 unsafe impl<'gc, T: ?Sized + 'gc> Collect for Gc<'gc, T> {
     #[inline]
-    fn trace(&self, cc: &Collection) {
+    fn trace(&self, mut cc: Collection<'_>) {
         cc.trace_gc(Self::erase(*self))
     }
 }

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -118,7 +118,7 @@ impl<'gc, T: 'static> Gc<'gc, T> {
 impl<'gc, T: ?Sized + 'gc> Gc<'gc, T> {
     /// Cast a `Gc` pointer to a different type.
     ///
-    /// SAFETY:
+    /// # Safety
     /// It must be valid to dereference a `*mut U` that has come from casting a `*mut T`.
     #[inline]
     pub unsafe fn cast<U: 'gc>(this: Gc<'gc, T>) -> Gc<'gc, U> {
@@ -140,7 +140,7 @@ impl<'gc, T: ?Sized + 'gc> Gc<'gc, T> {
 
     /// Retrieve a `Gc` from a raw pointer obtained from `Gc::as_ptr`
     ///
-    /// SAFETY:
+    /// # Safety
     /// The provided pointer must have been obtained from `Gc::as_ptr`, and the pointer must not
     /// have been collected yet.
     #[inline]

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -57,9 +57,7 @@ impl<'gc, T: ?Sized + 'gc> Clone for Gc<'gc, T> {
 unsafe impl<'gc, T: ?Sized + 'gc> Collect for Gc<'gc, T> {
     #[inline]
     fn trace(&self, cc: &Collection) {
-        unsafe {
-            cc.trace(GcBox::erase(self.ptr));
-        }
+        cc.trace_gc(Self::erase(*self))
     }
 }
 

--- a/src/gc_weak.rs
+++ b/src/gc_weak.rs
@@ -104,12 +104,10 @@ impl<'gc, T: ?Sized + 'gc> GcWeak<'gc, T> {
     pub fn as_ptr(self) -> *const T {
         Gc::as_ptr(self.inner)
     }
-}
 
-impl<'gc, T: 'gc> GcWeak<'gc, T> {
     /// Cast the internal pointer to a different type.
     ///
-    /// SAFETY:
+    /// # Safety
     /// It must be valid to dereference a `*mut U` that has come from casting a `*mut T`.
     #[inline]
     pub unsafe fn cast<U: 'gc>(this: GcWeak<'gc, T>) -> GcWeak<'gc, U> {
@@ -118,9 +116,21 @@ impl<'gc, T: 'gc> GcWeak<'gc, T> {
         }
     }
 
+    /// Cast a `GcWeak` to the unit type.
+    ///
+    /// This is exactly the same as `unsafe { GcWeak::cast::<()>(this) }`, but we can provide this
+    /// method safely because it is always safe to dereference a `*mut ()` that has come from
+    /// casting a `*mut T`.
+    #[inline]
+    pub fn erase(this: GcWeak<'gc, T>) -> GcWeak<'gc, ()> {
+        GcWeak {
+            inner: Gc::erase(this.inner),
+        }
+    }
+
     /// Retrieve a `GcWeak` from a raw pointer obtained from `GcWeak::as_ptr`
     ///
-    /// SAFETY:
+    /// # Safety
     /// The provided pointer must have been obtained from `GcWeak::as_ptr` or `Gc::as_ptr`, and
     /// the pointer must not have been *fully* collected yet (it may be a dropped but valid weak
     /// pointer).

--- a/src/gc_weak.rs
+++ b/src/gc_weak.rs
@@ -28,9 +28,7 @@ impl<'gc, T: ?Sized + 'gc> Debug for GcWeak<'gc, T> {
 unsafe impl<'gc, T: ?Sized + 'gc> Collect for GcWeak<'gc, T> {
     #[inline]
     fn trace(&self, cc: &Collection) {
-        unsafe {
-            cc.trace_weak(GcBox::erase(self.inner.ptr));
-        }
+        cc.trace_gc_weak(Self::erase(*self))
     }
 }
 

--- a/src/gc_weak.rs
+++ b/src/gc_weak.rs
@@ -27,7 +27,7 @@ impl<'gc, T: ?Sized + 'gc> Debug for GcWeak<'gc, T> {
 
 unsafe impl<'gc, T: ?Sized + 'gc> Collect for GcWeak<'gc, T> {
     #[inline]
-    fn trace(&self, cc: &Collection) {
+    fn trace(&self, mut cc: Collection<'_>) {
         cc.trace_gc_weak(Self::erase(*self))
     }
 }

--- a/src/hashbrown.rs
+++ b/src/hashbrown.rs
@@ -11,18 +11,15 @@ mod inner {
         S: 'static,
         A: Allocator + Clone + Collect,
     {
-        #[inline]
-        fn needs_trace() -> bool {
-            K::needs_trace() || V::needs_trace() || A::needs_trace()
-        }
+        const NEEDS_TRACE: bool = K::NEEDS_TRACE || V::NEEDS_TRACE || A::NEEDS_TRACE;
 
         #[inline]
-        fn trace(&self, cc: &Collection) {
-            self.allocator().trace(cc);
+        fn trace(&self, mut cc: Collection<'_>) {
             for (k, v) in self {
-                k.trace(cc);
-                v.trace(cc);
+                cc.trace(k);
+                cc.trace(v);
             }
+            self.allocator().trace(cc);
         }
     }
 
@@ -32,17 +29,14 @@ mod inner {
         S: 'static,
         A: Allocator + Clone + Collect,
     {
-        #[inline]
-        fn needs_trace() -> bool {
-            T::needs_trace() || A::needs_trace()
-        }
+        const NEEDS_TRACE: bool = T::NEEDS_TRACE || A::NEEDS_TRACE;
 
         #[inline]
-        fn trace(&self, cc: &Collection) {
-            self.allocator().trace(cc);
+        fn trace(&self, mut cc: Collection<'_>) {
             for v in self {
-                v.trace(cc);
+                cc.trace(v);
             }
+            self.allocator().trace(cc);
         }
     }
 
@@ -51,17 +45,14 @@ mod inner {
         T: Collect,
         A: Allocator + Clone + Collect,
     {
-        #[inline]
-        fn needs_trace() -> bool {
-            T::needs_trace() || A::needs_trace()
-        }
+        const NEEDS_TRACE: bool = T::NEEDS_TRACE || A::NEEDS_TRACE;
 
         #[inline]
-        fn trace(&self, cc: &Collection) {
-            self.allocator().trace(cc);
+        fn trace(&self, mut cc: Collection<'_>) {
             for v in self {
-                v.trace(cc);
+                cc.trace(v);
             }
+            self.allocator().trace(cc);
         }
     }
 }
@@ -76,16 +67,13 @@ mod inner {
         V: Collect,
         S: 'static,
     {
-        #[inline]
-        fn needs_trace() -> bool {
-            K::needs_trace() || V::needs_trace()
-        }
+        const NEEDS_TRACE: bool = K::NEEDS_TRACE || V::NEEDS_TRACE;
 
         #[inline]
-        fn trace(&self, cc: &Collection) {
+        fn trace(&self, mut cc: Collection<'_>) {
             for (k, v) in self {
-                k.trace(cc);
-                v.trace(cc);
+                cc.trace(k);
+                cc.trace(v);
             }
         }
     }
@@ -95,15 +83,12 @@ mod inner {
         T: Collect,
         S: 'static,
     {
-        #[inline]
-        fn needs_trace() -> bool {
-            T::needs_trace()
-        }
+        const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
         #[inline]
-        fn trace(&self, cc: &Collection) {
+        fn trace(&self, mut cc: Collection<'_>) {
             for v in self {
-                v.trace(cc);
+                cc.trace(v);
             }
         }
     }
@@ -112,15 +97,12 @@ mod inner {
     where
         T: Collect,
     {
-        #[inline]
-        fn needs_trace() -> bool {
-            T::needs_trace()
-        }
+        const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
         #[inline]
-        fn trace(&self, cc: &Collection) {
+        fn trace(&self, mut cc: Collection<'_>) {
             for v in self {
-                v.trace(cc);
+                cc.trace(v);
             }
         }
     }

--- a/src/static_collect.rs
+++ b/src/static_collect.rs
@@ -16,10 +16,7 @@ impl<'a, T: ?Sized + 'static> Rootable<'a> for Static<T> {
 }
 
 unsafe impl<T: ?Sized + 'static> Collect for Static<T> {
-    #[inline]
-    fn needs_trace() -> bool {
-        false
-    }
+    const NEEDS_TRACE: bool = false;
 }
 
 impl<T> From<T> for Static<T> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -47,7 +47,7 @@ impl GcBox {
     ///
     /// **SAFETY**: `Self::drop_in_place` must not have been called.
     #[inline(always)]
-    pub(crate) unsafe fn trace_value(&self, cc: &crate::Collection) {
+    pub(crate) unsafe fn trace_value(&self, cc: crate::Collection<'_>) {
         (self.header().vtable().trace_value)(*self, cc)
     }
 
@@ -193,7 +193,7 @@ struct CollectVtable {
     /// Drops the value stored in the given `GcBox` (without deallocating the box).
     drop_value: unsafe fn(GcBox),
     /// Traces the value stored in the given `GcBox`.
-    trace_value: unsafe fn(GcBox, &crate::Collection),
+    trace_value: unsafe fn(GcBox, crate::Collection<'_>),
 }
 
 impl CollectVtable {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -312,12 +312,12 @@ fn derive_collect() {
     #[collect(no_drop)]
     struct Test6(i32);
 
-    assert_eq!(Test1::needs_trace(), true);
-    assert_eq!(Test2::needs_trace(), false);
-    assert_eq!(Test3::needs_trace(), true);
-    assert_eq!(Test4::needs_trace(), false);
-    assert_eq!(Test5::needs_trace(), true);
-    assert_eq!(Test6::needs_trace(), false);
+    assert_eq!(Test1::NEEDS_TRACE, true);
+    assert_eq!(Test2::NEEDS_TRACE, false);
+    assert_eq!(Test3::NEEDS_TRACE, true);
+    assert_eq!(Test4::NEEDS_TRACE, false);
+    assert_eq!(Test5::NEEDS_TRACE, true);
+    assert_eq!(Test6::NEEDS_TRACE, false);
 
     struct NoImpl;
 
@@ -339,8 +339,8 @@ fn derive_collect() {
         },
     }
 
-    assert_eq!(Test7::needs_trace(), false);
-    assert_eq!(Test8::needs_trace(), false);
+    assert_eq!(Test7::NEEDS_TRACE, false);
+    assert_eq!(Test8::NEEDS_TRACE, false);
 }
 
 #[test]
@@ -602,7 +602,7 @@ fn okay_panic() {
     }
 
     unsafe impl<'gc> Collect for Test<'gc> {
-        fn trace(&self, cc: &gc_arena::Collection) {
+        fn trace(&self, cc: gc_arena::Collection<'_>) {
             let panics = self.panic_count.get();
             if panics > 0 {
                 self.panic_count.set(panics - 1);

--- a/tests/ui/bad_collect_bound.stderr
+++ b/tests/ui/bad_collect_bound.stderr
@@ -37,4 +37,9 @@ error[E0277]: the trait bound `NotCollect: Collect` is not satisfied
             (A, B, C, D, E, F)
             (A, B, C, D, E, F, G)
           and $N others
+note: required by a bound in `Collection::<'a>::trace`
+ --> src/context.rs
+  |
+  |     pub fn trace<T: Collect + ?Sized>(&mut self, value: &T) {
+  |                     ^^^^^^^ required by this bound in `Collection::<'a>::trace`
   = note: this error originates in the derive macro `Collect` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/bad_collect_bound.stderr
+++ b/tests/ui/bad_collect_bound.stderr
@@ -8,14 +8,14 @@ error[E0277]: the trait bound `NotCollect: Collect` is not satisfied
   |            the trait `Collect` is not implemented for `NotCollect`
   |
   = help: the following other types implement trait `Collect`:
-            bool
-            char
-            isize
-            i8
-            i16
-            i32
-            i64
-            usize
+            &'static T
+            ()
+            (A, B)
+            (A, B, C)
+            (A, B, C, D)
+            (A, B, C, D, E)
+            (A, B, C, D, E, F)
+            (A, B, C, D, E, F, G)
           and $N others
 
 error[E0277]: the trait bound `NotCollect: Collect` is not satisfied
@@ -28,13 +28,13 @@ error[E0277]: the trait bound `NotCollect: Collect` is not satisfied
   |     ^^^^^ the trait `Collect` is not implemented for `NotCollect`
   |
   = help: the following other types implement trait `Collect`:
-            bool
-            char
-            isize
-            i8
-            i16
-            i32
-            i64
-            usize
+            &'static T
+            ()
+            (A, B)
+            (A, B, C)
+            (A, B, C, D)
+            (A, B, C, D, E)
+            (A, B, C, D, E, F)
+            (A, B, C, D, E, F, G)
           and $N others
   = note: this error originates in the derive macro `Collect` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/require_static_not_static.rs
+++ b/tests/ui/require_static_not_static.rs
@@ -10,7 +10,7 @@ struct MyStruct<'a> {
 }
 
 fn assert_my_struct_collect<'a>() {
-    MyStruct::<'a>::needs_trace();
+    let _ = MyStruct::<'a>::NEEDS_TRACE;
 }
 
 fn main() {}

--- a/tests/ui/require_static_not_static.stderr
+++ b/tests/ui/require_static_not_static.stderr
@@ -1,7 +1,7 @@
 error: lifetime may not live long enough
-  --> $DIR/require_static_not_static.rs:13:5
+  --> tests/ui/require_static_not_static.rs:13:13
    |
 12 | fn assert_my_struct_collect<'a>() {
    |                             -- lifetime `'a` defined here
-13 |     MyStruct::<'a>::needs_trace();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+13 |     let _ = MyStruct::<'a>::NEEDS_TRACE;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`


### PR DESCRIPTION
Implements (mostly) the changes discussed in https://github.com/kyren/gc-arena/pull/105#issuecomment-2225971064.  
A small difference: I ditched the `CollectFlags` abstraction in favor of keeping a simple boolean; this makes the trait slightly less cumbersome to implement.

This also refactors `Context` to drastically reduce the need for `RefCell` locking, by borrowing the gray queues mutably during marking and tracing.