### PR TITLE
Remove `{Deref, Index}Mut` guarantee from `{Deref, Index}Write`

### DIFF
--- a/src/barrier.rs
+++ b/src/barrier.rs
@@ -155,14 +155,14 @@ impl<T, E> Write<Result<T, E>> {
 ///
 /// # Safety
 /// Implementing this trait is a promise that the corresponding [`Deref`] impl
-/// (and [`DerefMut`], if it exists) can be used to project a [`Write`] reference.
+/// can be used to project a [`Write`] reference.
 ///
-/// In particular, both `Deref::deref` and `DerefMut::deref_mut`:
+/// In particular, `Deref::deref`:
 /// - must return a reference into the *same* GC'd object as the input;
 /// - must not adopt new [`Gc`] pointers.
 pub unsafe trait DerefWrite: Deref {}
 
-// SAFETY: All these types have pure & non-GC-traversing Deref(Mut) impls
+// SAFETY: All these types have pure & non-GC-traversing Deref impls
 unsafe impl<T: ?Sized> DerefWrite for &T {}
 unsafe impl<T: ?Sized> DerefWrite for alloc::boxed::Box<T> {}
 unsafe impl<T> DerefWrite for Vec<T> {}
@@ -174,14 +174,14 @@ unsafe impl<T: ?Sized> DerefWrite for alloc::sync::Arc<T> {}
 ///
 /// # Safety
 /// Implementing this trait is a promise that the corresponding [`Index<I>`] impl
-/// (and [`IndexMut<I>`], if it exists) can be used to project a [`Write`] reference.
+/// can be used to project a [`Write`] reference.
 ///
-/// In particular, both `Index::index` and `IndexMut::index_mut`:
+/// In particular, `Index::index`:
 /// - must return a reference into the *same* GC'd object as the input;
 /// - must not adopt new [`Gc`] pointers.
 pub unsafe trait IndexWrite<I: ?Sized>: Index<I> {}
 
-// SAFETY: All these types have pure & non-GC-traversing Index(Mut) impls
+// SAFETY: All these types have pure & non-GC-traversing Index impls
 // Note that we don't write `impl<..., I> IndexWrite<I> for ... where ...: Index<I>`,
 // as this would allow arbitrary implementations through third-party `I` types.
 unsafe impl<T> IndexWrite<usize> for [T] {}


### PR DESCRIPTION
Such 'cross-trait requirements' can be circumvented with trait objects, making them unsound (see [this similar issue](https://github.com/rust-lang/rust/issues/154619) in the stdlib for a worked-out example).

The `{Deref, Index}Mut` guarantee is currently mostly useless, so the simplest fix is to remove it.

If it ever becomes needed in the future, we'll have two possible solutions:
- Make `{Deref, Index}Write` dyn-incompatible, e.g. with a hidden associated constant;
- Add separate `{Deref, Index}WriteMut` marker traits instead.