### PR TITLE
Add `OnceLock` (a GC-aware `OnceCell`)

### DIFF
--- a/src/gc.rs
+++ b/src/gc.rs
@@ -166,9 +166,7 @@ impl<'gc, T: Unlock + ?Sized + 'gc> Gc<'gc, T> {
     /// Shorthand for [`Gc::write`]`(mc, self).`[`unlock()`](Write::unlock).
     #[inline]
     pub fn unlock(self, mc: &Mutation<'gc>) -> &'gc T::Unlocked {
-        Gc::write(mc, self);
-        // SAFETY: see doc-comment.
-        unsafe { self.as_ref().unlock_unchecked() }
+        Gc::write(mc, self).unlock()
     }
 }
 


### PR DESCRIPTION
The name clash with `std::sync::OnceLock` is a little unfortunate, but I can't think of a better name.