### PR TITLE
Further `Collect` trait improvements

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -202,7 +202,7 @@ fn collect_derive(s: synstructure::Structure) -> TokenStream {
                     // merge the spans. This is purely for diagnostic purposes, and has no effect
                     // on correctness
                     let bi = #bi;
-                    ::gc_arena::collect::TraceExt::trace(cc, bi);
+                    cc.trace(bi);
                 }
             )
         });
@@ -242,7 +242,7 @@ fn collect_derive(s: synstructure::Structure) -> TokenStream {
                     const NEEDS_TRACE: bool = #needs_trace_expr;
 
                     #[inline]
-                    fn trace<Trace: ::gc_arena::collect::Trace<#gc_lifetime> + ?Sized>(&self, cc: &mut Trace) {
+                    fn trace<Trace: ::gc_arena::collect::Trace<#gc_lifetime>>(&self, cc: &mut Trace) {
                         match *self { #trace_body }
                     }
                 }
@@ -253,7 +253,7 @@ fn collect_derive(s: synstructure::Structure) -> TokenStream {
                     const NEEDS_TRACE: bool = #needs_trace_expr;
 
                     #[inline]
-                    fn trace<Trace: ::gc_arena::collect::Trace<'gc> + ?Sized>(&self, cc: &mut Trace) {
+                    fn trace<Trace: ::gc_arena::collect::Trace<'gc>>(&self, cc: &mut Trace) {
                         match *self { #trace_body }
                     }
                 }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -185,7 +185,7 @@ fn collect_derive(mut s: synstructure::Structure) -> TokenStream {
                     // merge the spans. This is purely for diagnostic purposes, and has no effect
                     // on correctness
                     let bi = #bi;
-                    cc.trace(bi);
+                    ::gc_arena::collect::TraceExt::trace(cc, bi);
                 }
             )
         });
@@ -200,7 +200,7 @@ fn collect_derive(mut s: synstructure::Structure) -> TokenStream {
                 const NEEDS_TRACE: bool = #needs_trace_expr;
 
                 #[inline]
-                fn trace(&self, mut cc: ::gc_arena::Collection<'_>) {
+                fn trace<Trace: ::gc_arena::collect::Trace + ?Sized>(&self, cc: &mut Trace) {
                     match *self { #trace_body }
                 }
             }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -7,41 +7,44 @@ use syn::{
 };
 use synstructure::{decl_derive, AddBounds};
 
-fn find_collect_meta(attrs: &[syn::Attribute]) -> syn::Result<Option<&syn::Attribute>> {
-    let mut found = None;
-    for attr in attrs {
-        if attr.path().is_ident("collect") && found.replace(attr).is_some() {
-            return Err(syn::parse::Error::new_spanned(
-                attr.path(),
-                "Cannot specify multiple `#[collect]` attributes! Consider merging them.",
-            ));
+fn collect_derive(s: synstructure::Structure) -> TokenStream {
+    fn find_collect_meta(attrs: &[syn::Attribute]) -> syn::Result<Option<&syn::Attribute>> {
+        let mut found = None;
+        for attr in attrs {
+            if attr.path().is_ident("collect") && found.replace(attr).is_some() {
+                return Err(syn::parse::Error::new_spanned(
+                    attr.path(),
+                    "Cannot specify multiple `#[collect]` attributes! Consider merging them.",
+                ));
+            }
         }
+
+        Ok(found)
     }
 
-    Ok(found)
-}
+    // Deriving `Collect` must be done with care, because an implementation of `Drop` is not
+    // necessarily safe for `Collect` types. This derive macro has three available modes to ensure
+    // that this is safe:
+    //   1) Require that the type be 'static with `#[collect(require_static)]`.
+    //   2) Prohibit a `Drop` impl on the type with `#[collect(no_drop)]`
+    //   3) Allow a custom `Drop` impl that might be unsafe with `#[collect(unsafe_drop)]`. Such
+    //      `Drop` impls must *not* access garbage collected pointers during `Drop::drop`.
+    #[derive(PartialEq)]
+    enum Mode {
+        RequireStatic,
+        NoDrop,
+        UnsafeDrop,
+    }
 
-fn usage_error(meta: &syn::meta::ParseNestedMeta, msg: &str) -> syn::parse::Error {
-    meta.error(format_args!("{msg}. `#[collect(...)]` requires one mode (`require_static`, `no_drop`, or `unsafe_drop`) and optionally `bound = \"...\"`."))
-}
-
-// Deriving `Collect` must be done with care, because an implementation of `Drop` is not
-// necessarily safe for `Collect` types. This derive macro has three available modes to ensure
-// that this is safe:
-//   1) Require that the type be 'static with `#[collect(require_static)]`.
-//   2) Prohibit a `Drop` impl on the type with `#[collect(no_drop)]`
-//   3) Allow a custom `Drop` impl that might be unsafe with `#[collect(unsafe_drop)]`. Such
-//      `Drop` impls must *not* access garbage collected pointers during `Drop::drop`.
-#[derive(PartialEq)]
-enum Mode {
-    RequireStatic,
-    NoDrop,
-    UnsafeDrop,
-}
-
-fn collect_derive(mut s: synstructure::Structure) -> TokenStream {
     let mut mode = None;
     let mut override_bound = None;
+    let mut gc_lifetime = None;
+
+    fn usage_error(meta: &syn::meta::ParseNestedMeta, msg: &str) -> syn::parse::Error {
+        meta.error(format_args!(
+            "{msg}. `#[collect(...)]` requires one mode (`require_static`, `no_drop`, or `unsafe_drop`) and optionally `bound = \"...\"`."
+        ))
+    }
 
     let result = match find_collect_meta(&s.ast().attrs) {
         Ok(Some(attr)) => attr.parse_nested_meta(|meta| {
@@ -52,6 +55,16 @@ fn collect_derive(mut s: synstructure::Structure) -> TokenStream {
 
                 let lit: syn::LitStr = meta.value()?.parse()?;
                 override_bound = Some(lit);
+                return Ok(());
+            }
+
+            if meta.path.is_ident("gc_lifetime") {
+                if gc_lifetime.is_some() {
+                    return Err(usage_error(&meta, "multiple `'gc` lifetimes specified"));
+                }
+
+                let lit: syn::Lifetime = meta.value()?.parse()?;
+                gc_lifetime = Some(lit);
                 return Ok(());
             }
 
@@ -100,12 +113,16 @@ fn collect_derive(mut s: synstructure::Structure) -> TokenStream {
     let mut errors = vec![];
 
     let collect_impl = if mode == Mode::RequireStatic {
-        s.clone().add_bounds(AddBounds::None).gen_impl(quote! {
-            gen unsafe impl ::gc_arena::Collect for @Self #where_clause {
+        let mut impl_struct = s.clone();
+        impl_struct.add_bounds(AddBounds::None);
+        impl_struct.gen_impl(quote! {
+            gen unsafe impl<'gc> ::gc_arena::Collect<'gc> for @Self #where_clause {
                 const NEEDS_TRACE: bool = false;
             }
         })
     } else {
+        let mut impl_struct = s.clone();
+
         let mut needs_trace_expr = TokenStream::new();
         quote!(false).to_tokens(&mut needs_trace_expr);
 
@@ -116,7 +133,7 @@ fn collect_derive(mut s: synstructure::Structure) -> TokenStream {
         // `static_bindings`, which will be added to the genererated `Collect` impl. The presence of
         // the bound guarantees that the field cannot hold any `Gc` pointers, so it's safe to ignore
         // that field in `needs_trace` and `trace`
-        s.filter(|b| match find_collect_meta(&b.ast().attrs) {
+        impl_struct.filter(|b| match find_collect_meta(&b.ast().attrs) {
             Ok(Some(attr)) => {
                 let mut static_binding = false;
                 let result = attr.parse_nested_meta(|meta| {
@@ -139,13 +156,13 @@ fn collect_derive(mut s: synstructure::Structure) -> TokenStream {
         });
 
         for static_binding in static_bindings {
-            s.add_where_predicate(syn::parse_quote! { #static_binding: 'static });
+            impl_struct.add_where_predicate(syn::parse_quote! { #static_binding: 'static });
         }
 
         // `#[collect(require_static)]` only makes sense on fields, not enum variants. Emit an error
         // if it is used in the wrong place
-        if let syn::Data::Enum(..) = s.ast().data {
-            for v in s.variants() {
+        if let syn::Data::Enum(..) = impl_struct.ast().data {
+            for v in impl_struct.variants() {
                 for attr in v.ast().attrs {
                     if attr.path().is_ident("collect") {
                         errors.push(syn::parse::Error::new_spanned(
@@ -157,9 +174,9 @@ fn collect_derive(mut s: synstructure::Structure) -> TokenStream {
             }
         }
 
-        // We've already called `s.filter`, so we we won't try to include `NEEDS_TRACE` for the types
-        // of fields that have `#[collect(require_static)]`
-        for v in s.variants() {
+        // We've already called `impl_struct.filter`, so we we won't try to include `NEEDS_TRACE`
+        // for the types of fields that have `#[collect(require_static)]`
+        for v in impl_struct.variants() {
             for b in v.bindings() {
                 let ty = &b.ast().ty;
                 // Resolving the span at the call site makes rustc emit a 'the error originates a
@@ -173,7 +190,7 @@ fn collect_derive(mut s: synstructure::Structure) -> TokenStream {
             }
         }
         // Likewise, this will skip any fields that have `#[collect(require_static)]`
-        let trace_body = s.each(|bi| {
+        let trace_body = impl_struct.each(|bi| {
             // See the above handling of `NEEDS_TRACE` for an explanation of this
             let call_span = bi.ast().span().resolved_at(Span::call_site());
             quote_spanned!(call_span=>
@@ -190,26 +207,63 @@ fn collect_derive(mut s: synstructure::Structure) -> TokenStream {
             )
         });
 
-        let bounds_type = if override_bound.is_some() {
-            AddBounds::None
-        } else {
-            AddBounds::Generics
-        };
-        s.clone().add_bounds(bounds_type).gen_impl(quote! {
-            gen unsafe impl ::gc_arena::Collect for @Self #where_clause {
-                const NEEDS_TRACE: bool = #needs_trace_expr;
+        // If we have no configured `'gc` lifetime and the type has a *single* generic lifetime, use
+        // that one.
+        if gc_lifetime.is_none() {
+            let mut all_lifetimes =
+                impl_struct
+                    .ast()
+                    .generics
+                    .params
+                    .iter()
+                    .filter_map(|p| match p {
+                        syn::GenericParam::Lifetime(lt) => Some(lt),
+                        _ => None,
+                    });
 
-                #[inline]
-                fn trace<Trace: ::gc_arena::collect::Trace + ?Sized>(&self, cc: &mut Trace) {
-                    match *self { #trace_body }
+            if let Some(lt) = all_lifetimes.next() {
+                if all_lifetimes.next().is_none() {
+                    gc_lifetime = Some(lt.lifetime.clone());
+                } else {
+                    panic!("deriving `Collect` on a type with multiple lifetime parameters requires a `#[collect(gc_lifetime = ...)]` attribute");
                 }
             }
-        })
+        };
+
+        if override_bound.is_some() {
+            impl_struct.add_bounds(AddBounds::None);
+        } else {
+            impl_struct.add_bounds(AddBounds::Generics);
+        };
+
+        if let Some(gc_lifetime) = gc_lifetime {
+            impl_struct.gen_impl(quote! {
+                gen unsafe impl ::gc_arena::Collect<#gc_lifetime> for @Self #where_clause {
+                    const NEEDS_TRACE: bool = #needs_trace_expr;
+
+                    #[inline]
+                    fn trace<Trace: ::gc_arena::collect::Trace<#gc_lifetime> + ?Sized>(&self, cc: &mut Trace) {
+                        match *self { #trace_body }
+                    }
+                }
+            })
+        } else {
+            impl_struct.gen_impl(quote! {
+                gen unsafe impl<'gc> ::gc_arena::Collect<'gc> for @Self #where_clause {
+                    const NEEDS_TRACE: bool = #needs_trace_expr;
+
+                    #[inline]
+                    fn trace<Trace: ::gc_arena::collect::Trace<'gc> + ?Sized>(&self, cc: &mut Trace) {
+                        match *self { #trace_body }
+                    }
+                }
+            })
+        }
     };
 
     let drop_impl = if mode == Mode::NoDrop {
-        let mut s = s;
-        s.add_bounds(AddBounds::None).gen_impl(quote! {
+        let mut drop_struct = s.clone();
+        drop_struct.add_bounds(AddBounds::None).gen_impl(quote! {
             gen impl ::gc_arena::__MustNotImplDrop for @Self {}
         })
     } else {
@@ -249,8 +303,14 @@ decl_derive! {
     ///   Also note that providing an explicit bound in this way is safe, and only changes the trait
     ///   bounds used to enable the implementation of `Collect`.
     ///
-    /// Options may be passed to the `collect` attribute together, e.g., `#[collect(no_drop, bound
-    /// = "")]`.
+    /// - `#[collect(gc_lifetime = "<lifetime>")]` - the `Collect` trait requires a `'gc` lifetime
+    ///   parameter. If there is no lifetime parameter on the type, then `Collect` will be
+    ///   implemented for all `'gc` lifetimes. If there is one lifetime on the type, this is assumed
+    ///   to be the `'gc` lifetime. In the very unusual case that there are two or more lifetime
+    ///   parameters, you must specify *which* lifetime should be used as the `'gc` lifetime.
+    ///
+    /// Options may be passed to the `collect` attribute together, e.g.,
+    /// `#[collect(no_drop, bound = "")]`.
     ///
     /// The `collect` attribute may also be used on any field of an enum or struct, however the
     /// only allowed usage is to specify the strategy as `require_static` (no other strategies are

--- a/examples/linked_list.rs
+++ b/examples/linked_list.rs
@@ -30,7 +30,7 @@ type NodePtr<'gc, T> = Gc<'gc, RefLock<Node<'gc, T>>>;
 //
 // We need to pass the `&Mutation<'gc>` context here because we are mutating the
 // object graph (by creating a new "object" with `Gc::new`).
-fn new_node<'gc, T: Collect>(mc: &Mutation<'gc>, value: T) -> NodePtr<'gc, T> {
+fn new_node<'gc, T: Collect<'gc>>(mc: &Mutation<'gc>, value: T) -> NodePtr<'gc, T> {
     Gc::new(
         mc,
         RefLock::new(Node {

--- a/src/allocator_api.rs
+++ b/src/allocator_api.rs
@@ -6,7 +6,7 @@ use allocator_api2::{
 };
 
 use crate::{
-    collect::{Collect, Trace, TraceExt},
+    collect::{Collect, Trace},
     context::Mutation,
     metrics::Metrics,
     types::Invariant,
@@ -128,13 +128,11 @@ unsafe impl<'gc> Collect<'gc> for Global {
     const NEEDS_TRACE: bool = false;
 }
 
-unsafe impl<'gc, T: Collect<'gc> + ?Sized, A: Collect<'gc> + Allocator> Collect<'gc>
-    for boxed::Box<T, A>
-{
+unsafe impl<'gc, T: Collect<'gc>, A: Collect<'gc> + Allocator> Collect<'gc> for boxed::Box<T, A> {
     const NEEDS_TRACE: bool = T::NEEDS_TRACE || A::NEEDS_TRACE;
 
     #[inline]
-    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
         cc.trace(&**self);
         cc.trace(boxed::Box::allocator(self));
     }
@@ -144,7 +142,7 @@ unsafe impl<'gc, T: Collect<'gc>, A: Collect<'gc> + Allocator> Collect<'gc> for 
     const NEEDS_TRACE: bool = T::NEEDS_TRACE || A::NEEDS_TRACE;
 
     #[inline]
-    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
         for v in self {
             cc.trace(v);
         }

--- a/src/allocator_api.rs
+++ b/src/allocator_api.rs
@@ -120,29 +120,31 @@ unsafe impl<'gc, A: Allocator> Allocator for MetricsAlloc<'gc, A> {
     }
 }
 
-unsafe impl<'gc, A: 'static> Collect for MetricsAlloc<'gc, A> {
+unsafe impl<'gc, A: 'static> Collect<'gc> for MetricsAlloc<'gc, A> {
     const NEEDS_TRACE: bool = false;
 }
 
-unsafe impl Collect for Global {
+unsafe impl<'gc> Collect<'gc> for Global {
     const NEEDS_TRACE: bool = false;
 }
 
-unsafe impl<T: Collect + ?Sized, A: Collect + Allocator> Collect for boxed::Box<T, A> {
+unsafe impl<'gc, T: Collect<'gc> + ?Sized, A: Collect<'gc> + Allocator> Collect<'gc>
+    for boxed::Box<T, A>
+{
     const NEEDS_TRACE: bool = T::NEEDS_TRACE || A::NEEDS_TRACE;
 
     #[inline]
-    fn trace<C: Trace + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
         cc.trace(&**self);
         cc.trace(boxed::Box::allocator(self));
     }
 }
 
-unsafe impl<T: Collect, A: Collect + Allocator> Collect for vec::Vec<T, A> {
+unsafe impl<'gc, T: Collect<'gc>, A: Collect<'gc> + Allocator> Collect<'gc> for vec::Vec<T, A> {
     const NEEDS_TRACE: bool = T::NEEDS_TRACE || A::NEEDS_TRACE;
 
     #[inline]
-    fn trace<C: Trace + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
         for v in self {
             cc.trace(v);
         }

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -262,7 +262,7 @@ where
 impl<R> Arena<R>
 where
     R: for<'a> Rootable<'a>,
-    for<'a> Root<'a, R>: Collect,
+    for<'a> Root<'a, R>: Collect<'a>,
 {
     /// Run incremental garbage collection until the allocation debt is <= 0.0.
     ///
@@ -342,7 +342,7 @@ pub struct MarkedArena<'a, R: for<'b> Rootable<'b>>(&'a mut Arena<R>);
 impl<'a, R> MarkedArena<'a, R>
 where
     R: for<'b> Rootable<'b>,
-    for<'b> Root<'b, R>: Collect,
+    for<'b> Root<'b, R>: Collect<'b>,
 {
     /// Examine the state of a fully marked arena.
     ///

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -1,35 +1,83 @@
-use crate::context::Collection;
+use crate::{Gc, GcWeak};
 
 /// A trait for garbage collected objects that can be placed into `Gc` pointers. This trait is
 /// unsafe, because `Gc` pointers inside an Arena are assumed never to be dangling, and in order to
 /// ensure this certain rules must be followed:
 ///
-///   1. `Collect::trace` *must* trace over *every* `Gc` pointer held inside this type, and cannot
-///      fail.
-///   2. Held `Gc` pointers must not be accessed inside `Drop::drop` since during drop any such
-///      pointer may be dangling.
-///   3. Internal mutability *must* not be used to adopt new `Gc` pointers without calling
-///      `Gc::write` during the same arena mutation.
+///   1. `Collect::trace` *must* trace over *every* `Gc` and `GcWeak` pointer held inside this type.
+///   2. Held `Gc` and `GcWeak` pointers must not be accessed inside `Drop::drop` since during drop
+///      any such pointer may be dangling.
+///   3. Internal mutability *must* not be used to adopt new `Gc` or `GcWeak` pointers without
+///      calling appropriate write barrier operations during the same arena mutation.
 ///
 /// It is, however, possible to implement this trait safely by procedurally deriving it (see
 /// [`gc_arena_derive::Collect`]), which requires that every field in the structure also implement
 /// `Collect`, and ensures that `Drop` cannot safely be implemented. Internally mutable types like
 /// `Cell` and `RefCell` do not implement `Collect` in such a way that it is possible to store
-/// `Gc` pointers inside them, so the write barrier requirement cannot be broken when procedurally
+/// `Gc` pointers inside them, so write barrier requirements cannot be broken when procedurally
 /// deriving `Collect`. A safe way of providing internal mutability in this case is to use
 /// [`crate::lock::Lock<T>`] and [`crate::lock::RefLock<T>`], which provides internal mutability
-/// while ensuring that the write barrier is always executed.
+/// while ensuring that write barriers are correctly executed.
 pub unsafe trait Collect {
     /// As an optimization, if this type can never hold a `Gc` pointer and `trace` is unnecessary
     /// to call, you may set this to `false`. The default value is `true`, signaling that
     /// `Collect::trace` must be called.
     const NEEDS_TRACE: bool = true;
 
-    /// *Must* call [`Collection::trace_gc`] (resp. [`Collection::trace_gc_weak`]) on all held
-    /// [`Gc`] (resp. [`GcWeak`]) pointers. If this type holds inner types that implement
-    /// `Collect`, a valid implementation would simply call `Collection::trace` on all the held
-    /// values to ensure this.
+    /// *Must* call [`Trace::trace_gc`] (resp. [`Trace::trace_gc_weak`]) on all directly owned
+    /// [`Gc`] (resp. [`GcWeak`]) pointers. If this type holds inner types that implement `Collect`,
+    /// a valid implementation would simply call [`TraceExt::trace`] on all the held values to
+    /// ensure this.
+    ///
+    /// # Tracing pointers
+    ///
+    /// [`Gc`] and [`GcWeak`] have their own implementations of `Collect` which in turn call
+    /// [`Trace::trace_gc`] and [`Trace::trace_gc_weak`] respectively. Because of this, it is not
+    /// actually ever necessary to call [`Trace::trace_gc`] and [`Trace::trace_gc_weak`] directly,
+    /// but be careful! It is important that owned pointers *themselves* are traced and NOT their
+    /// contents (the content type will usually also implement `Collect`, so this is easy to
+    /// accidentally do).
+    ///
+    /// It is always okay to use the [`Trace::trace_gc`] and [`Trace::trace_gc_weak`] directly as a
+    /// potentially less risky alternative when manually implementing `Collect`.
     #[inline]
-    #[allow(unused_variables, unused_mut)]
-    fn trace(&self, mut cc: Collection<'_>) {}
+    #[allow(unused_variables)]
+    fn trace<T: Trace + ?Sized>(&self, cc: &mut T) {}
+}
+
+/// The trait that is passed to the [`Collect::trace`] method.
+///
+/// Though [`Collect::trace`] is primarily used during the marking phase of the mark and sweep
+/// collector, this is a trait rather than a concrete type to facilitate other kinds of uses.
+///
+/// This trait is not itself unsafe, but implementers of [`Collect`] *must* uphold the safety
+/// guarantees of [`Collect`] when using this trait.
+pub trait Trace {
+    /// Trace a [`Gc`] pointer (of any real type).
+    fn trace_gc(&mut self, gc: Gc<'_, ()>);
+
+    /// Trace a [`GcWeak`] pointer (of any real type).
+    fn trace_gc_weak(&mut self, gc: GcWeak<'_, ()>);
+}
+
+pub trait TraceExt {
+    /// Trace an inner type that implements [`Collect`].
+    ///
+    /// This is a convenience method that calls [`Collect::trace`] but automatically adds a
+    /// [`Collect::NEEDS_TRACE`] check around it.
+    ///
+    /// Manual implementations of [`Collect`] are encouraged to use this to ensure that there
+    /// is a [`Collect::NEEDS_TRACE`] check without having to implement it manually. This can be
+    /// important in cases where the [`Collect::trace`] method impl is not `#[inline]` or does not
+    /// have its own early exit.
+    fn trace<C: Collect + ?Sized>(&mut self, _value: &C);
+}
+
+impl<T: Trace + ?Sized> TraceExt for T {
+    #[inline]
+    fn trace<C: Collect + ?Sized>(&mut self, value: &C) {
+        if C::NEEDS_TRACE {
+            value.trace(self);
+        }
+    }
 }

--- a/src/collect_impl.rs
+++ b/src/collect_impl.rs
@@ -9,7 +9,7 @@ use core::marker::PhantomData;
 #[cfg(feature = "std")]
 use std::collections::{HashMap, HashSet};
 
-use crate::collect::{Collect, Trace, TraceExt};
+use crate::collect::{Collect, Trace};
 
 /// If a type is static, we know that it can never hold `Gc` pointers, so it is safe to provide a
 /// simple empty `Collect` implementation.
@@ -87,7 +87,7 @@ unsafe impl<'gc, T: ?Sized + Collect<'gc>> Collect<'gc> for Box<T> {
     const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
     #[inline]
-    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
         cc.trace(&**self)
     }
 }
@@ -96,7 +96,7 @@ unsafe impl<'gc, T: Collect<'gc>> Collect<'gc> for [T] {
     const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
     #[inline]
-    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
         for t in self.iter() {
             cc.trace(t)
         }
@@ -107,7 +107,7 @@ unsafe impl<'gc, T: Collect<'gc>> Collect<'gc> for Option<T> {
     const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
     #[inline]
-    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
         if let Some(t) = self.as_ref() {
             cc.trace(t)
         }
@@ -118,7 +118,7 @@ unsafe impl<'gc, T: Collect<'gc>, E: Collect<'gc>> Collect<'gc> for Result<T, E>
     const NEEDS_TRACE: bool = T::NEEDS_TRACE || E::NEEDS_TRACE;
 
     #[inline]
-    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
         match self {
             Ok(r) => cc.trace(r),
             Err(e) => cc.trace(e),
@@ -130,7 +130,7 @@ unsafe impl<'gc, T: Collect<'gc>> Collect<'gc> for Vec<T> {
     const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
     #[inline]
-    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
         for t in self {
             cc.trace(t)
         }
@@ -141,7 +141,7 @@ unsafe impl<'gc, T: Collect<'gc>> Collect<'gc> for VecDeque<T> {
     const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
     #[inline]
-    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
         for t in self {
             cc.trace(t)
         }
@@ -152,7 +152,7 @@ unsafe impl<'gc, T: Collect<'gc>> Collect<'gc> for LinkedList<T> {
     const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
     #[inline]
-    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
         for t in self {
             cc.trace(t)
         }
@@ -169,7 +169,7 @@ where
     const NEEDS_TRACE: bool = K::NEEDS_TRACE || V::NEEDS_TRACE;
 
     #[inline]
-    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
         for (k, v) in self {
             cc.trace(k);
             cc.trace(v);
@@ -186,7 +186,7 @@ where
     const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
     #[inline]
-    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
         for v in self {
             cc.trace(v);
         }
@@ -201,7 +201,7 @@ where
     const NEEDS_TRACE: bool = K::NEEDS_TRACE || V::NEEDS_TRACE;
 
     #[inline]
-    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
         for (k, v) in self {
             cc.trace(k);
             cc.trace(v);
@@ -216,7 +216,7 @@ where
     const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
     #[inline]
-    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
         for v in self {
             cc.trace(v);
         }
@@ -230,7 +230,7 @@ where
     const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
     #[inline]
-    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
         cc.trace(&**self);
     }
 }
@@ -243,7 +243,7 @@ where
     const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
     #[inline]
-    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
         cc.trace(&**self);
     }
 }
@@ -271,7 +271,7 @@ unsafe impl<'gc, T: Collect<'gc>, const N: usize> Collect<'gc> for [T; N] {
     const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
     #[inline]
-    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
         for t in self {
             cc.trace(t)
         }
@@ -293,7 +293,7 @@ macro_rules! impl_tuple {
 
             #[allow(non_snake_case)]
             #[inline]
-            fn trace<TR: Trace<'gc> + ?Sized>(&self, cc: &mut TR) {
+            fn trace<TR: Trace<'gc> >(&self, cc: &mut TR) {
                 let ($($name,)*) = self;
                 $(cc.trace($name);)*
             }

--- a/src/context.rs
+++ b/src/context.rs
@@ -106,12 +106,12 @@ impl<'gc> Finalization<'gc> {
 impl<'gc> Trace<'gc> for Context {
     fn trace_gc(&mut self, gc: Gc<'gc, ()>) {
         let gc_box = unsafe { GcBox::erase(gc.ptr) };
-        self.trace(gc_box)
+        Context::trace(self, gc_box)
     }
 
     fn trace_gc_weak(&mut self, gc: GcWeak<'gc, ()>) {
         let gc_box = unsafe { GcBox::erase(gc.inner.ptr) };
-        self.trace_weak(gc_box)
+        Context::trace_weak(self, gc_box)
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,7 +1,6 @@
 use alloc::{boxed::Box, vec::Vec};
 use core::{
-    cell::{Cell, RefCell},
-    marker::PhantomData,
+    cell::{Cell, UnsafeCell},
     mem,
     ops::{ControlFlow, Deref, DerefMut},
     ptr::NonNull,
@@ -108,28 +107,24 @@ impl<'gc> Finalization<'gc> {
 /// `Collect::trace` implementations.
 #[repr(transparent)]
 pub struct Collection<'a> {
-    mark: &'a mut MarkState,
-    _invariant: Invariant<'a>,
+    context: &'a Context,
 }
 
 impl<'a> Collection<'a> {
     #[inline]
-    fn from_state(mark: &'a mut MarkState) -> Self {
-        Self {
-            mark,
-            _invariant: PhantomData,
-        }
+    fn from_context(context: &'a Context) -> Self {
+        Self { context }
     }
 
     #[inline]
     pub fn metrics(&self) -> &Metrics {
-        &self.mark.metrics
+        &self.context.metrics
     }
 
     #[inline]
     pub fn trace<T: Collect + ?Sized>(&mut self, value: &T) {
         if T::NEEDS_TRACE {
-            let cc = Collection::from_state(self.mark);
+            let cc = Collection::from_context(self.context);
             value.trace(cc);
         }
     }
@@ -137,13 +132,13 @@ impl<'a> Collection<'a> {
     #[inline]
     pub fn trace_gc(&mut self, gc: Gc<'_, ()>) {
         let gc_box = unsafe { GcBox::erase(gc.ptr) };
-        self.mark.trace(gc_box)
+        self.context.trace(gc_box)
     }
 
     #[inline]
     pub fn trace_gc_weak(&mut self, gc: GcWeak<'_, ()>) {
         let gc_box = unsafe { GcBox::erase(gc.inner.ptr) };
-        self.mark.trace_weak(gc_box)
+        self.context.trace_weak(gc_box)
     }
 }
 
@@ -165,10 +160,7 @@ pub(crate) struct Context {
     metrics: Metrics,
     phase: Phase,
     #[cfg(feature = "tracing")]
-    phase_span: Cell<tracing::Span>,
-
-    // The queues used during marking.
-    mark: RefCell<MarkState>,
+    phase_span: tracing::Span,
 
     // A linked list of all allocated `GcBox`es.
     all: Cell<Option<GcBox>>,
@@ -178,17 +170,12 @@ pub(crate) struct Context {
     // Any allocations created *during* `Phase::Sweep` will be added to `all`,
     // but `sweep` will *not* be updated. This ensures that we keep allocations
     // alive until we've had a chance to trace them.
-    sweep: Cell<Option<GcBox>>,
+    sweep: Option<GcBox>,
 
     // The most recent black object that we encountered during `Phase::Sweep`.
     // When we free objects, we update this `GcBox.next` to remove them from
     // the linked list.
     sweep_prev: Cell<Option<GcBox>>,
-}
-
-struct MarkState {
-    // Duplicated so that `Collection` can access it.
-    metrics: Metrics,
 
     /// Does the root needs to be traced?
     /// This should be `true` at the beginning of `Phase::Mark`.
@@ -196,11 +183,11 @@ struct MarkState {
 
     /// A queue of gray objects, used during `Phase::Mark`.
     /// This holds traceable objects that have yet to be traced.
-    gray: Vec<GcBox>,
+    gray: Queue<GcBox>,
 
     // A queue of gray objects that became gray as a result
     // of a write barrier.
-    gray_again: Vec<GcBox>,
+    gray_again: Queue<GcBox>,
 }
 
 impl Drop for Context {
@@ -233,12 +220,14 @@ impl Context {
         Context {
             phase: Phase::Sleep,
             #[cfg(feature = "tracing")]
-            phase_span: Cell::new(PhaseGuard::span_for(&metrics, Phase::Sleep)),
+            phase_span: PhaseGuard::span_for(&metrics, Phase::Sleep),
             metrics: metrics.clone(),
-            mark: RefCell::new(MarkState::new(metrics)),
             all: Cell::new(None),
-            sweep: Cell::new(None),
+            sweep: None,
             sweep_prev: Cell::new(None),
+            root_needs_trace: true,
+            gray: Queue::new(),
+            gray_again: Queue::new(),
         }
     }
 
@@ -260,7 +249,7 @@ impl Context {
     #[inline]
     pub(crate) fn root_barrier(&mut self) {
         if self.phase == Phase::Mark {
-            self.mark.get_mut().root_needs_trace = true;
+            self.root_needs_trace = true;
         }
     }
 
@@ -271,7 +260,7 @@ impl Context {
 
     #[inline]
     pub(crate) fn gray_remaining(&self) -> bool {
-        self.mark.borrow().gray_remaining()
+        !self.gray.is_empty() || !self.gray_again.is_empty() || self.root_needs_trace
     }
 
     // Do some collection work until either the debt goes down below the target amount or we have
@@ -283,16 +272,8 @@ impl Context {
     // reachable from the given root object.
     //
     // If we are currently in `Phase::Sleep`, this will transition the collector to `Phase::Mark`.
+    #[deny(unsafe_op_in_unsafe_fn)]
     pub(crate) unsafe fn do_collection<R: Collect + ?Sized>(
-        &mut self,
-        root: &R,
-        target_debt: f64,
-        early_stop: Option<EarlyStop>,
-    ) {
-        self.do_collection_inner(root, target_debt, early_stop)
-    }
-
-    fn do_collection_inner<R: Collect + ?Sized>(
         &mut self,
         root: &R,
         mut target_debt: f64,
@@ -313,8 +294,7 @@ impl Context {
                     continue;
                 }
                 Phase::Mark => {
-                    let ctrl = cx.mark.get_mut().mark_one(root);
-                    if ctrl.is_break() {
+                    if cx.mark_one(root).is_break() {
                         if early_stop == Some(EarlyStop::BeforeSweep) {
                             target_debt = f64::INFINITY;
                         } else {
@@ -324,7 +304,7 @@ impl Context {
                             // Set `sweep to the current head of our `all` linked list. Any new
                             // allocations during the newly-entered `Phase:Sweep` will update `all`,
                             // but will *not* be reachable from `this.sweep`.
-                            cx.sweep.set(cx.all.get());
+                            cx.sweep = cx.all.get();
 
                             // No need to update metrics here.
                             continue;
@@ -339,7 +319,7 @@ impl Context {
                         target_debt = f64::INFINITY;
 
                         // Begin a new cycle.
-                        cx.mark.get_mut().root_needs_trace = true;
+                        cx.root_needs_trace = true;
                         cx.switch(Phase::Sleep);
                         cx.metrics.start_cycle();
                     }
@@ -401,8 +381,7 @@ impl Context {
             #[cold]
             fn barrier(this: &Context, parent: GcBox) {
                 parent.header().set_color(GcColor::Gray);
-                let mut mark = this.mark.borrow_mut();
-                mark.gray_again.push(parent);
+                this.gray_again.push(parent);
             }
             barrier(&self, parent);
         }
@@ -418,7 +397,36 @@ impl Context {
                 .map(|p| p.header().color() == GcColor::Black)
                 .unwrap_or(true)
         {
-            self.mark.borrow_mut().trace(child)
+            self.trace(child)
+        }
+    }
+
+    #[inline]
+    fn trace(&self, gc_box: GcBox) {
+        let header = gc_box.header();
+        match header.color() {
+            GcColor::Black | GcColor::Gray => {}
+            GcColor::White | GcColor::WhiteWeak => {
+                if header.needs_trace() {
+                    // A white traceable object is not in the gray queue, becomes gray and enters
+                    // the normal gray queue.
+                    header.set_color(GcColor::Gray);
+                    debug_assert!(header.is_live());
+                    self.gray.push(gc_box);
+                } else {
+                    // A white object that doesn't need tracing simply becomes black.
+                    header.set_color(GcColor::Black);
+                    self.metrics.mark_gc_traced(header.size_of_box());
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn trace_weak(&self, gc_box: GcBox) {
+        let header = gc_box.header();
+        if header.color() == GcColor::White {
+            header.set_color(GcColor::WhiteWeak);
         }
     }
 
@@ -477,13 +485,72 @@ impl Context {
         debug_assert!(header.is_live());
         if matches!(header.color(), GcColor::White | GcColor::WhiteWeak) {
             header.set_color(GcColor::Gray);
-            let mut mark = self.mark.borrow_mut();
-            mark.gray.push(gc_box);
+            self.gray.push(gc_box);
         }
     }
 
-    fn sweep_one(&self) -> ControlFlow<()> {
-        let Some(mut sweep) = self.sweep.get() else {
+    fn mark_one<R: Collect + ?Sized>(&mut self, root: &R) -> ControlFlow<()> {
+        // We look for an object first in the normal gray queue, then the "gray again"
+        // queue. Objects from the normal gray queue count as regular work, but objects
+        // which are gray a second time have already been counted as work, so we don't
+        // double count them. Processing "gray again" objects later also gives them more
+        // time to be mutated again without triggering another write barrier.
+        let next_gray = if let Some(gc_box) = self.gray.pop() {
+            self.metrics.mark_gc_traced(gc_box.header().size_of_box());
+            Some(gc_box)
+        } else if let Some(gc_box) = self.gray_again.pop() {
+            Some(gc_box)
+        } else {
+            None
+        };
+
+        if let Some(gc_box) = next_gray {
+            // If we have an object in the gray queue, take one, trace it, and turn it
+            // black.
+
+            // Our `Collect::trace` call may panic, and if it does the object will be
+            // lost from the gray queue but potentially incompletely traced. By catching
+            // a panic during `Arena::collect()`, this could lead to memory unsafety.
+            //
+            // So, if the `Collect::trace` call panics, we need to add the popped object
+            // back to the `gray_again` queue. If the panic is caught, this will maybe
+            // give it some time to not panic before attempting to collect it again, and
+            // also this doesn't invalidate the collection debt math.
+            struct DropGuard<'a> {
+                context: &'a mut Context,
+                gc_box: GcBox,
+            }
+
+            impl<'a> Drop for DropGuard<'a> {
+                fn drop(&mut self) {
+                    self.context.gray_again.push(self.gc_box);
+                }
+            }
+
+            let guard = DropGuard {
+                context: self,
+                gc_box,
+            };
+            debug_assert!(gc_box.header().is_live());
+            unsafe { gc_box.trace_value(Collection::from_context(guard.context)) }
+            gc_box.header().set_color(GcColor::Black);
+            mem::forget(guard);
+
+            ControlFlow::Continue(())
+        } else if self.root_needs_trace {
+            // We treat the root object as gray if `root_needs_trace` is set, and we
+            // process it at the end of the gray queue for the same reason as the "gray
+            // again" objects.
+            root.trace(Collection::from_context(self));
+            self.root_needs_trace = false;
+            ControlFlow::Continue(())
+        } else {
+            ControlFlow::Break(())
+        }
+    }
+
+    fn sweep_one(&mut self) -> ControlFlow<()> {
+        let Some(mut sweep) = self.sweep else {
             self.sweep_prev.set(None);
             return ControlFlow::Break(());
         };
@@ -491,7 +558,7 @@ impl Context {
         let sweep_header = sweep.header();
 
         let next_box = sweep_header.next();
-        self.sweep.set(next_box);
+        self.sweep = next_box;
 
         match sweep_header.color() {
             // If the next object in the sweep portion of the main list is white, we
@@ -546,108 +613,6 @@ impl Context {
     }
 }
 
-impl MarkState {
-    fn new(metrics: Metrics) -> Self {
-        Self {
-            metrics,
-            root_needs_trace: true,
-            gray: Vec::new(),
-            gray_again: Vec::new(),
-        }
-    }
-
-    #[inline]
-    fn gray_remaining(&self) -> bool {
-        !self.gray.is_empty() || !self.gray_again.is_empty() || self.root_needs_trace
-    }
-
-    #[inline]
-    fn trace(&mut self, gc_box: GcBox) {
-        let header = gc_box.header();
-        match header.color() {
-            GcColor::Black | GcColor::Gray => {}
-            GcColor::White | GcColor::WhiteWeak => {
-                if header.needs_trace() {
-                    // A white traceable object is not in the gray queue, becomes gray and enters
-                    // the normal gray queue.
-                    header.set_color(GcColor::Gray);
-                    debug_assert!(header.is_live());
-                    self.gray.push(gc_box);
-                } else {
-                    // A white object that doesn't need tracing simply becomes black.
-                    header.set_color(GcColor::Black);
-                    self.metrics.mark_gc_traced(header.size_of_box());
-                }
-            }
-        }
-    }
-
-    #[inline]
-    fn trace_weak(&mut self, gc_box: GcBox) {
-        let header = gc_box.header();
-        if header.color() == GcColor::White {
-            header.set_color(GcColor::WhiteWeak);
-        }
-    }
-
-    fn mark_one<R: Collect + ?Sized>(&mut self, root: &R) -> ControlFlow<()> {
-        // We look for an object first in the normal gray queue, then the "gray again"
-        // queue. Objects from the normal gray queue count as regular work, but objects
-        // which are gray a second time have already been counted as work, so we don't
-        // double count them. Processing "gray again" objects later also gives them more
-        // time to be mutated again without triggering another write barrier.
-        let next_gray = if let Some(gc_box) = self.gray.pop() {
-            self.metrics.mark_gc_traced(gc_box.header().size_of_box());
-            Some(gc_box)
-        } else if let Some(gc_box) = self.gray_again.pop() {
-            Some(gc_box)
-        } else {
-            None
-        };
-
-        if let Some(gc_box) = next_gray {
-            // If we have an object in the gray queue, take one, trace it, and turn it
-            // black.
-
-            // Our `Collect::trace` call may panic, and if it does the object will be
-            // lost from the gray queue but potentially incompletely traced. By catching
-            // a panic during `Arena::collect()`, this could lead to memory unsafety.
-            //
-            // So, if the `Collect::trace` call panics, we need to add the popped object
-            // back to the `gray_again` queue. If the panic is caught, this will maybe
-            // give it some time to not panic before attempting to collect it again, and
-            // also this doesn't invalidate the collection debt math.
-            struct DropGuard<'a> {
-                mark: &'a mut MarkState,
-                gc_box: GcBox,
-            }
-
-            impl<'a> Drop for DropGuard<'a> {
-                fn drop(&mut self) {
-                    self.mark.gray_again.push(self.gc_box);
-                }
-            }
-
-            let guard = DropGuard { mark: self, gc_box };
-            debug_assert!(gc_box.header().is_live());
-            unsafe { gc_box.trace_value(Collection::from_state(guard.mark)) }
-            gc_box.header().set_color(GcColor::Black);
-            mem::forget(guard);
-
-            ControlFlow::Continue(())
-        } else if self.root_needs_trace {
-            // We treat the root object as gray if `root_needs_trace` is set, and we
-            // process it at the end of the gray queue for the same reason as the "gray
-            // again" objects.
-            root.trace(Collection::from_state(self));
-            self.root_needs_trace = false;
-            ControlFlow::Continue(())
-        } else {
-            ControlFlow::Break(())
-        }
-    }
-}
-
 // SAFETY: the gc_box must never be accessed after calling this function.
 unsafe fn free_gc_box<'gc>(mut gc_box: GcBox) {
     if gc_box.header().is_live() {
@@ -669,7 +634,7 @@ impl<'a> Drop for PhaseGuard<'a> {
         #[cfg(feature = "tracing")]
         {
             let span = mem::replace(&mut self.span, tracing::Span::none().entered());
-            self.cx.phase_span.set(span.exit());
+            self.cx.phase_span = span.exit();
         }
     }
 }
@@ -699,7 +664,7 @@ impl<'a> PhaseGuard<'a> {
         Self {
             #[cfg(feature = "tracing")]
             span: {
-                let mut span = cx.phase_span.replace(tracing::Span::none());
+                let mut span = mem::replace(&mut cx.phase_span, tracing::Span::none());
                 if let Some(phase) = phase {
                     span = Self::span_for(&cx.metrics, phase);
                 }
@@ -739,5 +704,38 @@ impl<'a> PhaseGuard<'a> {
             id = metrics.arena_id(),
             ?phase,
         )
+    }
+}
+
+// A shared, internally mutable `Vec<T>` that avoids the overhead of `RefCell`. Used for the "gray"
+// and "gray again" queues.
+//
+// SAFETY: We do not return any references at all to the contents of the internal `UnsafeCell`, nor
+// do we provide any methods with callbacks. Since this type is `!Sync`, only one reference to the
+// `UnsafeCell` contents can be alive at any given time, thus we cannot violate aliasing rules.
+#[derive(Default)]
+struct Queue<T> {
+    vec: UnsafeCell<Vec<T>>,
+}
+
+impl<T> Queue<T> {
+    fn new() -> Self {
+        Self {
+            vec: UnsafeCell::new(Vec::new()),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        unsafe { (*self.vec.get().cast_const()).is_empty() }
+    }
+
+    fn push(&self, val: T) {
+        unsafe {
+            (*self.vec.get()).push(val);
+        }
+    }
+
+    fn pop(&self) -> Option<T> {
+        unsafe { (*self.vec.get()).pop() }
     }
 }

--- a/src/dynamic_roots.rs
+++ b/src/dynamic_roots.rs
@@ -30,8 +30,8 @@ use crate::{
 #[derive(Copy, Clone)]
 pub struct DynamicRootSet<'gc>(Gc<'gc, Inner<'gc>>);
 
-unsafe impl<'gc> Collect for DynamicRootSet<'gc> {
-    fn trace<T: Trace + ?Sized>(&self, cc: &mut T) {
+unsafe impl<'gc> Collect<'gc> for DynamicRootSet<'gc> {
+    fn trace<T: Trace<'gc> + ?Sized>(&self, cc: &mut T) {
         cc.trace(&self.0);
     }
 }
@@ -194,8 +194,8 @@ struct Inner<'gc> {
     slots: Rc<RefCell<Slots<'gc>>>,
 }
 
-unsafe impl<'gc> Collect for Inner<'gc> {
-    fn trace<T: Trace + ?Sized>(&self, cc: &mut T) {
+unsafe impl<'gc> Collect<'gc> for Inner<'gc> {
+    fn trace<T: Trace<'gc> + ?Sized>(&self, cc: &mut T) {
         cc.trace(&*self.slots.borrow());
     }
 }
@@ -213,8 +213,8 @@ enum Slot<'gc> {
     Occupied { root: Gc<'gc, ()>, ref_count: usize },
 }
 
-unsafe impl<'gc> Collect for Slot<'gc> {
-    fn trace<T: Trace + ?Sized>(&self, cc: &mut T) {
+unsafe impl<'gc> Collect<'gc> for Slot<'gc> {
+    fn trace<T: Trace<'gc> + ?Sized>(&self, cc: &mut T) {
         match self {
             Slot::Vacant { .. } => {}
             Slot::Occupied { root, ref_count: _ } => cc.trace_gc(*root),
@@ -235,8 +235,8 @@ impl<'gc> Drop for Slots<'gc> {
     }
 }
 
-unsafe impl<'gc> Collect for Slots<'gc> {
-    fn trace<T: Trace + ?Sized>(&self, cc: &mut T) {
+unsafe impl<'gc> Collect<'gc> for Slots<'gc> {
+    fn trace<T: Trace<'gc> + ?Sized>(&self, cc: &mut T) {
         cc.trace(&self.slots);
     }
 }

--- a/src/dynamic_roots.rs
+++ b/src/dynamic_roots.rs
@@ -7,7 +7,7 @@ use alloc::{
 
 use crate::{
     arena::Root,
-    collect::{Collect, Trace, TraceExt},
+    collect::{Collect, Trace},
     metrics::Metrics,
     Gc, Mutation, Rootable,
 };
@@ -31,7 +31,7 @@ use crate::{
 pub struct DynamicRootSet<'gc>(Gc<'gc, Inner<'gc>>);
 
 unsafe impl<'gc> Collect<'gc> for DynamicRootSet<'gc> {
-    fn trace<T: Trace<'gc> + ?Sized>(&self, cc: &mut T) {
+    fn trace<T: Trace<'gc>>(&self, cc: &mut T) {
         cc.trace(&self.0);
     }
 }
@@ -195,7 +195,7 @@ struct Inner<'gc> {
 }
 
 unsafe impl<'gc> Collect<'gc> for Inner<'gc> {
-    fn trace<T: Trace<'gc> + ?Sized>(&self, cc: &mut T) {
+    fn trace<T: Trace<'gc>>(&self, cc: &mut T) {
         cc.trace(&*self.slots.borrow());
     }
 }
@@ -214,7 +214,7 @@ enum Slot<'gc> {
 }
 
 unsafe impl<'gc> Collect<'gc> for Slot<'gc> {
-    fn trace<T: Trace<'gc> + ?Sized>(&self, cc: &mut T) {
+    fn trace<T: Trace<'gc>>(&self, cc: &mut T) {
         match self {
             Slot::Vacant { .. } => {}
             Slot::Occupied { root, ref_count: _ } => cc.trace_gc(*root),
@@ -236,7 +236,7 @@ impl<'gc> Drop for Slots<'gc> {
 }
 
 unsafe impl<'gc> Collect<'gc> for Slots<'gc> {
-    fn trace<T: Trace<'gc> + ?Sized>(&self, cc: &mut T) {
+    fn trace<T: Trace<'gc>>(&self, cc: &mut T) {
         cc.trace(&self.slots);
     }
 }

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -57,7 +57,7 @@ impl<'gc, T: ?Sized + 'gc> Clone for Gc<'gc, T> {
 
 unsafe impl<'gc, T: ?Sized + 'gc> Collect<'gc> for Gc<'gc, T> {
     #[inline]
-    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
         cc.trace_gc(Self::erase(*self))
     }
 }

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -10,8 +10,8 @@ use core::{
 
 use crate::{
     barrier::{Unlock, Write},
-    collect::Collect,
-    context::{Collection, Mutation},
+    collect::{Collect, Trace},
+    context::Mutation,
     gc_weak::GcWeak,
     static_collect::Static,
     types::{GcBox, GcBoxHeader, GcBoxInner, GcColor, Invariant},
@@ -57,7 +57,7 @@ impl<'gc, T: ?Sized + 'gc> Clone for Gc<'gc, T> {
 
 unsafe impl<'gc, T: ?Sized + 'gc> Collect for Gc<'gc, T> {
     #[inline]
-    fn trace(&self, mut cc: Collection<'_>) {
+    fn trace<C: Trace + ?Sized>(&self, cc: &mut C) {
         cc.trace_gc(Self::erase(*self))
     }
 }

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -55,9 +55,9 @@ impl<'gc, T: ?Sized + 'gc> Clone for Gc<'gc, T> {
     }
 }
 
-unsafe impl<'gc, T: ?Sized + 'gc> Collect for Gc<'gc, T> {
+unsafe impl<'gc, T: ?Sized + 'gc> Collect<'gc> for Gc<'gc, T> {
     #[inline]
-    fn trace<C: Trace + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
         cc.trace_gc(Self::erase(*self))
     }
 }
@@ -85,7 +85,7 @@ impl<'gc, T: ?Sized + 'gc> Borrow<T> for Gc<'gc, T> {
     }
 }
 
-impl<'gc, T: Collect + 'gc> Gc<'gc, T> {
+impl<'gc, T: Collect<'gc> + 'gc> Gc<'gc, T> {
     #[inline]
     pub fn new(mc: &Mutation<'gc>, t: T) -> Gc<'gc, T> {
         Gc {

--- a/src/gc_weak.rs
+++ b/src/gc_weak.rs
@@ -25,9 +25,9 @@ impl<'gc, T: ?Sized + 'gc> Debug for GcWeak<'gc, T> {
     }
 }
 
-unsafe impl<'gc, T: ?Sized + 'gc> Collect for GcWeak<'gc, T> {
+unsafe impl<'gc, T: ?Sized + 'gc> Collect<'gc> for GcWeak<'gc, T> {
     #[inline]
-    fn trace<C: Trace + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
         cc.trace_gc_weak(Self::erase(*self))
     }
 }

--- a/src/gc_weak.rs
+++ b/src/gc_weak.rs
@@ -27,7 +27,7 @@ impl<'gc, T: ?Sized + 'gc> Debug for GcWeak<'gc, T> {
 
 unsafe impl<'gc, T: ?Sized + 'gc> Collect<'gc> for GcWeak<'gc, T> {
     #[inline]
-    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
         cc.trace_gc_weak(Self::erase(*self))
     }
 }

--- a/src/hashbrown.rs
+++ b/src/hashbrown.rs
@@ -4,17 +4,17 @@ mod inner {
 
     use crate::collect::{Collect, Trace, TraceExt};
 
-    unsafe impl<K, V, S, A> Collect for hashbrown::HashMap<K, V, S, A>
+    unsafe impl<'gc, K, V, S, A> Collect<'gc> for hashbrown::HashMap<K, V, S, A>
     where
-        K: Collect,
-        V: Collect,
+        K: Collect<'gc>,
+        V: Collect<'gc>,
         S: 'static,
-        A: Allocator + Clone + Collect,
+        A: Allocator + Clone + Collect<'gc>,
     {
         const NEEDS_TRACE: bool = K::NEEDS_TRACE || V::NEEDS_TRACE || A::NEEDS_TRACE;
 
         #[inline]
-        fn trace<C: Trace + ?Sized>(&self, cc: &mut C) {
+        fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
             for (k, v) in self {
                 cc.trace(k);
                 cc.trace(v);
@@ -23,16 +23,16 @@ mod inner {
         }
     }
 
-    unsafe impl<T, S, A> Collect for hashbrown::HashSet<T, S, A>
+    unsafe impl<'gc, T, S, A> Collect<'gc> for hashbrown::HashSet<T, S, A>
     where
-        T: Collect,
+        T: Collect<'gc>,
         S: 'static,
-        A: Allocator + Clone + Collect,
+        A: Allocator + Clone + Collect<'gc>,
     {
         const NEEDS_TRACE: bool = T::NEEDS_TRACE || A::NEEDS_TRACE;
 
         #[inline]
-        fn trace<C: Trace + ?Sized>(&self, cc: &mut C) {
+        fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
             for v in self {
                 cc.trace(v);
             }
@@ -40,15 +40,15 @@ mod inner {
         }
     }
 
-    unsafe impl<T, A> Collect for hashbrown::HashTable<T, A>
+    unsafe impl<'gc, T, A> Collect<'gc> for hashbrown::HashTable<T, A>
     where
-        T: Collect,
-        A: Allocator + Clone + Collect,
+        T: Collect<'gc>,
+        A: Allocator + Clone + Collect<'gc>,
     {
         const NEEDS_TRACE: bool = T::NEEDS_TRACE || A::NEEDS_TRACE;
 
         #[inline]
-        fn trace<C: Trace + ?Sized>(&self, cc: &mut C) {
+        fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
             for v in self {
                 cc.trace(v);
             }
@@ -61,16 +61,16 @@ mod inner {
 mod inner {
     use crate::collect::{Collect, Trace, TraceExt};
 
-    unsafe impl<K, V, S> Collect for hashbrown::HashMap<K, V, S>
+    unsafe impl<'gc, K, V, S> Collect<'gc> for hashbrown::HashMap<K, V, S>
     where
-        K: Collect,
-        V: Collect,
+        K: Collect<'gc>,
+        V: Collect<'gc>,
         S: 'static,
     {
         const NEEDS_TRACE: bool = K::NEEDS_TRACE || V::NEEDS_TRACE;
 
         #[inline]
-        fn trace<C: Trace + ?Sized>(&self, cc: &mut C) {
+        fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
             for (k, v) in self {
                 cc.trace(k);
                 cc.trace(v);
@@ -78,29 +78,29 @@ mod inner {
         }
     }
 
-    unsafe impl<T, S> Collect for hashbrown::HashSet<T, S>
+    unsafe impl<'gc, T, S> Collect<'gc> for hashbrown::HashSet<T, S>
     where
-        T: Collect,
+        T: Collect<'gc>,
         S: 'static,
     {
         const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
         #[inline]
-        fn trace<C: Trace + ?Sized>(&self, cc: &mut C) {
+        fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
             for v in self {
                 cc.trace(v);
             }
         }
     }
 
-    unsafe impl<T> Collect for hashbrown::HashTable<T>
+    unsafe impl<'gc, T> Collect<'gc> for hashbrown::HashTable<T>
     where
-        T: Collect,
+        T: Collect<'gc>,
     {
         const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
         #[inline]
-        fn trace<C: Trace + ?Sized>(&self, cc: &mut C) {
+        fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
             for v in self {
                 cc.trace(v);
             }

--- a/src/hashbrown.rs
+++ b/src/hashbrown.rs
@@ -2,7 +2,7 @@
 mod inner {
     use allocator_api2::alloc::Allocator;
 
-    use crate::{collect::Collect, context::Collection};
+    use crate::collect::{Collect, Trace, TraceExt};
 
     unsafe impl<K, V, S, A> Collect for hashbrown::HashMap<K, V, S, A>
     where
@@ -14,12 +14,12 @@ mod inner {
         const NEEDS_TRACE: bool = K::NEEDS_TRACE || V::NEEDS_TRACE || A::NEEDS_TRACE;
 
         #[inline]
-        fn trace(&self, mut cc: Collection<'_>) {
+        fn trace<C: Trace + ?Sized>(&self, cc: &mut C) {
             for (k, v) in self {
                 cc.trace(k);
                 cc.trace(v);
             }
-            self.allocator().trace(cc);
+            cc.trace(self.allocator());
         }
     }
 
@@ -32,11 +32,11 @@ mod inner {
         const NEEDS_TRACE: bool = T::NEEDS_TRACE || A::NEEDS_TRACE;
 
         #[inline]
-        fn trace(&self, mut cc: Collection<'_>) {
+        fn trace<C: Trace + ?Sized>(&self, cc: &mut C) {
             for v in self {
                 cc.trace(v);
             }
-            self.allocator().trace(cc);
+            cc.trace(self.allocator());
         }
     }
 
@@ -48,18 +48,18 @@ mod inner {
         const NEEDS_TRACE: bool = T::NEEDS_TRACE || A::NEEDS_TRACE;
 
         #[inline]
-        fn trace(&self, mut cc: Collection<'_>) {
+        fn trace<C: Trace + ?Sized>(&self, cc: &mut C) {
             for v in self {
                 cc.trace(v);
             }
-            self.allocator().trace(cc);
+            cc.trace(self.allocator());
         }
     }
 }
 
 #[cfg(not(feature = "allocator-api2"))]
 mod inner {
-    use crate::{collect::Collect, context::Collection};
+    use crate::collect::{Collect, Trace, TraceExt};
 
     unsafe impl<K, V, S> Collect for hashbrown::HashMap<K, V, S>
     where
@@ -70,7 +70,7 @@ mod inner {
         const NEEDS_TRACE: bool = K::NEEDS_TRACE || V::NEEDS_TRACE;
 
         #[inline]
-        fn trace(&self, mut cc: Collection<'_>) {
+        fn trace<C: Trace + ?Sized>(&self, cc: &mut C) {
             for (k, v) in self {
                 cc.trace(k);
                 cc.trace(v);
@@ -86,7 +86,7 @@ mod inner {
         const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
         #[inline]
-        fn trace(&self, mut cc: Collection<'_>) {
+        fn trace<C: Trace + ?Sized>(&self, cc: &mut C) {
             for v in self {
                 cc.trace(v);
             }
@@ -100,7 +100,7 @@ mod inner {
         const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
         #[inline]
-        fn trace(&self, mut cc: Collection<'_>) {
+        fn trace<C: Trace + ?Sized>(&self, cc: &mut C) {
             for v in self {
                 cc.trace(v);
             }

--- a/src/hashbrown.rs
+++ b/src/hashbrown.rs
@@ -2,7 +2,7 @@
 mod inner {
     use allocator_api2::alloc::Allocator;
 
-    use crate::collect::{Collect, Trace, TraceExt};
+    use crate::collect::{Collect, Trace};
 
     unsafe impl<'gc, K, V, S, A> Collect<'gc> for hashbrown::HashMap<K, V, S, A>
     where
@@ -14,7 +14,7 @@ mod inner {
         const NEEDS_TRACE: bool = K::NEEDS_TRACE || V::NEEDS_TRACE || A::NEEDS_TRACE;
 
         #[inline]
-        fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+        fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
             for (k, v) in self {
                 cc.trace(k);
                 cc.trace(v);
@@ -32,7 +32,7 @@ mod inner {
         const NEEDS_TRACE: bool = T::NEEDS_TRACE || A::NEEDS_TRACE;
 
         #[inline]
-        fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+        fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
             for v in self {
                 cc.trace(v);
             }
@@ -48,7 +48,7 @@ mod inner {
         const NEEDS_TRACE: bool = T::NEEDS_TRACE || A::NEEDS_TRACE;
 
         #[inline]
-        fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+        fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
             for v in self {
                 cc.trace(v);
             }
@@ -59,7 +59,7 @@ mod inner {
 
 #[cfg(not(feature = "allocator-api2"))]
 mod inner {
-    use crate::collect::{Collect, Trace, TraceExt};
+    use crate::collect::{Collect, Trace};
 
     unsafe impl<'gc, K, V, S> Collect<'gc> for hashbrown::HashMap<K, V, S>
     where
@@ -70,7 +70,7 @@ mod inner {
         const NEEDS_TRACE: bool = K::NEEDS_TRACE || V::NEEDS_TRACE;
 
         #[inline]
-        fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+        fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
             for (k, v) in self {
                 cc.trace(k);
                 cc.trace(v);
@@ -86,7 +86,7 @@ mod inner {
         const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
         #[inline]
-        fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+        fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
             for v in self {
                 cc.trace(v);
             }
@@ -100,7 +100,7 @@ mod inner {
         const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
         #[inline]
-        fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+        fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
             for v in self {
                 cc.trace(v);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ extern crate alloc;
 
 pub mod arena;
 pub mod barrier;
-mod collect;
+pub mod collect;
 mod collect_impl;
 mod context;
 pub mod dynamic_roots;
@@ -36,7 +36,7 @@ pub use self::{arena::__DynRootable, no_drop::__MustNotImplDrop, unsize::__Coerc
 pub use self::{
     arena::{Arena, Rootable},
     collect::Collect,
-    context::{Collection, Finalization, Mutation},
+    context::{Finalization, Mutation},
     dynamic_roots::{DynamicRoot, DynamicRootSet},
     gc::Gc,
     gc_weak::GcWeak,

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -155,11 +155,11 @@ impl<'gc, T: Copy + 'gc> Gc<'gc, Lock<T>> {
     }
 }
 
-unsafe impl<'gc, T: Collect + Copy + 'gc> Collect for Lock<T> {
+unsafe impl<'gc, T: Collect<'gc> + Copy + 'gc> Collect<'gc> for Lock<T> {
     const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
     #[inline]
-    fn trace<C: Trace + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
         // Okay, so this calls `T::trace` on a *copy* of `T`.
         //
         // This is theoretically a correctness issue, because technically `T` could have interior
@@ -287,11 +287,11 @@ impl<'gc, T: ?Sized + 'gc> Gc<'gc, RefLock<T>> {
     }
 }
 
-unsafe impl<'gc, T: Collect + 'gc + ?Sized> Collect for RefLock<T> {
+unsafe impl<'gc, T: Collect<'gc> + 'gc + ?Sized> Collect<'gc> for RefLock<T> {
     const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
     #[inline]
-    fn trace<C: Trace + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
         cc.trace(&*self.borrow());
     }
 }

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -8,7 +8,7 @@ use core::{
 
 use crate::{
     barrier::Unlock,
-    collect::{Collect, Trace, TraceExt},
+    collect::{Collect, Trace},
     Gc, Mutation,
 };
 
@@ -159,7 +159,7 @@ unsafe impl<'gc, T: Collect<'gc> + Copy + 'gc> Collect<'gc> for Lock<T> {
     const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
     #[inline]
-    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
         // Okay, so this calls `T::trace` on a *copy* of `T`.
         //
         // This is theoretically a correctness issue, because technically `T` could have interior
@@ -291,7 +291,7 @@ unsafe impl<'gc, T: Collect<'gc> + 'gc + ?Sized> Collect<'gc> for RefLock<T> {
     const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
     #[inline]
-    fn trace<C: Trace<'gc> + ?Sized>(&self, cc: &mut C) {
+    fn trace<C: Trace<'gc>>(&self, cc: &mut C) {
         cc.trace(&*self.borrow());
     }
 }

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -6,7 +6,11 @@ use core::{
     fmt,
 };
 
-use crate::{barrier::Unlock, Collect, Collection, Gc, Mutation};
+use crate::{
+    barrier::Unlock,
+    collect::{Collect, Trace, TraceExt},
+    Gc, Mutation,
+};
 
 // Helper macro to factor out the common parts of locks types.
 macro_rules! make_lock_wrapper {
@@ -155,7 +159,7 @@ unsafe impl<'gc, T: Collect + Copy + 'gc> Collect for Lock<T> {
     const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
     #[inline]
-    fn trace(&self, cc: Collection<'_>) {
+    fn trace<C: Trace + ?Sized>(&self, cc: &mut C) {
         // Okay, so this calls `T::trace` on a *copy* of `T`.
         //
         // This is theoretically a correctness issue, because technically `T` could have interior
@@ -172,7 +176,7 @@ unsafe impl<'gc, T: Collect + Copy + 'gc> Collect for Lock<T> {
         //
         // It could be fixed now, but since it is not even testable because it is currently
         // *impossible*, I did not bother. One day this may need to be implemented!
-        T::trace(&self.get(), cc);
+        cc.trace(&self.get());
     }
 }
 
@@ -287,7 +291,7 @@ unsafe impl<'gc, T: Collect + 'gc + ?Sized> Collect for RefLock<T> {
     const NEEDS_TRACE: bool = T::NEEDS_TRACE;
 
     #[inline]
-    fn trace(&self, cc: Collection<'_>) {
-        self.borrow().trace(cc);
+    fn trace<C: Trace + ?Sized>(&self, cc: &mut C) {
+        cc.trace(&*self.borrow());
     }
 }

--- a/src/static_collect.rs
+++ b/src/static_collect.rs
@@ -15,7 +15,7 @@ impl<'a, T: ?Sized + 'static> Rootable<'a> for Static<T> {
     type Root = Static<T>;
 }
 
-unsafe impl<T: ?Sized + 'static> Collect for Static<T> {
+unsafe impl<'gc, T: ?Sized + 'static> Collect<'gc> for Static<T> {
     const NEEDS_TRACE: bool = false;
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,7 +4,7 @@ use core::marker::PhantomData;
 use core::ptr::NonNull;
 use core::{mem, ptr};
 
-use crate::collect::Collect;
+use crate::{collect::Collect, context::Context};
 
 /// A thin-pointer-sized box containing a type-erased GC object.
 /// Stores the metadata required by the GC algorithm inline (see `GcBoxInner`
@@ -47,7 +47,7 @@ impl GcBox {
     ///
     /// **SAFETY**: `Self::drop_in_place` must not have been called.
     #[inline(always)]
-    pub(crate) unsafe fn trace_value(&self, cc: crate::Collection<'_>) {
+    pub(crate) unsafe fn trace_value(&self, cc: &mut Context) {
         (self.header().vtable().trace_value)(*self, cc)
     }
 
@@ -193,7 +193,7 @@ struct CollectVtable {
     /// Drops the value stored in the given `GcBox` (without deallocating the box).
     drop_value: unsafe fn(GcBox),
     /// Traces the value stored in the given `GcBox`.
-    trace_value: unsafe fn(GcBox, crate::Collection<'_>),
+    trace_value: unsafe fn(GcBox, &mut Context),
 }
 
 impl CollectVtable {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -621,7 +621,7 @@ fn okay_panic() {
     }
 
     unsafe impl<'gc> Collect<'gc> for Test<'gc> {
-        fn trace<T: Trace<'gc> + ?Sized>(&self, cc: &mut T) {
+        fn trace<T: Trace<'gc>>(&self, cc: &mut T) {
             let panics = self.panic_count.get();
             if panics > 0 {
                 self.panic_count.set(panics - 1);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -595,6 +595,8 @@ fn ptr_magic() {
 fn okay_panic() {
     use std::panic::{catch_unwind, AssertUnwindSafe};
 
+    use gc_arena::collect::Trace;
+
     struct Test<'gc> {
         data: Gc<'gc, [u8; 256]>,
         panic_count: Cell<u8>,
@@ -602,7 +604,7 @@ fn okay_panic() {
     }
 
     unsafe impl<'gc> Collect for Test<'gc> {
-        fn trace(&self, cc: gc_arena::Collection<'_>) {
+        fn trace<T: Trace + ?Sized>(&self, cc: &mut T) {
             let panics = self.panic_count.get();
             if panics > 0 {
                 self.panic_count.set(panics - 1);

--- a/tests/ui/bad_collect_bound.stderr
+++ b/tests/ui/bad_collect_bound.stderr
@@ -1,13 +1,13 @@
-error[E0277]: the trait bound `NotCollect: Collect` is not satisfied
+error[E0277]: the trait bound `NotCollect: Collect<'_>` is not satisfied
  --> tests/ui/bad_collect_bound.rs:8:12
   |
 8 |     field: NotCollect
   |            ^^^^^^^^^^
   |            |
-  |            the trait `Collect` is not implemented for `NotCollect`
-  |            the trait `Collect` is not implemented for `NotCollect`
+  |            the trait `Collect<'_>` is not implemented for `NotCollect`
+  |            the trait `Collect<'_>` is not implemented for `NotCollect`
   |
-  = help: the following other types implement trait `Collect`:
+  = help: the following other types implement trait `Collect<'gc>`:
             &'static T
             ()
             (A, B)
@@ -18,16 +18,16 @@ error[E0277]: the trait bound `NotCollect: Collect` is not satisfied
             (A, B, C, D, E, F, G)
           and $N others
 
-error[E0277]: the trait bound `NotCollect: Collect` is not satisfied
+error[E0277]: the trait bound `NotCollect: Collect<'_>` is not satisfied
  --> tests/ui/bad_collect_bound.rs:8:5
   |
 5 | #[derive(Collect)]
   |          ------- in this derive macro expansion
 ...
 8 |     field: NotCollect
-  |     ^^^^^ the trait `Collect` is not implemented for `NotCollect`
+  |     ^^^^^ the trait `Collect<'_>` is not implemented for `NotCollect`
   |
-  = help: the following other types implement trait `Collect`:
+  = help: the following other types implement trait `Collect<'gc>`:
             &'static T
             ()
             (A, B)
@@ -40,6 +40,6 @@ error[E0277]: the trait bound `NotCollect: Collect` is not satisfied
 note: required by a bound in `gc_arena::collect::TraceExt::trace`
  --> src/collect.rs
   |
-  |     fn trace<C: Collect + ?Sized>(&mut self, _value: &C);
-  |                 ^^^^^^^ required by this bound in `TraceExt::trace`
+  |     fn trace<C: Collect<'gc> + ?Sized>(&mut self, _value: &C);
+  |                 ^^^^^^^^^^^^ required by this bound in `TraceExt::trace`
   = note: this error originates in the derive macro `Collect` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/bad_collect_bound.stderr
+++ b/tests/ui/bad_collect_bound.stderr
@@ -18,14 +18,14 @@ error[E0277]: the trait bound `NotCollect: Collect<'_>` is not satisfied
             (A, B, C, D, E, F, G)
           and $N others
 
-error[E0277]: the trait bound `NotCollect: Collect<'_>` is not satisfied
+error[E0277]: the trait bound `NotCollect: Collect<'gc>` is not satisfied
  --> tests/ui/bad_collect_bound.rs:8:5
   |
 5 | #[derive(Collect)]
   |          ------- in this derive macro expansion
 ...
 8 |     field: NotCollect
-  |     ^^^^^ the trait `Collect<'_>` is not implemented for `NotCollect`
+  |     ^^^^^ the trait `Collect<'gc>` is not implemented for `NotCollect`
   |
   = help: the following other types implement trait `Collect<'gc>`:
             &'static T
@@ -37,9 +37,9 @@ error[E0277]: the trait bound `NotCollect: Collect<'_>` is not satisfied
             (A, B, C, D, E, F)
             (A, B, C, D, E, F, G)
           and $N others
-note: required by a bound in `gc_arena::collect::TraceExt::trace`
+note: required by a bound in `gc_arena::collect::Trace::trace`
  --> src/collect.rs
   |
-  |     fn trace<C: Collect<'gc> + ?Sized>(&mut self, _value: &C);
-  |                 ^^^^^^^^^^^^ required by this bound in `TraceExt::trace`
+  |     fn trace<C: Collect<'gc> + ?Sized>(&mut self, value: &C)
+  |                 ^^^^^^^^^^^^ required by this bound in `Trace::trace`
   = note: this error originates in the derive macro `Collect` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/bad_collect_bound.stderr
+++ b/tests/ui/bad_collect_bound.stderr
@@ -37,9 +37,9 @@ error[E0277]: the trait bound `NotCollect: Collect` is not satisfied
             (A, B, C, D, E, F)
             (A, B, C, D, E, F, G)
           and $N others
-note: required by a bound in `Collection::<'a>::trace`
- --> src/context.rs
+note: required by a bound in `gc_arena::collect::TraceExt::trace`
+ --> src/collect.rs
   |
-  |     pub fn trace<T: Collect + ?Sized>(&mut self, value: &T) {
-  |                     ^^^^^^^ required by this bound in `Collection::<'a>::trace`
+  |     fn trace<C: Collect + ?Sized>(&mut self, _value: &C);
+  |                 ^^^^^^^ required by this bound in `TraceExt::trace`
   = note: this error originates in the derive macro `Collect` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Builds off of #107 to further improve the `Collect` trait.

There are three main API changes:

* Makes the `Collect::trace` method take a generic parameter that must implement the new trait `Trace`. This will be useful in the future to generically scan any value type for the properties of their held pointers.
* Adds a `'gc` lifetime parameter to `Collect` and `Trace`, allowing for more safety especially when implementing `Trace` which is a safe trait.
* Changes the `#[derive(Collect)]` proc macro to handle the required `'gc` lifetime on `Collect` and `Trace`. Almost always this will work without any further changes, but in the extremely rare and almost completely useless case where a type has multiple lifetime parameters, one must now be selected with `#[collect(gc_lifetime = 'gc)]`.

There are also some additional related internal changes
* Internally, don't use `RefCell<Vec<GcBox>>` for the gray queues. Instead, just unsafety via a new internal `Queue` type. This avoids the need for locking in all cases.
* Because of the previous change, we can get rid of `MarkState` entirely and implement `Trace` on `Context` directly.

This also changes some parts of the design of #107 and there are some open questions.

* `Collect::trace` now accepts `&mut (impl Trace<'gc> + ?Sized)` instead of `impl Trace<'gc>` which would more closely match what used to be `Collection<'_>`. This is for a few reasons:

  1) Requiring the implementer of `Trace` to always provide a special reborrow trace method that takes `T: Collect` is slightly obnoxious, and would require that every implementation always include the `if T::NEEDS_TRACE { ... }` check itself.
  2) We probably want to leave open the possibility of passing a dyn trait here, in case we need to one day need to allow tracing the *contents* of a `Gc` via vtable (such as with a cast `Gc` pointer).
  3) Every method on `Trace` accepts `&mut self`, so accepting a `&mut impl Trace<'gc>` allows for avoiding a double indirection on `Trace` methods.

  However, this does not *enforce* that implementers of `Collect` must always use a convenience method that includes `if T::NEEDS_TRACE { ... }`. To me this is not a very big deal, because:
  1) The previous technique only enforced this *in the case where there were multiple fields* due to moving the `Collection<'_>` object, and the fact that it doesn't work doesn't automatically hint to *why* things were designed that way.
  2) We can do whatever we want in the proc derive
  3) It usually not actually THAT bad if `Collect::trace` doesn't check `NEEDS_TRACE` on its field types. This only matters when the inner `Collect::trace` is not inline or doesn't itself early exit.

  Instead of `Collection::trace`, I added a `TraceExt` extension trait and a `TraceExt::trace` extension method which does what `Collection::trace` used to do. I would have liked to avoid an extension trait, but adding it as an inherent `Trace` method has problems as well, namely that it wouldn't work with `&mut dyn Trace` (which would be required for one day tracing pointee of `Gc<'gc, ()>`). I could have also added this convenience method on `Collect` in the form of an additional method that always checked `Self::NEEDS_TRACE`, but that is also somewhat confusing because both methods would have default implementations (and it wouldn't be immediately clear which one to implement). On the balance, this seemed the best option but I'm open to changing how this works.

* Should `Collect<'gc>` also imply `: 'gc`?
* Is `#[collect(gc_lifetime = 'gc)]` just overkill?
* The vtable `trace_value` function signature is `unsafe fn(GcBox, &mut Context)`, it *could* be `unsafe fn(GcBox, &mut dyn Trace<'gc>)` for future use, but I figured it was worth it to micro-optimize this?