### PR TITLE
Adds support for sized types with a dynamic layout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ allocator-api2 = ["dep:allocator-api2", "hashbrown?/allocator-api2"]
 
 [dependencies]
 allocator-api2 = { version = "0.2", optional = true, default-features = false, features = ["alloc"] }
+contracts = { version = "0.6.7", default-features = false }
 gc-arena-derive = { path = "./derive", version = "0.5.3"}
 hashbrown = { version = "0.15.2", optional = true, default-features = false }
 tracing = { version = "0.1.37", optional = true, default-features = false }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,16 +1,15 @@
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{alloc::Layout, vec::Vec};
 use core::{
     cell::{Cell, UnsafeCell},
-    mem,
+    mem::{self, MaybeUninit},
     ops::{ControlFlow, Deref, DerefMut},
-    ptr::NonNull,
 };
 
 use crate::{
     Gc, GcWeak,
     collect::{Collect, Trace},
     metrics::Metrics,
-    types::{GcBox, GcBoxHeader, GcBoxInner, GcColor, Invariant},
+    types::{ErasedGcBox, GcBox, GcColor, Invariant},
 };
 
 /// Handle value given by arena callbacks during construction and mutation. Allows allocating new
@@ -40,19 +39,15 @@ impl<'gc> Mutation<'gc> {
     /// pointer(s) before collection is next triggered.
     #[inline]
     pub fn backward_barrier(&self, parent: Gc<'gc, ()>, child: Option<Gc<'gc, ()>>) {
-        self.context.backward_barrier(
-            unsafe { GcBox::erase(parent.ptr) },
-            child.map(|p| unsafe { GcBox::erase(p.ptr) }),
-        )
+        self.context
+            .backward_barrier(parent.ptr.erase(), child.map(|p| p.ptr.erase()))
     }
 
     /// A version of [`Mutation::backward_barrier`] that allows adopting a [`GcWeak`] child.
     #[inline]
     pub fn backward_barrier_weak(&self, parent: Gc<'gc, ()>, child: GcWeak<'gc, ()>) {
         self.context
-            .backward_barrier_weak(unsafe { GcBox::erase(parent.ptr) }, unsafe {
-                GcBox::erase(child.inner.ptr)
-            })
+            .backward_barrier_weak(parent.ptr.erase(), child.inner.ptr.erase())
     }
 
     /// IF we are in the marking phase AND the `parent` pointer (if given) is colored black, AND
@@ -70,27 +65,31 @@ impl<'gc> Mutation<'gc> {
     #[inline]
     pub fn forward_barrier(&self, parent: Option<Gc<'gc, ()>>, child: Gc<'gc, ()>) {
         self.context
-            .forward_barrier(parent.map(|p| unsafe { GcBox::erase(p.ptr) }), unsafe {
-                GcBox::erase(child.ptr)
-            })
+            .forward_barrier(parent.map(|p| p.ptr.erase()), child.ptr.erase())
     }
 
     /// A version of [`Mutation::forward_barrier`] that allows adopting a [`GcWeak`] child.
     #[inline]
     pub fn forward_barrier_weak(&self, parent: Option<Gc<'gc, ()>>, child: GcWeak<'gc, ()>) {
         self.context
-            .forward_barrier_weak(parent.map(|p| unsafe { GcBox::erase(p.ptr) }), unsafe {
-                GcBox::erase(child.inner.ptr)
-            })
+            .forward_barrier_weak(parent.map(|p| p.ptr.erase()), child.inner.ptr.erase())
     }
 
     #[inline]
-    pub(crate) fn allocate<T: Collect<'gc> + 'gc>(&self, t: T) -> NonNull<GcBoxInner<T>> {
-        self.context.allocate(t)
+    pub(crate) fn allocate_sized<T: Collect<'gc> + 'gc>(&self, t: T) -> GcBox<T> {
+        self.context.allocate_sized(t)
     }
 
     #[inline]
-    pub(crate) fn upgrade(&self, gc_box: GcBox) -> bool {
+    pub(crate) fn allocate_dynamic_layout<T: Collect<'gc> + 'gc>(
+        &self,
+        layout: Layout,
+    ) -> GcBox<MaybeUninit<T>> {
+        self.context.allocate_dynamic_layout(layout)
+    }
+
+    #[inline]
+    pub(crate) fn upgrade(&self, gc_box: ErasedGcBox) -> bool {
         self.context.upgrade(gc_box)
     }
 }
@@ -116,19 +115,19 @@ impl<'gc> Deref for Finalization<'gc> {
 
 impl<'gc> Finalization<'gc> {
     #[inline]
-    pub(crate) fn resurrect(&self, gc_box: GcBox) {
+    pub(crate) fn resurrect(&self, gc_box: ErasedGcBox) {
         self.context.resurrect(gc_box)
     }
 }
 
 impl<'gc> Trace<'gc> for Context {
     fn trace_gc(&mut self, gc: Gc<'gc, ()>) {
-        let gc_box = unsafe { GcBox::erase(gc.ptr) };
+        let gc_box = gc.ptr.erase();
         Context::trace(self, gc_box)
     }
 
     fn trace_gc_weak(&mut self, gc: GcWeak<'gc, ()>) {
-        let gc_box = unsafe { GcBox::erase(gc.inner.ptr) };
+        let gc_box = gc.inner.ptr.erase();
         Context::trace_weak(self, gc_box)
     }
 }
@@ -170,19 +169,19 @@ pub(crate) struct Context {
     phase_span: tracing::Span,
 
     // A linked list of all allocated `GcBox`es.
-    all: Cell<Option<GcBox>>,
+    all: Cell<Option<ErasedGcBox>>,
 
     // A copy of the head of `all` at the end of `Phase::Mark`.
     // During `Phase::Sweep`, we free all white allocations on this list.
     // Any allocations created *during* `Phase::Sweep` will be added to `all`,
     // but `sweep` will *not* be updated. This ensures that we keep allocations
     // alive until we've had a chance to trace them.
-    sweep: Option<GcBox>,
+    sweep: Option<ErasedGcBox>,
 
     // The most recent black object that we encountered during `Phase::Sweep`.
     // When we free objects, we update this `GcBox.next` to remove them from
     // the linked list.
-    sweep_prev: Cell<Option<GcBox>>,
+    sweep_prev: Cell<Option<ErasedGcBox>>,
 
     /// Does the root needs to be traced?
     /// This should be `true` at the beginning of `Phase::Mark`.
@@ -190,16 +189,16 @@ pub(crate) struct Context {
 
     /// A queue of gray objects, used during `Phase::Mark`.
     /// This holds traceable objects that have yet to be traced.
-    gray: Queue<GcBox>,
+    gray: Queue<ErasedGcBox>,
 
     // A queue of gray objects that became gray as a result
     // of a write barrier.
-    gray_again: Queue<GcBox>,
+    gray_again: Queue<ErasedGcBox>,
 }
 
 impl Drop for Context {
     fn drop(&mut self) {
-        struct DropAll<'a>(&'a Metrics, Option<GcBox>);
+        struct DropAll<'a>(&'a Metrics, Option<ErasedGcBox>);
 
         impl<'a> Drop for DropAll<'a> {
             fn drop(&mut self) {
@@ -208,7 +207,7 @@ impl Drop for Context {
                     while let Some(mut gc_box) = drop_resume.1.take() {
                         let header = gc_box.header();
                         drop_resume.1 = header.next();
-                        let gc_size = header.size_of_box();
+                        let gc_size = gc_box.layout().size();
                         // SAFETY: the context owns its GC'd objects
                         unsafe {
                             if header.is_live() {
@@ -365,36 +364,45 @@ impl Context {
         cx.log_progress("GC: yielding...");
     }
 
-    fn allocate<'gc, T: Collect<'gc>>(&self, t: T) -> NonNull<GcBoxInner<T>> {
-        let header = GcBoxHeader::new::<T>();
-        header.set_next(self.all.get());
-        header.set_live(true);
-        header.set_needs_trace(T::NEEDS_TRACE);
+    fn allocate_sized<'gc, T: Collect<'gc>>(&self, value: T) -> GcBox<T> {
+        let mut out: GcBox<MaybeUninit<T>> = GcBox::alloc_fixed(self.all.get());
+        unsafe {
+            out.get_mut().write(value);
+        }
+        let out: GcBox<T> = out.cast();
 
-        let alloc_size = header.size_of_box();
+        self.all.set(Some(out.erase()));
 
-        // Make the generated code easier to optimize into `T` being constructed in place or at the
-        // very least only memcpy'd once.
-        // For more information, see: https://github.com/kyren/gc-arena/pull/14
-        let (gc_box, ptr) = unsafe {
-            let mut uninitialized = Box::new(mem::MaybeUninit::<GcBoxInner<T>>::uninit());
-            core::ptr::write(uninitialized.as_mut_ptr(), GcBoxInner::new(header, t));
-            let ptr = NonNull::new_unchecked(Box::into_raw(uninitialized) as *mut GcBoxInner<T>);
-            (GcBox::erase(ptr), ptr)
-        };
-
-        self.all.set(Some(gc_box));
         if self.phase == Phase::Sweep && self.sweep_prev.get().is_none() {
             self.sweep_prev.set(self.all.get());
         }
 
+        let alloc_size = out.erase().layout().size();
         self.metrics.mark_gc_allocated(alloc_size);
 
-        ptr
+        out
+    }
+
+    fn allocate_dynamic_layout<'gc, T: Collect<'gc>>(
+        &self,
+        layout: Layout,
+    ) -> GcBox<MaybeUninit<T>> {
+        let out: GcBox<MaybeUninit<T>> = GcBox::alloc_dynamic(self.all.get(), layout);
+
+        self.all.set(Some(out.erase()));
+
+        if self.phase == Phase::Sweep && self.sweep_prev.get().is_none() {
+            self.sweep_prev.set(self.all.get());
+        }
+
+        let alloc_size = out.erase().layout().size();
+        self.metrics.mark_gc_allocated(alloc_size);
+
+        out
     }
 
     #[inline]
-    fn backward_barrier(&self, parent: GcBox, child: Option<GcBox>) {
+    fn backward_barrier(&self, parent: ErasedGcBox, child: Option<ErasedGcBox>) {
         // During the marking phase, if we are mutating a black object, we may add a white object to
         // it and invalidate the invariant that black objects may not point to white objects. Turn
         // the black parent object gray to prevent this.
@@ -411,7 +419,7 @@ impl Context {
             // Outline the actual barrier code (which is somewhat expensive and won't be executed
             // often) to promote the inlining of the write barrier.
             #[cold]
-            fn barrier(this: &Context, parent: GcBox) {
+            fn barrier(this: &Context, parent: ErasedGcBox) {
                 this.make_gray_again(parent);
             }
             barrier(&self, parent);
@@ -419,7 +427,7 @@ impl Context {
     }
 
     #[inline]
-    fn backward_barrier_weak(&self, parent: GcBox, child: GcBox) {
+    fn backward_barrier_weak(&self, parent: ErasedGcBox, child: ErasedGcBox) {
         if self.phase == Phase::Mark
             && parent.header().color() == GcColor::Black
             && child.header().color() == GcColor::White
@@ -427,7 +435,7 @@ impl Context {
             // Outline the actual barrier code (which is somewhat expensive and won't be executed
             // often) to promote the inlining of the write barrier.
             #[cold]
-            fn barrier(this: &Context, parent: GcBox) {
+            fn barrier(this: &Context, parent: ErasedGcBox) {
                 this.make_gray_again(parent);
             }
             barrier(&self, parent);
@@ -435,7 +443,7 @@ impl Context {
     }
 
     #[inline]
-    fn forward_barrier(&self, parent: Option<GcBox>, child: GcBox) {
+    fn forward_barrier(&self, parent: Option<ErasedGcBox>, child: ErasedGcBox) {
         // During the marking phase, if we are mutating a black object, we may add a white object
         // to it and invalidate the invariant that black objects may not point to white objects.
         // Immediately trace the child white object to turn it gray (or black) to prevent this.
@@ -447,7 +455,7 @@ impl Context {
             // Outline the actual barrier code (which is somewhat expensive and won't be executed
             // often) to promote the inlining of the write barrier.
             #[cold]
-            fn barrier(this: &Context, child: GcBox) {
+            fn barrier(this: &Context, child: ErasedGcBox) {
                 this.trace(child);
             }
             barrier(&self, child);
@@ -455,7 +463,7 @@ impl Context {
     }
 
     #[inline]
-    fn forward_barrier_weak(&self, parent: Option<GcBox>, child: GcBox) {
+    fn forward_barrier_weak(&self, parent: Option<ErasedGcBox>, child: ErasedGcBox) {
         // During the marking phase, if we are mutating a black object, we may add a white object
         // to it and invalidate the invariant that black objects may not point to white objects.
         // Immediately trace the child white object to turn it gray (or black) to prevent this.
@@ -467,7 +475,7 @@ impl Context {
             // Outline the actual barrier code (which is somewhat expensive and won't be executed
             // often) to promote the inlining of the write barrier.
             #[cold]
-            fn barrier(this: &Context, child: GcBox) {
+            fn barrier(this: &Context, child: ErasedGcBox) {
                 this.trace_weak(child);
             }
             barrier(&self, child);
@@ -475,7 +483,7 @@ impl Context {
     }
 
     #[inline]
-    fn trace(&self, gc_box: GcBox) {
+    fn trace(&self, gc_box: ErasedGcBox) {
         let header = gc_box.header();
         let color = header.color();
         match color {
@@ -494,25 +502,25 @@ impl Context {
 
                 // Only marking the *first* time counts as a mark metric.
                 if color == GcColor::White {
-                    self.metrics.mark_gc_marked(header.size_of_box());
+                    self.metrics.mark_gc_marked(gc_box.layout().size());
                 }
             }
         }
     }
 
     #[inline]
-    fn trace_weak(&self, gc_box: GcBox) {
+    fn trace_weak(&self, gc_box: ErasedGcBox) {
         let header = gc_box.header();
         if header.color() == GcColor::White {
             header.set_color(GcColor::WhiteWeak);
-            self.metrics.mark_gc_marked(header.size_of_box());
+            self.metrics.mark_gc_marked(gc_box.layout().size());
         }
     }
 
     /// Determines whether or not a Gc pointer is safe to be upgraded.
     /// This is used by weak pointers to determine if it can safely upgrade to a strong pointer.
     #[inline]
-    fn upgrade(&self, gc_box: GcBox) -> bool {
+    fn upgrade(&self, gc_box: ErasedGcBox) -> bool {
         let header = gc_box.header();
 
         // This object has already been freed, definitely not safe to upgrade.
@@ -558,7 +566,7 @@ impl Context {
     }
 
     #[inline]
-    fn resurrect(&self, gc_box: GcBox) {
+    fn resurrect(&self, gc_box: ErasedGcBox) {
         let header = gc_box.header();
         debug_assert_eq!(self.phase, Phase::Mark);
         debug_assert!(header.is_live());
@@ -568,7 +576,7 @@ impl Context {
             self.gray.push(gc_box);
             // Only marking the *first* time counts as a mark metric.
             if color == GcColor::White {
-                self.metrics.mark_gc_marked(header.size_of_box());
+                self.metrics.mark_gc_marked(gc_box.layout().size());
             }
         }
     }
@@ -589,7 +597,7 @@ impl Context {
             // We always mark work for objects processed from both the gray and "gray again" queue.
             // When objects are placed into the "gray again" queue due to a write barrier, the
             // original work is *undone*, so we do it again here.
-            self.metrics.mark_gc_traced(gc_box.header().size_of_box());
+            self.metrics.mark_gc_traced(gc_box.layout().size());
             gc_box.header().set_color(GcColor::Black);
 
             // If we have an object in the gray queue, take one, trace it, and turn it black.
@@ -603,7 +611,7 @@ impl Context {
             // trace method to not panic before attempting to collect it again.
             struct DropGuard<'a> {
                 context: &'a mut Context,
-                gc_box: GcBox,
+                gc_box: ErasedGcBox,
             }
 
             impl<'a> Drop for DropGuard<'a> {
@@ -639,7 +647,7 @@ impl Context {
         };
 
         let sweep_header = sweep.header();
-        let sweep_size = sweep_header.size_of_box();
+        let sweep_size = sweep.layout().size();
 
         let next_box = sweep_header.next();
         self.sweep = next_box;
@@ -707,12 +715,12 @@ impl Context {
     }
 
     // Take a black pointer and turn it gray and put it in the `gray_again` queue.
-    fn make_gray_again(&self, gc_box: GcBox) {
+    fn make_gray_again(&self, gc_box: ErasedGcBox) {
         let header = gc_box.header();
         debug_assert_eq!(header.color(), GcColor::Black);
         header.set_color(GcColor::Gray);
         self.gray_again.push(gc_box);
-        self.metrics.mark_gc_untraced(header.size_of_box());
+        self.metrics.mark_gc_untraced(gc_box.layout().size());
     }
 }
 

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -1,9 +1,10 @@
+use alloc::alloc::Layout;
 use core::{
-    alloc::Layout,
     borrow::Borrow,
     fmt::{self, Debug, Display, Pointer},
     hash::{Hash, Hasher},
     marker::PhantomData,
+    mem::MaybeUninit,
     ops::Deref,
     ptr::NonNull,
 };
@@ -15,16 +16,16 @@ use crate::{
     context::Mutation,
     gc_weak::GcWeak,
     static_collect::Static,
-    types::{GcBox, GcBoxHeader, GcBoxInner, GcColor, Invariant},
+    types::{GcBox, GcColor, Invariant},
 };
 
 /// A garbage collected pointer to a type T. Implements Copy, and is implemented as a plain machine
-/// pointer. You can only allocate `Gc` pointers through a `&Mutation<'gc>` inside an arena type,
-/// and through "generativity" such `Gc` pointers may not escape the arena they were born in or
-/// be stored inside TLS. This, combined with correct `Collect` implementations, means that `Gc`
+/// pointer to `T`. You can only allocate `Gc` pointers through a `&Mutation<'gc>` inside an arena
+/// type, and through "generativity" such `Gc` pointers may not escape the arena they were born in
+/// or be stored inside TLS. This, combined with correct `Collect` implementations, means that `Gc`
 /// pointers will never be dangling and are always safe to access.
 pub struct Gc<'gc, T: ?Sized + 'gc> {
-    pub(crate) ptr: NonNull<GcBoxInner<T>>,
+    pub(crate) ptr: GcBox<T>,
     pub(crate) _invariant: Invariant<'gc>,
 }
 
@@ -67,21 +68,21 @@ impl<'gc, T: ?Sized + 'gc> Deref for Gc<'gc, T> {
 
     #[inline]
     fn deref(&self) -> &T {
-        unsafe { &self.ptr.as_ref().value }
+        unsafe { &self.ptr.get_ptr().as_ref() }
     }
 }
 
 impl<'gc, T: ?Sized + 'gc> AsRef<T> for Gc<'gc, T> {
     #[inline]
     fn as_ref(&self) -> &T {
-        unsafe { &self.ptr.as_ref().value }
+        unsafe { &self.ptr.get_ptr().as_ref() }
     }
 }
 
 impl<'gc, T: ?Sized + 'gc> Borrow<T> for Gc<'gc, T> {
     #[inline]
     fn borrow(&self) -> &T {
-        unsafe { &self.ptr.as_ref().value }
+        unsafe { &self.ptr.get_ptr().as_ref() }
     }
 }
 
@@ -89,9 +90,25 @@ impl<'gc, T: Collect<'gc> + 'gc> Gc<'gc, T> {
     #[inline]
     pub fn new(mc: &Mutation<'gc>, t: T) -> Gc<'gc, T> {
         Gc {
-            ptr: mc.allocate(t),
+            ptr: mc.allocate_sized(t),
             _invariant: PhantomData,
         }
+    }
+}
+
+impl<'gc, T: Collect<'gc> + 'gc> Gc<'gc, T> {
+    #[inline]
+    pub fn new_dynamic_layout(mc: &Mutation<'gc>, layout: Layout) -> Gc<'gc, MaybeUninit<T>> {
+        Gc {
+            ptr: mc.allocate_dynamic_layout(layout),
+            _invariant: PhantomData,
+        }
+    }
+}
+
+impl<'gc, T: Collect<'gc> + 'gc> Gc<'gc, MaybeUninit<T>> {
+    pub unsafe fn assume_init(self) -> Gc<'gc, T> {
+        unsafe { Gc::cast(self) }
     }
 }
 
@@ -129,7 +146,7 @@ impl<'gc, T: ?Sized + 'gc> Gc<'gc, T> {
     #[inline]
     pub unsafe fn cast<U: 'gc>(this: Gc<'gc, T>) -> Gc<'gc, U> {
         Gc {
-            ptr: NonNull::cast(this.ptr),
+            ptr: this.ptr.cast(),
             _invariant: PhantomData,
         }
     }
@@ -152,12 +169,8 @@ impl<'gc, T: ?Sized + 'gc> Gc<'gc, T> {
     #[inline]
     pub unsafe fn from_ptr(ptr: *const T) -> Gc<'gc, T> {
         unsafe {
-            let layout = Layout::new::<GcBoxHeader>();
-            let (_, header_offset) = layout.extend(Layout::for_value(&*ptr)).unwrap();
-            let header_offset = -(header_offset as isize);
-            let ptr = (ptr as *mut T).byte_offset(header_offset) as *mut GcBoxInner<T>;
             Gc {
-                ptr: NonNull::new_unchecked(ptr),
+                ptr: GcBox::from_ptr(NonNull::new(ptr as *mut T).unwrap()),
                 _invariant: PhantomData,
             }
         }
@@ -182,7 +195,7 @@ impl<'gc, T: ?Sized + 'gc> Gc<'gc, T> {
         // SAFETY: The returned reference cannot escape the current arena callback, as `&'gc T`
         // never implements `Collect` (unless `'gc` is `'static`, which is impossible here), and
         // so cannot be stored inside the GC root.
-        unsafe { &self.ptr.as_ref().value }
+        unsafe { self.ptr.get_ptr().as_ref() }
     }
 
     #[inline]
@@ -220,10 +233,7 @@ impl<'gc, T: ?Sized + 'gc> Gc<'gc, T> {
 
     #[inline]
     pub fn as_ptr(gc: Gc<'gc, T>) -> *const T {
-        unsafe {
-            let inner = gc.ptr.as_ptr();
-            core::ptr::addr_of!((*inner).value) as *const T
-        }
+        gc.ptr.get_ptr().as_ptr()
     }
 
     /// Returns true when a pointer is *dead* during finalization. This is equivalent to
@@ -233,8 +243,7 @@ impl<'gc, T: ?Sized + 'gc> Gc<'gc, T> {
     /// pointers reachable only through other weak pointers that can be dead.
     #[inline]
     pub fn is_dead(_: &Finalization<'gc>, gc: Gc<'gc, T>) -> bool {
-        let inner = unsafe { gc.ptr.as_ref() };
-        matches!(inner.header.color(), GcColor::White | GcColor::WhiteWeak)
+        matches!(gc.ptr.header().color(), GcColor::White | GcColor::WhiteWeak)
     }
 
     /// Manually marks a dead `Gc` pointer as reachable and keeps it alive.
@@ -244,9 +253,7 @@ impl<'gc, T: ?Sized + 'gc> Gc<'gc, T> {
     /// collection cycle.
     #[inline]
     pub fn resurrect(fc: &Finalization<'gc>, gc: Gc<'gc, T>) {
-        unsafe {
-            fc.resurrect(GcBox::erase(gc.ptr));
-        }
+        fc.resurrect(gc.ptr.erase());
     }
 }
 

--- a/src/gc_weak.rs
+++ b/src/gc_weak.rs
@@ -2,7 +2,6 @@ use crate::Mutation;
 use crate::collect::{Collect, Trace};
 use crate::context::Finalization;
 use crate::gc::Gc;
-use crate::types::GcBox;
 
 use core::fmt::{self, Debug};
 
@@ -39,7 +38,7 @@ impl<'gc, T: ?Sized + 'gc> GcWeak<'gc, T> {
     /// [`crate::arena::CollectionPhase::Sweeping`] phase and we know the pointer *will* be dropped.
     #[inline]
     pub fn upgrade(self, mc: &Mutation<'gc>) -> Option<Gc<'gc, T>> {
-        let ptr = unsafe { GcBox::erase(self.inner.ptr) };
+        let ptr = self.inner.ptr.erase();
         mc.upgrade(ptr).then(|| self.inner)
     }
 
@@ -54,7 +53,7 @@ impl<'gc, T: ?Sized + 'gc> GcWeak<'gc, T> {
     /// It is not safe to use this to use this and casting as a substitute for [`GcWeak::upgrade`].
     #[inline]
     pub fn is_dropped(self) -> bool {
-        !unsafe { self.inner.ptr.as_ref() }.header.is_live()
+        !self.inner.ptr.header().is_live()
     }
 
     /// Returns true when a pointer is *dead* during finalization.
@@ -90,7 +89,7 @@ impl<'gc, T: ?Sized + 'gc> GcWeak<'gc, T> {
     pub fn resurrect(self, fc: &Finalization<'gc>) -> Option<Gc<'gc, T>> {
         // SAFETY: We know that we are currently marking, so any non-dropped pointer is safe to
         // resurrect.
-        if unsafe { self.inner.ptr.as_ref() }.header.is_live() {
+        if self.inner.ptr.header().is_live() {
             Gc::resurrect(fc, self.inner);
             Some(self.inner)
         } else {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,46 +1,297 @@
-use core::alloc::Layout;
-use core::cell::Cell;
-use core::marker::PhantomData;
-use core::ptr::NonNull;
-use core::{mem, ptr};
+use alloc::alloc::{alloc, dealloc, handle_alloc_error};
+use contracts::ensures;
+use core::{
+    alloc::Layout,
+    cell::Cell,
+    fmt::{self, Debug, Formatter},
+    marker::PhantomData,
+    mem::MaybeUninit,
+    num::NonZero,
+    ptr::{self, NonNull},
+};
 
 use crate::{collect::Collect, context::Context};
 
-/// A thin-pointer-sized box containing a type-erased GC object.
-/// Stores the metadata required by the GC algorithm inline (see `GcBoxInner`
-/// for its typed counterpart).
+/// A type storing layout information about a box containing a GC'd object.
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct GcBoxLayout {
+    /// The overall layout of the box.
+    box_layout: Layout,
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub(crate) struct GcBox(NonNull<GcBoxInner<()>>);
+    /// The offset from the start of the allocation to the layout, if this is a dynamic layout. If
+    /// this is a fixed layout, always 0.
+    offset_of_box_layout: usize,
 
-impl GcBox {
-    /// Erases a pointer to a typed GC object.
-    ///
-    /// **SAFETY:** The pointer must point to a valid `GcBoxInner` allocated
-    /// in a `Box`.
+    /// The offset from the start of the allocation to the GC header.
+    offset_of_header: usize,
+
+    /// The offset from the start of the allocation to the boxed value.
+    offset_of_value: usize,
+}
+
+impl GcBoxLayout {
+    /// Returns the `GcBoxLayout` to use for an allocation of the given type with a fixed layout.
     #[inline(always)]
-    pub(crate) unsafe fn erase<T: ?Sized>(ptr: NonNull<GcBoxInner<T>>) -> Self {
-        // This cast is sound because `GcBoxInner` is `repr(C)`.
-        let erased = ptr.as_ptr() as *mut GcBoxInner<()>;
-        unsafe { Self(NonNull::new_unchecked(erased)) }
-    }
+    #[ensures(ret.box_layout.size() != 0)]
+    #[ensures(ret.offset_of_box_layout == 0)]
+    #[ensures((ret.offset_of_header % Layout::new::<GcBoxHeader>().align()) == 0)]
+    #[ensures((ret.offset_of_value % Layout::new::<T>().align()) == 0)]
+    pub const fn for_fixed<T>() -> GcBoxLayout {
+        let header_layout = Layout::new::<GcBoxHeader>();
+        let value_layout = Layout::new::<T>();
 
-    /// Gets a pointer to the value stored inside this box.
-    /// `T` must be the same type that was used with `erase`, so that
-    /// we can correctly compute the field offset.
-    #[inline(always)]
-    fn unerased_value<T>(&self) -> *mut T {
-        unsafe {
-            let ptr = self.0.as_ptr() as *mut GcBoxInner<T>;
-            // Don't create a reference, to keep the full provenance.
-            // Also, this gives us interior mutability "for free".
-            ptr::addr_of_mut!((*ptr).value) as *mut T
+        let (box_layout, offset_of_value) = layout_extend_or_die(header_layout, value_layout);
+
+        assert!(header_layout.size() <= offset_of_value);
+        let offset_of_header = offset_of_value - header_layout.size();
+
+        GcBoxLayout {
+            box_layout,
+            offset_of_box_layout: 0,
+            offset_of_header,
+            offset_of_value,
         }
     }
 
+    /// Returns the `GcBoxLayout` to use for an allocation of the given type with a dynamic layout.
     #[inline(always)]
-    pub(crate) fn header(&self) -> &GcBoxHeader {
-        unsafe { &self.0.as_ref().header }
+    #[ensures(ret.box_layout.size() != 0)]
+    #[ensures((ret.offset_of_box_layout % Layout::new::<Layout>().align()) == 0)]
+    #[ensures((ret.offset_of_header % Layout::new::<GcBoxHeader>().align()) == 0)]
+    #[ensures((ret.offset_of_value % value_layout.align()) == 0)]
+    pub const fn for_dynamic(value_layout: Layout) -> GcBoxLayout {
+        let box_layout_layout = Layout::new::<Layout>();
+        let header_layout = Layout::new::<GcBoxHeader>();
+
+        let (box_layout, _) = layout_extend_or_die(box_layout_layout, header_layout);
+        let (box_layout, offset_of_value) = layout_extend_or_die(box_layout, value_layout);
+
+        assert!(header_layout.size() <= offset_of_value);
+        let offset_of_header = offset_of_value - header_layout.size();
+        assert!(box_layout_layout.size() <= offset_of_header);
+        let offset_of_box_layout = offset_of_header - box_layout_layout.size();
+
+        GcBoxLayout {
+            box_layout,
+            offset_of_box_layout,
+            offset_of_header,
+            offset_of_value,
+        }
+    }
+}
+
+/// A wrapper for `Layout::extend(...).unwrap()` to work around `.unwrap()` not being const.
+const fn layout_extend_or_die(l1: Layout, l2: Layout) -> (Layout, usize) {
+    match l1.extend(l2) {
+        Ok(out) => out,
+        Err(_) => panic!("GcBox would be impossibly large"),
+    }
+}
+
+/// A box containing a GC'd object.
+///
+/// The metadata is stored before the value in memory, possibly including a layout if this object
+/// was allocated with a dynamic layout.
+///
+/// Note that this means there may be padding at the _start_ of the allocation, if the object's
+/// alignment is greater than the header and layout's alignment.
+pub(crate) struct GcBox<T: ?Sized>(NonNull<T>);
+
+impl<'gc, T: Collect<'gc>> GcBox<T> {
+    /// Allocates a `GcBox` with a fixed layout.
+    pub fn alloc_fixed(next: Option<ErasedGcBox>) -> GcBox<MaybeUninit<T>> {
+        let header = GcBoxHeader::new_fixed::<T>(next);
+        let layout = GcBoxLayout::for_fixed::<T>();
+
+        // SAFETY: The post-condition on GcBoxLayout::for_fixed guarantees that the size is
+        // non-zero.
+        let ptr = unsafe { alloc(layout.box_layout) };
+        let ptr = NonNull::new(ptr).unwrap_or_else(|| {
+            handle_alloc_error(layout.box_layout);
+        });
+
+        // SAFETY: If this overflows, the allocation does too.
+        let value_ptr = unsafe { ptr.byte_add(layout.offset_of_value) };
+
+        // SAFETY: Uninitialized memory is a valid MaybeUninit, and we initialize the header before
+        // returning this.
+        let gc_box = unsafe { GcBox::from_ptr(value_ptr.cast::<MaybeUninit<T>>()) };
+
+        // SAFETY: TODO
+        unsafe {
+            gc_box.erase().header_ptr().write(header);
+        }
+
+        assert_eq!(layout.box_layout, gc_box.erase().layout());
+        gc_box
+    }
+
+    /// Allocates a `GcBox` with the given layout for its value.
+    pub fn alloc_dynamic(next: Option<ErasedGcBox>, value_layout: Layout) -> GcBox<MaybeUninit<T>> {
+        let header = GcBoxHeader::new_dynamic::<T>(next);
+        let layout = GcBoxLayout::for_dynamic(value_layout);
+
+        // SAFETY: The post-condition on GcBoxLayout::for_fixed guarantees that the size is
+        // non-zero.
+        let ptr = unsafe { alloc(layout.box_layout) };
+        let ptr = NonNull::new(ptr).unwrap_or_else(|| {
+            handle_alloc_error(layout.box_layout);
+        });
+
+        // SAFETY: This has to be in-bounds.
+        unsafe {
+            ptr.byte_add(layout.offset_of_box_layout)
+                .cast()
+                .write(layout.box_layout);
+            ptr.byte_add(layout.offset_of_header).cast().write(header);
+        };
+
+        // SAFETY: If this overflows, the allocation does too.
+        let value_ptr = unsafe { ptr.byte_add(layout.offset_of_value) };
+
+        // SAFETY: Uninitialized memory is a valid MaybeUninit, and we initialize the header before
+        // returning this.
+        let gc_box = unsafe { GcBox::from_ptr(value_ptr.cast::<MaybeUninit<T>>()) };
+
+        assert_eq!(layout.box_layout, gc_box.erase().layout());
+        gc_box
+    }
+}
+
+impl<T: ?Sized> GcBox<T> {
+    /// TODO: Docs
+    #[inline(always)]
+    pub unsafe fn from_ptr(ptr: NonNull<T>) -> GcBox<T> {
+        GcBox(ptr)
+    }
+
+    /// TODO
+    #[inline(always)]
+    pub fn cast<U>(self) -> GcBox<U> {
+        GcBox(self.0.cast())
+    }
+
+    /// Gets a mutable reference to the value stored inside this box.
+    ///
+    /// TODO: docs
+    #[inline(always)]
+    pub unsafe fn get_mut(&mut self) -> &mut T {
+        unsafe { self.0.as_mut() }
+    }
+
+    /// Gets a pointer to the value stored inside this box.
+    #[inline(always)]
+    pub fn get_ptr(self) -> NonNull<T> {
+        self.0
+    }
+
+    /// Type-erases the box.
+    #[inline(always)]
+    pub fn erase(self) -> ErasedGcBox {
+        ErasedGcBox(self.0.cast())
+    }
+
+    /// Returns a reference to the GC header.
+    #[inline(always)]
+    pub fn header(&self) -> &GcBoxHeader {
+        unsafe { self.erase().header_ptr().as_ref() }
+    }
+}
+
+impl<T: ?Sized> Copy for GcBox<T> {}
+
+impl<T: ?Sized> Clone for GcBox<T> {
+    fn clone(&self) -> GcBox<T> {
+        GcBox(self.0)
+    }
+}
+
+impl<T: ?Sized> Debug for GcBox<T> {
+    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
+        fmt.debug_tuple("GcBox").field(&self.0).finish()
+    }
+}
+
+impl<T: ?Sized> Eq for GcBox<T> {}
+
+impl<T: ?Sized> PartialEq for GcBox<T> {
+    fn eq(&self, other: &GcBox<T>) -> bool {
+        ptr::eq(self.0.as_ptr(), other.0.as_ptr())
+    }
+}
+
+/// A type-erased version of `GcBox`.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ErasedGcBox(NonNull<()>);
+
+impl ErasedGcBox {
+    /// "Unerases" the type.
+    ///
+    /// **SAFETY**: The type `T` must be the same type as in the `GcBox<T>` that was erased.
+    pub(crate) unsafe fn unerase<T>(self) -> GcBox<T> {
+        GcBox(self.0.cast())
+    }
+
+    /// Returns a pointer to the start of the box.
+    fn box_ptr(self) -> NonNull<()> {
+        // SAFETY: TODO
+        let unaligned_ptr = if self.header().dynamic_layout() {
+            unsafe {
+                self.0
+                    .cast::<GcBoxHeader>()
+                    .sub(1)
+                    .cast::<Layout>()
+                    .sub(1)
+                    .cast::<()>()
+            }
+        } else {
+            unsafe { self.0.cast::<GcBoxHeader>().sub(1).cast::<()>() }
+        };
+
+        let layout = self.layout();
+        unaligned_ptr.map_addr(|addr| NonZero::new(addr.get() & !(layout.align() - 1)).unwrap())
+    }
+
+    /// Deallocates the box. Failing to call `Self::drop_in_place` beforehand
+    /// will cause the stored value to be leaked.
+    ///
+    /// **SAFETY**: once called, this `ErasedGcBox` should never be accessed by any GC
+    /// pointers again.
+    #[inline(always)]
+    pub(crate) unsafe fn dealloc(self) {
+        let ptr = self.box_ptr();
+        let layout = self.layout();
+
+        // SAFETY: the pointer was `Box`-allocated with this layout.
+        unsafe { dealloc(ptr.as_ptr().cast(), layout) }
+    }
+
+    /// Returns a reference to the GC header.
+    #[inline(always)]
+    pub fn header(&self) -> &GcBoxHeader {
+        unsafe { self.header_ptr().as_ref() }
+    }
+
+    /// Returns a pointer to the GC header.
+    #[inline(always)]
+    fn header_ptr(&self) -> NonNull<GcBoxHeader> {
+        unsafe { self.0.cast::<GcBoxHeader>().sub(1) }
+    }
+
+    #[inline]
+    pub fn layout(&self) -> Layout {
+        if self.header().dynamic_layout() {
+            // SAFETY: The pointer was allocated by the GC, so we know that this all stays
+            // in-bounds and the layout is at the appropriate location.
+            unsafe {
+                let value_ptr = self.0;
+                let header_ptr = value_ptr.cast::<GcBoxHeader>().sub(1);
+                let layout_ptr = header_ptr.cast::<Layout>().sub(1);
+                layout_ptr.read()
+            }
+        } else {
+            self.header().vtable().box_layout
+        }
     }
 
     /// Traces the stored value.
@@ -59,52 +310,50 @@ impl GcBox {
     pub(crate) unsafe fn drop_in_place(&mut self) {
         unsafe { (self.header().vtable().drop_value)(*self) }
     }
-
-    /// Deallocates the box. Failing to call `Self::drop_in_place` beforehand
-    /// will cause the stored value to be leaked.
-    ///
-    /// **SAFETY**: once called, this `GcBox` should never be accessed by any GC
-    /// pointers again.
-    #[inline(always)]
-    pub(crate) unsafe fn dealloc(self) {
-        unsafe {
-            let layout = self.header().vtable().box_layout;
-            let ptr = self.0.as_ptr() as *mut u8;
-            // SAFETY: the pointer was `Box`-allocated with this layout.
-            alloc::alloc::dealloc(ptr, layout);
-        }
-    }
 }
 
 pub(crate) struct GcBoxHeader {
     /// The next element in the global linked list of allocated objects.
-    next: Cell<Option<GcBox>>,
+    next: Cell<Option<ErasedGcBox>>,
+
     /// A custom virtual function table for handling type-specific operations.
     ///
     /// The lower bits of the pointer are used to store GC flags:
     /// - bits 0 & 1 for the current `GcColor`;
     /// - bit 2 for the `needs_trace` flag;
-    /// - bit 3 for the `is_live` flag.
+    /// - bit 3 for the `is_live` flag;
+    /// - bit 4 for the `dynamic_layout` flag.
     tagged_vtable: Cell<*const CollectVtable>,
 }
 
 impl GcBoxHeader {
+    /// Creates a header for an allocation of the given type with a fixed layout.
     #[inline(always)]
-    pub fn new<'gc, T: Collect<'gc>>() -> Self {
-        // Helper trait to materialize vtables in static memory.
-        trait HasCollectVtable {
-            const VTABLE: CollectVtable;
-        }
+    pub fn new_fixed<'gc, T: Collect<'gc>>(next: Option<ErasedGcBox>) -> GcBoxHeader {
+        let vtable: *const _ = CollectVtable::new::<T>();
+        let header = GcBoxHeader {
+            next: Cell::new(next),
+            tagged_vtable: Cell::new(vtable),
+        };
+        header.set_live(true);
+        header.set_needs_trace(T::NEEDS_TRACE);
+        header
+    }
 
-        impl<'gc, T: Collect<'gc>> HasCollectVtable for T {
-            const VTABLE: CollectVtable = CollectVtable::vtable_for::<T>();
-        }
-
-        let vtable: &'static _ = &<T as HasCollectVtable>::VTABLE;
-        Self {
-            next: Cell::new(None),
-            tagged_vtable: Cell::new(vtable as *const _),
-        }
+    /// Creates a header for an allocation of the given type with a dynamic layout.
+    ///
+    /// This still needs a generic `T` bound to get the function pointers in the vtable.
+    #[inline(always)]
+    pub fn new_dynamic<'gc, T: Collect<'gc>>(next: Option<ErasedGcBox>) -> GcBoxHeader {
+        let vtable: *const _ = CollectVtable::new::<T>();
+        let header = GcBoxHeader {
+            next: Cell::new(next),
+            tagged_vtable: Cell::new(vtable),
+        };
+        header.set_live(true);
+        header.set_needs_trace(T::NEEDS_TRACE);
+        header.set_dynamic_layout(true);
+        header
     }
 
     /// Gets a reference to the `CollectVtable` used by this box.
@@ -119,20 +368,14 @@ impl GcBoxHeader {
 
     /// Gets the next element in the global linked list of allocated objects.
     #[inline(always)]
-    pub(crate) fn next(&self) -> Option<GcBox> {
+    pub(crate) fn next(&self) -> Option<ErasedGcBox> {
         self.next.get()
     }
 
     /// Sets the next element in the global linked list of allocated objects.
     #[inline(always)]
-    pub(crate) fn set_next(&self, next: Option<GcBox>) {
+    pub(crate) fn set_next(&self, next: Option<ErasedGcBox>) {
         self.next.set(next)
-    }
-
-    /// Returns the (shallow) size occupied by this box in memory.
-    #[inline(always)]
-    pub(crate) fn size_of_box(&self) -> usize {
-        self.vtable().box_layout.size()
     }
 
     #[inline]
@@ -157,9 +400,15 @@ impl GcBoxHeader {
             },
         );
     }
+
     #[inline]
     pub(crate) fn needs_trace(&self) -> bool {
         tagged_ptr::get::<0x4, _>(self.tagged_vtable.get()) != 0x0
+    }
+
+    #[inline]
+    pub(crate) fn set_needs_trace(&self, needs_trace: bool) {
+        tagged_ptr::set_bool::<0x4, _>(&self.tagged_vtable, needs_trace);
     }
 
     /// Determines whether or not we've dropped the `dyn Collect` value
@@ -174,13 +423,21 @@ impl GcBoxHeader {
     }
 
     #[inline]
-    pub(crate) fn set_needs_trace(&self, needs_trace: bool) {
-        tagged_ptr::set_bool::<0x4, _>(&self.tagged_vtable, needs_trace);
-    }
-
-    #[inline]
     pub(crate) fn set_live(&self, alive: bool) {
         tagged_ptr::set_bool::<0x8, _>(&self.tagged_vtable, alive);
+    }
+
+    /// Returns whether the `Layout` is stored just before the `GcBoxHeader` instead of inside the
+    /// vtable.
+    #[inline]
+    pub(crate) fn dynamic_layout(&self) -> bool {
+        tagged_ptr::get::<0x10, _>(self.tagged_vtable.get()) != 0x0
+    }
+
+    /// Sets the `dynamic_layout` flag.
+    #[inline]
+    fn set_dynamic_layout(&self, dynamic_layout: bool) {
+        tagged_ptr::set_bool::<0x10, _>(&self.tagged_vtable, dynamic_layout);
     }
 }
 
@@ -188,52 +445,42 @@ impl GcBoxHeader {
 ///
 /// We use a custom vtable instead of `dyn Collect` for extra flexibility.
 /// The type is over-aligned so that `GcBoxHeader` can store flags into the LSBs of the vtable pointer.
-#[repr(align(16))]
+#[repr(align(32))]
 struct CollectVtable {
-    /// The layout of the `GcBox` the GC'd value is stored in.
+    /// The layout of the `GcBox` the GC'd value is stored in, if the object does not have a
+    /// dynamic layout. Ignored if it does.
     box_layout: Layout,
-    /// Drops the value stored in the given `GcBox` (without deallocating the box).
-    drop_value: unsafe fn(GcBox),
-    /// Traces the value stored in the given `GcBox`.
-    trace_value: unsafe fn(GcBox, &mut Context),
+
+    /// Given an `ErasedGcBox`, drops the value without deallocating the box.
+    drop_value: unsafe fn(ErasedGcBox),
+
+    /// Given an `ErasedGcBox`, traces the value.
+    trace_value: unsafe fn(ErasedGcBox, &mut Context),
 }
 
 impl CollectVtable {
-    /// Makes a vtable for a known, `Sized` type.
-    /// Because `T: Sized`, we can recover a typed pointer
-    /// directly from the erased `GcBox`.
-    #[inline(always)]
-    const fn vtable_for<'gc, T: Collect<'gc>>() -> Self {
-        Self {
-            box_layout: Layout::new::<GcBoxInner<T>>(),
-            drop_value: |erased| unsafe {
-                ptr::drop_in_place(erased.unerased_value::<T>());
-            },
-            trace_value: |erased, cc| unsafe {
-                let val = &*(erased.unerased_value::<T>());
-                val.trace(cc)
-            },
+    /// Returns a vtable for the current type, allocated in static memory.
+    fn new<'gc, T: Collect<'gc>>() -> &'static CollectVtable {
+        // Helper trait to materialize vtables in static memory.
+        trait HasCollectVtable {
+            const VTABLE: CollectVtable;
         }
-    }
-}
 
-/// A typed GC'd value, together with its metadata.
-/// This type is never manipulated directly by the GC algorithm, allowing
-/// user-facing `Gc`s to freely cast their pointer to it.
-#[repr(C)]
-pub(crate) struct GcBoxInner<T: ?Sized> {
-    pub(crate) header: GcBoxHeader,
-    /// The typed value stored in this `GcBox`.
-    pub(crate) value: mem::ManuallyDrop<T>,
-}
-
-impl<'gc, T: Collect<'gc>> GcBoxInner<T> {
-    #[inline(always)]
-    pub(crate) fn new(header: GcBoxHeader, t: T) -> Self {
-        Self {
-            header,
-            value: mem::ManuallyDrop::new(t),
+        impl<'gc, T: Collect<'gc>> HasCollectVtable for T {
+            const VTABLE: CollectVtable = CollectVtable {
+                box_layout: GcBoxLayout::for_fixed::<T>().box_layout,
+                drop_value: |erased| unsafe {
+                    let gc_box = erased.unerase::<T>();
+                    ptr::drop_in_place(gc_box.get_ptr().as_ptr());
+                },
+                trace_value: |erased, cc| unsafe {
+                    let gc_box = erased.unerase::<T>();
+                    gc_box.get_ptr().as_ref().trace(cc)
+                },
+            };
         }
+
+        &<T as HasCollectVtable>::VTABLE
     }
 }
 
@@ -309,5 +556,82 @@ mod tagged_ptr {
         let ptr = pcell.get();
         let ptr = ptr.map_addr(|addr| (addr & !MASK) | if value { MASK } else { 0 });
         pcell.set(ptr)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GcBoxLayout;
+    use core::alloc::Layout;
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn gcbox_layout() {
+        #[repr(align(32))]
+        struct Align32<T>(T);
+
+        assert_eq!(
+            GcBoxLayout::for_fixed::<u8>(),
+            GcBoxLayout {
+                box_layout: Layout::from_size_align(17, 8).unwrap(),
+                offset_of_box_layout: 0,
+                offset_of_header: 0,
+                offset_of_value: 16,
+            }
+        );
+        assert_eq!(
+            GcBoxLayout::for_fixed::<usize>(),
+            GcBoxLayout {
+                box_layout: Layout::from_size_align(24, 8).unwrap(),
+                offset_of_box_layout: 0,
+                offset_of_header: 0,
+                offset_of_value: 16,
+            }
+        );
+        assert_eq!(
+            GcBoxLayout::for_fixed::<u128>(),
+            GcBoxLayout {
+                box_layout: Layout::from_size_align(32, 16).unwrap(),
+                offset_of_box_layout: 0,
+                offset_of_header: 0,
+                offset_of_value: 16,
+            }
+        );
+        assert_eq!(
+            GcBoxLayout::for_fixed::<[u8; 32]>(),
+            GcBoxLayout {
+                box_layout: Layout::from_size_align(48, 8).unwrap(),
+                offset_of_box_layout: 0,
+                offset_of_header: 0,
+                offset_of_value: 16,
+            }
+        );
+        assert_eq!(
+            GcBoxLayout::for_fixed::<[u8; 64]>(),
+            GcBoxLayout {
+                box_layout: Layout::from_size_align(80, 8).unwrap(),
+                offset_of_box_layout: 0,
+                offset_of_header: 0,
+                offset_of_value: 16,
+            }
+        );
+        assert_eq!(
+            GcBoxLayout::for_fixed::<Align32<[u8; 32]>>(),
+            GcBoxLayout {
+                box_layout: Layout::from_size_align(64, 32).unwrap(),
+                offset_of_box_layout: 0,
+                offset_of_header: 16,
+                offset_of_value: 32,
+            }
+        );
+        assert_eq!(
+            GcBoxLayout::for_fixed::<Align32<[u8; 64]>>(),
+            GcBoxLayout {
+                box_layout: Layout::from_size_align(96, 32).unwrap(),
+                offset_of_box_layout: 0,
+                offset_of_header: 16,
+                offset_of_value: 32,
+            }
+        );
     }
 }

--- a/src/unsize.rs
+++ b/src/unsize.rs
@@ -2,7 +2,7 @@ use core::marker::PhantomData;
 use core::ptr::NonNull;
 
 use crate::{
-    types::GcBoxInner,
+    types::GcBox,
     {Gc, GcWeak},
 };
 
@@ -83,10 +83,10 @@ unsafe impl<'gc, T, U: ?Sized> __CoercePtrInternal<Gc<'gc, U>> for Gc<'gc, T> {
     where
         F: FnOnce(*mut T) -> *mut U,
     {
-        let ptr = self.ptr.as_ptr() as *mut T;
+        let ptr = self.ptr.get_ptr().as_ptr();
         unsafe {
             Gc {
-                ptr: NonNull::new_unchecked(coerce(ptr) as *mut GcBoxInner<U>),
+                ptr: GcBox::from_ptr(NonNull::new_unchecked(coerce(ptr) as *mut U)),
                 _invariant: PhantomData,
             }
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,8 +1,8 @@
-use core::{cell::Cell, mem};
+use core::{cell::Cell, mem, mem::MaybeUninit, ptr::drop_in_place};
 #[cfg(feature = "std")]
 use rand::distributions::Distribution;
 #[cfg(feature = "std")]
-use std::{collections::HashMap, rc::Rc};
+use std::{alloc::Layout, collections::HashMap, rc::Rc};
 
 use gc_arena::{
     Arena, Collect, DynamicRootSet, Gc, GcWeak, Lock, RefLock, Rootable,
@@ -1207,6 +1207,92 @@ fn dyn_collect() {
     struct Test2<'gc> {
         field: Box<dyn MyTrait2<'gc, ()>>,
     }
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn dynamic_layout() {
+    /// Slice of Rc<()> that stores its values in-place.
+    struct Foo {
+        len: usize,
+    }
+    static_collect!(Foo);
+
+    impl Foo {
+        /// SAFETY: `foo` must point to memory that's layout-compatible with `layout_for_len(len)`.
+        unsafe fn init(foo: *mut Foo, len: usize, rc: &Rc<()>) {
+            assert_eq!(size_of::<Rc<()>>(), size_of::<usize>());
+
+            // SAFETY: This is the length, which is in-bounds.
+            unsafe { foo.cast::<usize>().write(len) }
+
+            // SAFETY: A one-past-the-end pointer is valid if len=0, otherwise this is in-bounds.
+            let data = unsafe { foo.cast::<usize>().offset(1).cast::<Rc<()>>() };
+            for i in 0..len {
+                // SAFETY: This is in-bounds.
+                unsafe { data.add(i).write(rc.clone()) }
+            }
+        }
+
+        fn layout_for_len(len: usize) -> Layout {
+            Layout::new::<usize>()
+                .extend(Layout::array::<Rc<()>>(len).unwrap())
+                .unwrap()
+                .0
+        }
+    }
+
+    impl Drop for Foo {
+        fn drop(&mut self) {
+            // SAFETY: A one-past-the-end pointer is valid if len=0, otherwise this is in-bounds.
+            let data = unsafe { (&mut self.len as *mut usize).offset(1).cast::<Rc<()>>() };
+            for i in 0..self.len {
+                // SAFETY: The pointer is valid by the invariants of this type, and the pointee is
+                // never accessed again.
+                unsafe { drop_in_place(data.add(i)) }
+            }
+        }
+    }
+
+    assert_eq!(size_of::<Gc<'_, Foo>>(), size_of::<usize>());
+
+    #[derive(Collect)]
+    #[collect(no_drop)]
+    struct Root<'gc> {
+        foos: Vec<Gc<'gc, Foo>>,
+    }
+
+    let rc = Rc::new(());
+    let max = 5;
+
+    let mut arena = Arena::<Rootable![Root<'_>]>::new(|mc| {
+        let foos = (0..max)
+            .map(|len| {
+                let foo: Gc<'_, MaybeUninit<Foo>> =
+                    Gc::new_dynamic_layout(mc, Foo::layout_for_len(len));
+                // SAFETY: `Gc::new_dynamic_layout` allocates the memory as requested by the layout.
+                unsafe {
+                    // TODO: Oops, UB?
+                    Foo::init(foo.as_ptr() as *mut Foo, len, &rc);
+                }
+                // SAFETY: The Foo is now initialized.
+                unsafe { foo.assume_init() }
+            })
+            .collect::<Vec<_>>();
+
+        Root { foos }
+    });
+
+    assert_eq!(Rc::strong_count(&rc), 1 + ((max - 1) * max) / 2);
+
+    arena.finish_cycle();
+
+    assert_eq!(Rc::strong_count(&rc), 1 + ((max - 1) * max) / 2);
+
+    arena.mutate_root(|_mc, root| root.foos.clear());
+    arena.finish_cycle();
+
+    assert_eq!(Rc::strong_count(&rc), 1);
 }
 
 #[cfg(feature = "std")]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -159,6 +159,7 @@ fn repeated_allocation_deallocation() {
     assert_eq!(Rc::strong_count(&r.0), live_size + 1);
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn all_dropped() {
     #[derive(Clone)]
@@ -184,6 +185,7 @@ fn all_dropped() {
     assert_eq!(Rc::strong_count(&r.0), 1);
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn all_garbage_collected() {
     #[derive(Clone)]
@@ -1207,6 +1209,7 @@ fn dyn_collect() {
     }
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn static_collect_with_param() {
     #[allow(unused)]

--- a/tests/ui/bad_collect_bound.stderr
+++ b/tests/ui/bad_collect_bound.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `NotCollect: Collect<'_>` is not satisfied
  --> tests/ui/bad_collect_bound.rs:8:12
   |
 8 |     field: NotCollect
-  |            ^^^^^^^^^^ the trait `Collect<'_>` is not implemented for `NotCollect`
+  |            ^^^^^^^^^^ unsatisfied trait bound
   |
+help: the trait `Collect<'_>` is not implemented for `NotCollect`
+ --> tests/ui/bad_collect_bound.rs:3:1
+  |
+3 | struct NotCollect;
+  | ^^^^^^^^^^^^^^^^^
   = help: the following other types implement trait `Collect<'gc>`:
             &'static T
             ()
@@ -22,8 +27,13 @@ error[E0277]: the trait bound `NotCollect: Collect<'gc>` is not satisfied
   |          ------- in this derive macro expansion
 ...
 8 |     field: NotCollect
-  |     ^^^^^ the trait `Collect<'gc>` is not implemented for `NotCollect`
+  |     ^^^^^ unsatisfied trait bound
   |
+help: the trait `Collect<'gc>` is not implemented for `NotCollect`
+ --> tests/ui/bad_collect_bound.rs:3:1
+  |
+3 | struct NotCollect;
+  | ^^^^^^^^^^^^^^^^^
   = help: the following other types implement trait `Collect<'gc>`:
             &'static T
             ()


### PR DESCRIPTION
This, with a healthy dose of unsafe, allows making thin pointers to
dynamically-sized values.

This changes the ABI of `Gc<T>` -- instead of being a pointer to the
header, it's a pointer to the value.

The header comes immediately behind the value in the allocation, without
padding. (The value pointer always has sufficient alignment for this.)
If a dynamic `Layout` is provided, the header will now have a Layout
before _it_ (again without padding, since the alignment matches).

```
      box
      ┌──────────────────────┐
      ┆  (padding, if needed)  ┆
      ├──────────────────────┤
      │ box layout, if dynamic │
      ├──────────────────────┤
    Gc│ header                 │
     ↳├──────────────────────┤
      │ value                  │
      └──────────────────────┘
```

---

I'm filing this PR as an RFC on these changes to the internals.

There's a few more changes I'd probably like to do before this is merged:

- [ ] Resolve #106 
- [ ] Add a better API around things like https://github.com/kyren/gc-arena/blob/383284c13352cb45c5a0febdd9378d28cbdebea8/tests/tests.rs#L1271-L1279 (taking an `init` callback that runs before we update `self.all` should be panic-safe; right now, this API pushes the panic safety obligation to the user)
- [ ] API for taking a wide-pointer `Box<T>` and storing the metadata in the allocation, along the same lines as [fat_type](https://docs.rs/fat_type/latest/fat_type/)? I don't actually need that for my use-case, but it's the more normal thing to want this API for.