### PR TITLE
Add 'Arena::get_mut_gc' api to allow mutating a `Gc`

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -17,12 +17,19 @@ fn simple_allocation() {
         test: Gc<'gc, i32>,
     }
 
-    let arena = Arena::<Rootable![TestRoot<'_>]>::new(|mc| TestRoot {
+    let mut arena = Arena::<Rootable![TestRoot<'_>]>::new(|mc| TestRoot {
         test: Gc::new(mc, 42),
     });
 
     arena.mutate(|_mc, root| {
         assert_eq!(*((*root).test), 42);
+    });
+
+    let test_ref = arena.get_mut_gc(|root| root.test);
+    *test_ref = 100;
+
+    arena.mutate(|_mc, root| {
+        assert_eq!(*((*root).test), 100);
     });
 }
 


### PR DESCRIPTION
This method takes `&mut self`, so it can only be used outside of a `mutate`/`mutate_root` call.

This is useful when an application (e.g. Ruffle) almost always read from a particular `Gc`, and occasionally need to write. If modifying the `Gc` can be done outside of a `mutate` call, then this API can be used to avoid introducing a `GcCell`