### PR TITLE
Migrate to Edition 2024 and fix `field!` macro.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/rust:1.84.0
+      - image: cimg/rust:1.88.0
     steps:
       - checkout
       - run:
@@ -11,7 +11,7 @@ jobs:
           command: |
             rustup component add rustfmt
             rustup toolchain uninstall nightly
-            rustup toolchain install nightly -c miri rust-src
+            rustup toolchain install nightly -c miri,rust-src
       - run:
           name: Version information
           command: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 [workspace.package]
 version = "0.5.3"
 authors = ["kyren <catherine@kyju.org>", "moulins", "Aaron Hill <aa1ronham@gmail.com>"]
-edition = "2021"
+edition = "2024"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/kyren/gc-arena"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,11 +1,11 @@
 use proc_macro2::{Span, TokenStream};
-use quote::{quote, quote_spanned, ToTokens};
+use quote::{ToTokens, quote, quote_spanned};
 use syn::{
     parse::{Parse, ParseStream},
     spanned::Spanned,
     visit_mut::VisitMut,
 };
-use synstructure::{decl_derive, AddBounds};
+use synstructure::{AddBounds, decl_derive};
 
 fn collect_derive(s: synstructure::Structure) -> TokenStream {
     fn find_collect_meta(attrs: &[syn::Attribute]) -> syn::Result<Option<&syn::Attribute>> {
@@ -225,7 +225,9 @@ fn collect_derive(s: synstructure::Structure) -> TokenStream {
                 if all_lifetimes.next().is_none() {
                     gc_lifetime = Some(lt.lifetime.clone());
                 } else {
-                    panic!("deriving `Collect` on a type with multiple lifetime parameters requires a `#[collect(gc_lifetime = ...)]` attribute");
+                    panic!(
+                        "deriving `Collect` on a type with multiple lifetime parameters requires a `#[collect(gc_lifetime = ...)]` attribute"
+                    );
                 }
             }
         };

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -2,9 +2,9 @@ use alloc::boxed::Box;
 use core::marker::PhantomData;
 
 use crate::{
+    Collect,
     context::{Context, Finalization, Mutation, Phase, RunUntil, Stop},
     metrics::Metrics,
-    Collect,
 };
 
 /// A trait that produces a [`Collect`]-able type for the given lifetime. This is used to produce

--- a/src/context.rs
+++ b/src/context.rs
@@ -7,10 +7,10 @@ use core::{
 };
 
 use crate::{
+    Gc, GcWeak,
     collect::{Collect, Trace},
     metrics::Metrics,
     types::{GcBox, GcBoxHeader, GcBoxInner, GcColor, Invariant},
-    Gc, GcWeak,
 };
 
 /// Handle value given by arena callbacks during construction and mutation. Allows allocating new
@@ -247,12 +247,12 @@ impl Context {
 
     #[inline]
     pub(crate) unsafe fn mutation_context<'gc>(&self) -> &Mutation<'gc> {
-        mem::transmute::<&Self, &Mutation>(&self)
+        unsafe { mem::transmute::<&Self, &Mutation>(&self) }
     }
 
     #[inline]
     pub(crate) unsafe fn finalization_context<'gc>(&self) -> &Finalization<'gc> {
-        mem::transmute::<&Self, &Finalization>(&self)
+        unsafe { mem::transmute::<&Self, &Finalization>(&self) }
     }
 
     #[inline]

--- a/src/dynamic_roots.rs
+++ b/src/dynamic_roots.rs
@@ -6,10 +6,10 @@ use alloc::{
 };
 
 use crate::{
+    Gc, Mutation, Rootable,
     arena::Root,
     collect::{Collect, Trace},
     metrics::Metrics,
-    Gc, Mutation, Rootable,
 };
 
 /// A way of registering GC roots dynamically.

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -9,13 +9,13 @@ use core::{
 };
 
 use crate::{
+    Finalization,
     barrier::{Unlock, Write},
     collect::{Collect, Trace},
     context::Mutation,
     gc_weak::GcWeak,
     static_collect::Static,
     types::{GcBox, GcBoxHeader, GcBoxInner, GcColor, Invariant},
-    Finalization,
 };
 
 /// A garbage collected pointer to a type T. Implements Copy, and is implemented as a plain machine
@@ -151,13 +151,15 @@ impl<'gc, T: ?Sized + 'gc> Gc<'gc, T> {
     /// have been collected yet.
     #[inline]
     pub unsafe fn from_ptr(ptr: *const T) -> Gc<'gc, T> {
-        let layout = Layout::new::<GcBoxHeader>();
-        let (_, header_offset) = layout.extend(Layout::for_value(&*ptr)).unwrap();
-        let header_offset = -(header_offset as isize);
-        let ptr = (ptr as *mut T).byte_offset(header_offset) as *mut GcBoxInner<T>;
-        Gc {
-            ptr: NonNull::new_unchecked(ptr),
-            _invariant: PhantomData,
+        unsafe {
+            let layout = Layout::new::<GcBoxHeader>();
+            let (_, header_offset) = layout.extend(Layout::for_value(&*ptr)).unwrap();
+            let header_offset = -(header_offset as isize);
+            let ptr = (ptr as *mut T).byte_offset(header_offset) as *mut GcBoxInner<T>;
+            Gc {
+                ptr: NonNull::new_unchecked(ptr),
+                _invariant: PhantomData,
+            }
         }
     }
 }

--- a/src/gc_weak.rs
+++ b/src/gc_weak.rs
@@ -1,8 +1,8 @@
+use crate::Mutation;
 use crate::collect::{Collect, Trace};
 use crate::context::Finalization;
 use crate::gc::Gc;
 use crate::types::GcBox;
-use crate::Mutation;
 
 use core::fmt::{self, Debug};
 
@@ -120,8 +120,9 @@ impl<'gc, T: ?Sized + 'gc> GcWeak<'gc, T> {
     /// It must be valid to dereference a `*mut U` that has come from casting a `*mut T`.
     #[inline]
     pub unsafe fn cast<U: 'gc>(this: GcWeak<'gc, T>) -> GcWeak<'gc, U> {
-        GcWeak {
-            inner: Gc::cast::<U>(this.inner),
+        unsafe {
+            let inner = Gc::cast::<U>(this.inner);
+            GcWeak { inner }
         }
     }
 
@@ -145,8 +146,7 @@ impl<'gc, T: ?Sized + 'gc> GcWeak<'gc, T> {
     /// pointer).
     #[inline]
     pub unsafe fn from_ptr(ptr: *const T) -> GcWeak<'gc, T> {
-        GcWeak {
-            inner: Gc::from_ptr(ptr),
-        }
+        let inner = unsafe { Gc::from_ptr(ptr) };
+        GcWeak { inner }
     }
 }

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -7,9 +7,9 @@ use core::{
 };
 
 use crate::{
+    Gc, Mutation,
     barrier::Unlock,
     collect::{Collect, Trace},
-    Gc, Mutation,
 };
 
 // Helper macro to factor out the common parts of locks types.

--- a/src/static_collect.rs
+++ b/src/static_collect.rs
@@ -1,5 +1,5 @@
-use crate::collect::Collect;
 use crate::Rootable;
+use crate::collect::Collect;
 
 use alloc::borrow::{Borrow, BorrowMut};
 use core::convert::{AsMut, AsRef};

--- a/src/unsize.rs
+++ b/src/unsize.rs
@@ -84,10 +84,11 @@ unsafe impl<'gc, T, U: ?Sized> __CoercePtrInternal<Gc<'gc, U>> for Gc<'gc, T> {
         F: FnOnce(*mut T) -> *mut U,
     {
         let ptr = self.ptr.as_ptr() as *mut T;
-        let ptr = NonNull::new_unchecked(coerce(ptr) as *mut GcBoxInner<U>);
-        Gc {
-            ptr,
-            _invariant: PhantomData,
+        unsafe {
+            Gc {
+                ptr: NonNull::new_unchecked(coerce(ptr) as *mut GcBoxInner<U>),
+                _invariant: PhantomData,
+            }
         }
     }
 }
@@ -101,7 +102,9 @@ unsafe impl<'gc, T, U: ?Sized> __CoercePtrInternal<GcWeak<'gc, U>> for GcWeak<'g
     where
         F: FnOnce(*mut T) -> *mut U,
     {
-        let inner = self.inner.__coerce_unchecked(coerce);
-        GcWeak { inner }
+        unsafe {
+            let inner = self.inner.__coerce_unchecked(coerce);
+            GcWeak { inner }
+        }
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -5,8 +5,8 @@ use rand::distributions::Distribution;
 use std::{collections::HashMap, rc::Rc};
 
 use gc_arena::{
-    arena::CollectionPhase, metrics::Pacing, static_collect, unsize, Arena, Collect,
-    DynamicRootSet, Gc, GcWeak, Lock, RefLock, Rootable,
+    Arena, Collect, DynamicRootSet, Gc, GcWeak, Lock, RefLock, Rootable, arena::CollectionPhase,
+    metrics::Pacing, static_collect, unsize,
 };
 
 #[test]
@@ -46,11 +46,12 @@ fn weak_allocation() {
     });
     arena.finish_cycle();
     arena.mutate(|mc, root| {
-        assert!(root
-            .weak
-            .upgrade(mc)
-            .map(|gc| Gc::ptr_eq(gc, root.test.borrow().unwrap()))
-            .unwrap_or(false));
+        assert!(
+            root.weak
+                .upgrade(mc)
+                .map(|gc| Gc::ptr_eq(gc, root.test.borrow().unwrap()))
+                .unwrap_or(false)
+        );
 
         *root.test.unlock(mc).borrow_mut() = None;
     });
@@ -234,7 +235,7 @@ fn test_layouts() {
 
             let ptr = gc_arena::arena::rootless_mutate(|mc| {
                 let gc = Gc::new(mc, Wrapper(Aligned(array)));
-                assert_eq!(array, gc.0 .0);
+                assert_eq!(array, gc.0.0);
                 Gc::as_ptr(gc) as *mut ()
             });
 
@@ -605,7 +606,7 @@ fn ptr_magic() {
 #[cfg(feature = "std")]
 #[test]
 fn okay_panic() {
-    use std::panic::{catch_unwind, AssertUnwindSafe};
+    use std::panic::{AssertUnwindSafe, catch_unwind};
 
     use gc_arena::collect::Trace;
 

--- a/tests/ui/bad_write_field_projections.rs
+++ b/tests/ui/bad_write_field_projections.rs
@@ -5,20 +5,29 @@ use gc_arena::barrier::{Write, field};
 
 struct Foo<'gc> {
     foo: i32,
-    bar: Gc<'gc, u32>,
-    baz: f64,
+    bar: f64,
+    baz: &'static u32,
+    quux: Gc<'gc, u32>,
 }
 
-fn projection_prederef<'a, 'gc>(v: &'a Write<Gc<'gc, Foo<'gc>>>) -> &'a Write<i32> {
+fn projection_prederef1<'a, 'gc>(v: &'a Write<&'a Foo<'gc>>) -> &'a Write<i32> {
     field!(v, Foo, foo)
 }
 
-fn projection_postderef<'a, 'gc>(v: &'a Write<Foo<'gc>>) -> &'a Write<u32> {
-    field!(v, Foo, bar)
+fn projection_prederef2<'a, 'gc>(v: &'a Write<Gc<'gc, Foo<'gc>>>) -> &'a Write<i32> {
+    field!(v, Foo, foo)
+}
+
+fn projection_postderef1<'a, 'gc>(v: &'a Write<Foo<'gc>>) -> &'a Write<u32> {
+    field!(v, Foo, baz)
+}
+
+fn projection_postderef2<'a, 'gc>(v: &'a Write<Foo<'gc>>) -> &'a Write<u32> {
+    field!(v, Foo, quux)
 }
 
 fn projection_wrong_type<'a, 'gc>(v: &'a Write<Foo<'gc>>) -> &'a Write<i64> {
-    field!(v, Foo, baz)
+    field!(v, Foo, bar)
 }
 
 fn main() {}

--- a/tests/ui/bad_write_field_projections.stderr
+++ b/tests/ui/bad_write_field_projections.stderr
@@ -1,28 +1,40 @@
 error[E0308]: mismatched types
-  --> tests/ui/bad_write_field_projections.rs:13:5
+  --> tests/ui/bad_write_field_projections.rs:18:5
    |
-13 |     field!(v, Foo, foo)
+18 |     field!(v, Foo, foo)
    |     ^^^^^^^-^^^^^^^^^^^
    |     |      |
    |     |      this expression has type `&'a gc_arena::barrier::Write<Gc<'gc, Foo<'gc>>>`
    |     expected `Gc<'_, Foo<'_>>`, found `Foo<'_>`
    |
-   = note: expected struct `Gc<'gc, Foo<'gc>, >`
+   = note: expected struct `Gc<'gc, Foo<'gc>>`
               found struct `Foo<'_>`
    = note: this error originates in the macro `field` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0606]: casting `&Gc<'_, u32>` as `*const u32` is invalid
-  --> tests/ui/bad_write_field_projections.rs:17:5
+help: consider dereferencing to access the inner value using the Deref trait
    |
-17 |     field!(v, Foo, bar)
+18 |     field!(&***v, Foo, foo)
+   |            ++++
+
+error[E0606]: casting `&&'static u32` as `*const u32` is invalid
+  --> tests/ui/bad_write_field_projections.rs:22:5
+   |
+22 |     field!(v, Foo, baz)
    |     ^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `field` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0308]: mismatched types
-  --> tests/ui/bad_write_field_projections.rs:21:5
+error[E0606]: casting `&Gc<'_, u32>` as `*const u32` is invalid
+  --> tests/ui/bad_write_field_projections.rs:26:5
    |
-21 |     field!(v, Foo, baz)
+26 |     field!(v, Foo, quux)
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `field` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui/bad_write_field_projections.rs:30:5
+   |
+30 |     field!(v, Foo, bar)
    |     ^^^^^^^^^^^^^^^^^^^
    |     |
    |     expected `&i64`, found `&f64`
@@ -38,9 +50,23 @@ note: associated function defined here
    = note: this error originates in the macro `field` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0606]: casting `&f64` as `*const i64` is invalid
-  --> tests/ui/bad_write_field_projections.rs:21:5
+  --> tests/ui/bad_write_field_projections.rs:30:5
    |
-21 |     field!(v, Foo, baz)
+30 |     field!(v, Foo, bar)
    |     ^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `field` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: binding modifiers may only be written when the default binding mode is `move`
+  --> tests/ui/bad_write_field_projections.rs:14:5
+   |
+14 |     field!(v, Foo, foo)
+   |     ^^^^^^^^^^^^^^^^^^^ occurs within macro expansion
+   |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
+   = note: this error originates in the macro `field` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: make the implied reference pattern explicit
+  --> src/barrier.rs
+   |
+   |                 __inner: &$type { ref $field, .. },
+   |                          +


### PR DESCRIPTION
The `field!` macro incorrectly allowed projections through references (e.g. `&Write<&Container> -> &Write<Field>`); migrating to edition 2024 fixes this thanks to the tightening of pattern binding mode rules (decl-macro hygiene ensures that the 2024 rules are applied even if the calling crate is <=2024).

