### PR TITLE
Add a `DynCollect` trait and a way to safely GC custom dyn traits

### DIFF
--- a/src/collect_impl.rs
+++ b/src/collect_impl.rs
@@ -10,20 +10,6 @@ use std::collections::{HashMap, HashSet};
 
 use crate::collect::{Collect, Trace};
 
-/// If a type is static, we know that it can never hold `Gc` pointers, so it is safe to provide a
-/// simple empty `Collect` implementation.
-#[macro_export]
-macro_rules! static_collect {
-    ($type:ty) => {
-        unsafe impl<'gc> Collect<'gc> for $type
-        where
-            $type: 'static,
-        {
-            const NEEDS_TRACE: bool = false;
-        }
-    };
-}
-
 static_collect!(bool);
 static_collect!(char);
 static_collect!(u8);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ extern crate alloc;
 
 pub mod arena;
 pub mod barrier;
+#[macro_use]
 pub mod collect;
 mod collect_impl;
 mod context;


### PR DESCRIPTION
`Box<dyn DynCollect>` now implements `Collect`, and `Box<dyn MyTrait>` can implement `Collect` with the use of a safe macro.

As a drive-by change, moves the `static_collect!` macro to the `collect` module and backports the nicer generics syntax from `dyn_collect!`.