### PR TITLE
`dyn_collect!` macro examples: add missing `dyn` keyword

### DIFF
--- a/src/collect.rs
+++ b/src/collect.rs
@@ -157,9 +157,9 @@ unsafe impl<'gc, T: Collect<'gc>> DynCollect<'gc> for T {
 /// This macro may be called in multiple ways:
 ///
 /// ```ignore
-/// dyn_collect!(MyTrait<'gc>);
-/// dyn_collect!(<T> MyTrait<'gc, T> where T: Clone);
-/// dyn_collect!(<T> MyTrait<'gc, Assoc = T>);
+/// dyn_collect!(dyn MyTrait<'gc>);
+/// dyn_collect!(<T> dyn MyTrait<'gc, T> where T: Clone);
+/// dyn_collect!(<T> dyn MyTrait<'gc, Assoc = T>);
 /// ```
 ///
 /// The generated impl always has a single `'gc` lifetime parameter that is used as the `'gc`


### PR DESCRIPTION
Using the macro as currently documented results in a compilation error:

```
error[E0782]: expected a type, found a trait
   --> runtime/src/execution/foo.rs:100:14
    |
100 | dyn_collect!(Foo<'gc>);
    |              ^^^^^^^^
    |
help: you can add the `dyn` keyword if you want a trait object
    |
100 | dyn_collect!(dyn Foo<'gc>);
    |              +++
```

I waffled on adding the keyword to the macro expansions instead of the examples (so the macro would work as documented). I went with changing the examples because the current behavior is [tested](https://github.com/kyren/gc-arena/blob/ae08ea7a243ddec4e2f0a717d6b798cd90e00ee1/tests/tests.rs#L1114).