### PR TITLE
Add `Arena::cycle_debt` and some method renames to aid phase tracking

### DIFF
--- a/examples/linked_list.rs
+++ b/examples/linked_list.rs
@@ -146,7 +146,7 @@ fn main() {
     // automatically. We have to trigger collection *outside* of a mutation
     // method.
     //
-    // The `Arena::finish_collection` runs a full collection cycle, but this
+    // The `Arena::finish_cycle` method runs a full collection cycle, but this
     // is not the only way to trigger collection.
     //
     // `gc-arena` is an incremental collector, and so keeps track of "debt"
@@ -159,7 +159,7 @@ fn main() {
     // Since the collector has not yet started its marking phase, calling this
     // will fully mark the arena and collect all the garbage, so this method
     // will always free the 4 node.
-    arena.finish_collection();
+    arena.finish_cycle();
 
     arena.mutate_root(|_, root| {
         // Now we can see that if we rotate through our circular list, we will


### PR DESCRIPTION
Since `Arena::collect_debt` no longer deterministically returns at exact end of a cycle (because debt is now normally carried over to the next cycle), there is no way to always be able to track exactly when a new collection cycle starts.

This fixes the problem by adding `Arena::cycle_debt`, which works like the old `Arena::collect_debt` in that it always returns at the end of a cycle. It also renames `Arena::finish_collection` to `Arena::finish_cycle` to be in symmetry the same way as `Arena::mark_debt` and `Arena::finish_marking`, and improves the comments to make the situation easier to understand.