### PR TITLE
Add a few extra `Write` methods for `Box` and `[T]`

### DIFF
--- a/src/barrier.rs
+++ b/src/barrier.rs
@@ -118,6 +118,22 @@ impl<T, E> Write<Result<T, E>> {
     }
 }
 
+impl<T: ?Sized> Write<alloc::boxed::Box<T>> {
+    /// Converts from `&Write<Box<T>>` to `&Write<T>`.
+    #[inline(always)]
+    pub fn deref_write(&self) -> &Write<T> {
+        unsafe { Write::assume(&*self.__inner) }
+    }
+}
+
+impl<T> Write<[T]> {
+    /// Writes to a specific element in a `&Write<[T]>`, returning a `&Write<T>`.
+    #[inline(always)]
+    pub fn write_at(&self, index: usize) -> &Write<T> {
+        unsafe { Write::assume(&self.__inner[index]) }
+    }
+}
+
 /// Types that support additional operations (typically, mutation) when behind a write barrier.
 pub trait Unlock {
     /// This will typically be a cell-like type providing some sort of interior mutability.


### PR DESCRIPTION
Allows you to have a `Box<[Lock<T>]>` in a `Gc` and write to each element in the array.

In the future, when we allow directly allocating `dyn` types, the array write method will also allow you to have a `Gc<[Lock<T>]>` and write to a specific element.