### PR TITLE
Remove `sptr` polyfill for Strict Provenance APIs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/rust:1.79.0
+      - image: cimg/rust:1.84.0
     steps:
       - checkout
       - run:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ allocator-api2 = ["dep:allocator-api2", "hashbrown?/allocator-api2"]
 allocator-api2 = { version = "0.2", optional = true, default-features = false, features = ["alloc"] }
 gc-arena-derive = { path = "./derive", version = "0.5.3"}
 hashbrown = { version = "0.15.2", optional = true, default-features = false }
-sptr = "0.3.2"
 tracing = { version = "0.1.37", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/src/types.rs
+++ b/src/types.rs
@@ -263,11 +263,6 @@ pub(crate) type Invariant<'a> = PhantomData<Cell<&'a ()>>;
 
 /// Utility functions for tagging and untagging pointers.
 mod tagged_ptr {
-    #![cfg_attr(not(miri), allow(unstable_name_collisions))]
-
-    #[cfg(not(miri))]
-    use sptr::Strict as _;
-
     use core::cell::Cell;
 
     trait ValidMask<const MASK: usize> {

--- a/tests/ui/bad_collect_bound.stderr
+++ b/tests/ui/bad_collect_bound.stderr
@@ -2,10 +2,7 @@ error[E0277]: the trait bound `NotCollect: Collect<'_>` is not satisfied
  --> tests/ui/bad_collect_bound.rs:8:12
   |
 8 |     field: NotCollect
-  |            ^^^^^^^^^^
-  |            |
-  |            the trait `Collect<'_>` is not implemented for `NotCollect`
-  |            the trait `Collect<'_>` is not implemented for `NotCollect`
+  |            ^^^^^^^^^^ the trait `Collect<'_>` is not implemented for `NotCollect`
   |
   = help: the following other types implement trait `Collect<'gc>`:
             &'static T


### PR DESCRIPTION
The Strict Provenance APIs are stable since Rust 1.84, so let's use them instead.