### PR TITLE
Remove pub from 'inner' field in write barrier

### DIFF
--- a/src/barrier.rs
+++ b/src/barrier.rs
@@ -168,9 +168,9 @@ macro_rules! __field {
         // - similarly, the `__from_ref_and_ptr` method takes both a reference (for the lifetime)
         //   and a pointer, causing a compilation failure if the first argument was coerced.
         {
-            let _: &$crate::barrier::Write<_> = $value;
+            let value: &$crate::barrier::Write<_> = $value;
 
-            match $value.get_inner() {
+            match value.get_inner() {
                 $type { ref $field, .. } => unsafe {
                     $crate::barrier::Write::__from_ref_and_ptr($field, $field as *const _)
                 },

--- a/src/barrier.rs
+++ b/src/barrier.rs
@@ -171,8 +171,9 @@ macro_rules! __field {
             let _: &$crate::barrier::Write<_> = $value;
 
             match $value.get_inner() {
-                $type { ref $field, .. }
-                    => unsafe { $crate::barrier::Write::__from_ref_and_ptr($field, $field as *const _) },
+                $type { ref $field, .. } => unsafe {
+                    $crate::barrier::Write::__from_ref_and_ptr($field, $field as *const _)
+                },
             }
         }
     };

--- a/src/barrier.rs
+++ b/src/barrier.rs
@@ -11,7 +11,6 @@ use crate::Gc;
 /// This type can only exist behind a reference; it is typically obtained by calling
 /// [`Gc::write`] on a [`Gc`] pointer or by using the [`field!`] projection macro
 /// on a pre-existing `&Write<T>`.
-#[non_exhaustive]
 #[repr(transparent)]
 pub struct Write<T: ?Sized> {
     inner: T,


### PR DESCRIPTION
I think that because the inner field is pub, external code could potentially modify it which would be unsafe. By making inner private it also removes the need for `struct Write` to be non_exhaustive.

However, this does introduce some weirdness in needing an 'explicit' deref function to be used in the `field!`macro as well as a new way of asserting that the $value is of type `Write`.