### PR TITLE
Use raw `Gc` count for collection metrics, ignore allocation size.

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -208,15 +208,14 @@ impl Drop for Context {
                     while let Some(mut gc_box) = drop_resume.1.take() {
                         let header = gc_box.header();
                         drop_resume.1 = header.next();
-                        let gc_size = header.size_of_box();
                         // SAFETY: the context owns its GC'd objects
                         unsafe {
                             if header.is_live() {
                                 gc_box.drop_in_place();
-                                self.0.mark_gc_dropped(gc_size);
+                                self.0.mark_gc_dropped(1);
                             }
                             gc_box.dealloc();
-                            self.0.mark_gc_freed(gc_size);
+                            self.0.mark_gc_freed(1);
                         }
                     }
                 }
@@ -371,8 +370,6 @@ impl Context {
         header.set_live(true);
         header.set_needs_trace(T::NEEDS_TRACE);
 
-        let alloc_size = header.size_of_box();
-
         // Make the generated code easier to optimize into `T` being constructed in place or at the
         // very least only memcpy'd once.
         // For more information, see: https://github.com/kyren/gc-arena/pull/14
@@ -388,7 +385,7 @@ impl Context {
             self.sweep_prev.set(self.all.get());
         }
 
-        self.metrics.mark_gc_allocated(alloc_size);
+        self.metrics.mark_gc_allocated(1);
 
         ptr
     }
@@ -494,7 +491,7 @@ impl Context {
 
                 // Only marking the *first* time counts as a mark metric.
                 if color == GcColor::White {
-                    self.metrics.mark_gc_marked(header.size_of_box());
+                    self.metrics.mark_gc_marked(1);
                 }
             }
         }
@@ -505,7 +502,7 @@ impl Context {
         let header = gc_box.header();
         if header.color() == GcColor::White {
             header.set_color(GcColor::WhiteWeak);
-            self.metrics.mark_gc_marked(header.size_of_box());
+            self.metrics.mark_gc_marked(1);
         }
     }
 
@@ -568,7 +565,7 @@ impl Context {
             self.gray.push(gc_box);
             // Only marking the *first* time counts as a mark metric.
             if color == GcColor::White {
-                self.metrics.mark_gc_marked(header.size_of_box());
+                self.metrics.mark_gc_marked(1);
             }
         }
     }
@@ -589,7 +586,7 @@ impl Context {
             // We always mark work for objects processed from both the gray and "gray again" queue.
             // When objects are placed into the "gray again" queue due to a write barrier, the
             // original work is *undone*, so we do it again here.
-            self.metrics.mark_gc_traced(gc_box.header().size_of_box());
+            self.metrics.mark_gc_traced(1);
             gc_box.header().set_color(GcColor::Black);
 
             // If we have an object in the gray queue, take one, trace it, and turn it black.
@@ -639,7 +636,6 @@ impl Context {
         };
 
         let sweep_header = sweep.header();
-        let sweep_size = sweep_header.size_of_box();
 
         let next_box = sweep_header.next();
         self.sweep = next_box;
@@ -665,10 +661,10 @@ impl Context {
                         // If the alive flag is set, that means we haven't dropped the inner value
                         // of this object,
                         sweep.drop_in_place();
-                        self.metrics.mark_gc_dropped(sweep_size);
+                        self.metrics.mark_gc_dropped(1);
                     }
                     sweep.dealloc();
-                    self.metrics.mark_gc_freed(sweep_size);
+                    self.metrics.mark_gc_freed(1);
                 }
             }
             // Keep the `GcBox` as part of the linked list if we traced a weak pointer to it. The
@@ -684,16 +680,16 @@ impl Context {
                     // pointers to this object, only weak pointers, so we can safely drop its
                     // contents.
                     unsafe { sweep.drop_in_place() }
-                    self.metrics.mark_gc_dropped(sweep_size);
+                    self.metrics.mark_gc_dropped(1);
                 }
-                self.metrics.mark_gc_remembered(sweep_size);
+                self.metrics.mark_gc_remembered(1);
             }
             // If the next object in the sweep portion of the main list is black, we
             // need to keep it but turn it back white.
             GcColor::Black => {
                 self.sweep_prev.set(Some(sweep));
                 sweep_header.set_color(GcColor::White);
-                self.metrics.mark_gc_remembered(sweep_size);
+                self.metrics.mark_gc_remembered(1);
             }
             // No gray objects should be in this part of the main list, they should
             // be added to the beginning of the list before the sweep pointer, so it
@@ -712,7 +708,7 @@ impl Context {
         debug_assert_eq!(header.color(), GcColor::Black);
         header.set_color(GcColor::Gray);
         self.gray_again.push(gc_box);
-        self.metrics.mark_gc_untraced(header.size_of_box());
+        self.metrics.mark_gc_untraced(1);
     }
 }
 
@@ -786,7 +782,7 @@ impl<'a> PhaseGuard<'a> {
             parent: &self.span,
             message,
             phase = tracing::field::debug(self.cx.phase),
-            allocated = self.cx.metrics.total_gc_allocation(),
+            allocated_gcs = self.cx.metrics.total_gc_count(),
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![cfg_attr(miri, feature(strict_provenance))]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3,11 +3,11 @@ use core::cell::Cell;
 
 /// Tuning parameters for a given garbage collected [`crate::Arena`].
 ///
-/// Any allocation that occurs during a collection cycle will incur "debt" that is exactly equal to
-/// the allocated bytes. This "debt" is paid off by running the collection algorithm some amount of
-/// time proportional to the debt. Exactly how much "debt" is paid off and in what proportion by the
-/// different parts of the collection algorithm is configured by the chosen values here. We refer to
-/// the amount of "debt" paid off by running the collection algorithm as "work".
+/// Any allocation that occurs during a collection cycle will incur "debt" that is exactly equal
+/// to the number of allocated `Gc`s. This "debt" is paid off by running the collection algorithm
+/// some amount of time proportional to the debt. Exactly how much "debt" is paid off and in what
+/// proportion by the different parts of the collection algorithm is configured by the chosen values
+/// here. We refer to the amount of "debt" paid off by running the collection algorithm as "work".
 ///
 /// The most important idea behind choosing these tuning parameters is that we always want the
 /// collector (when it is not sleeping) to deterministically run *faster* than allocation. We do
@@ -16,19 +16,18 @@ use core::cell::Cell;
 /// it is also important that not *too* many costly operations are run within a single call to
 /// [`crate::Arena::collect_debt`], and this goal is in tension with the first, more important goal.
 ///
-/// How these two goals are balanced is that we must choose our tuning parameters so that the
-/// total amount of "work" performed to either *remember* or *free* one byte of allocated data
-/// is always *less than one*, as this makes the collector deterministically run faster than the
-/// rate of allocation (which is crucial). The closer the amount of "work" performed to remember
-/// or free one byte is to 1.0, the slower the collector will go and the higher the maximum amount
-/// of used memory will be. The closer the amount of "work" performed to remember or free one
-/// byte is to 0.0, the faster the collector will go and the closer it will get to behaving like a
-/// stop-the-world collector.
+/// How these two goals are balanced is that we must choose our tuning parameters so that the total
+/// amount of "work" performed to either *remember* or *free* one `Gc` is always *less than one*,
+/// as this makes the collector deterministically run faster than the rate of allocation (which
+/// is crucial). The closer the amount of "work" performed to remember or free one `Gc` is to 1.0,
+/// the slower the collector will go and the higher the maximum amount of used memory will be. The
+/// closer the amount of "work" performed to remember or free one `Gc` is to 0.0, the faster the
+/// collector will go and the closer it will get to behaving like a stop-the-world collector.
 ///
-/// All live pointers in a cycle are either remembered or freed once, but it is important that
-/// *both paths* require less than one unit of "work" per byte to fully complete. There is no way to
+/// All live `Gc`s in a cycle are either remembered or freed once, but it is important that *both
+/// paths* require less than one unit of "work" per `Gc` to fully complete. There is no way to
 /// predict a priori the ratio of remembered vs forgotten values, so if either path takes too close
-/// to or over 1.0 unit of work per byte to complete, collection may run too slowly.
+/// to or over 1.0 unit of work per `Gc` to complete, collection may run too slowly.
 ///
 /// # Factors that control the time the GC sleeps
 ///
@@ -46,17 +45,16 @@ use core::cell::Cell;
 /// Every remembered value will always have exactly three things done to it in a given cycle:
 ///
 /// 1) It will at some point be found and marked as reachable (and potentially queued for tracing).
-///    When this happens, `mark_factor * alloc_size` work is recorded.
+///    When this happens, `mark_factor` work is recorded.
 /// 2) Entries in the queue for tracing will eventually be traced by having their
-///    [`crate::Collect::trace`] method called. At this time, `trace_factor * alloc_size` work is
-///    recorded. Calling `Collect::trace` will usually mark other pointers as reachable and queue
-///    them for tracing if they have not already been, so this step may also transitively perform
-///    other work, but each step is only performed exactly once for each individual remembered
-///    value.
+///    [`crate::Collect::trace`] method called. At this time, `trace_factor` work is recorded.
+///    Calling `Collect::trace` will usually mark other `Gc`s as reachable and queue them for
+///    tracing if they have not already been, so this step may also transitively perform other work,
+///    but each step is only performed exactly once for each individual remembered value.
 /// 3) During the [`crate::arena::CollectionPhase::Sweeping`] phase, each remembered value has to
 ///    be iterated over in the sweep list and removed from it. This a small, constant amount of
 ///    work that is very fast, but it should always perform *some* work to keep pause time low, so
-///    `keep_factor * alloc_size` work is recorded.
+///    `keep_factor` work is recorded.
 ///
 /// # Timing factors for forgotten values
 ///
@@ -65,23 +63,22 @@ use core::cell::Cell;
 /// [`crate::arena::CollectionPhase::Sweeping`]: dropping and freeing.
 ///
 /// If a value is unreachable, then when it is encountered in the free list it will be dropped (and
-/// `drop_factor * alloc_size` work will be recorded), and then the memory backing the value will be
-/// freed (and `free_factor * alloc_size` work will be recorded).
+/// `drop_factor` work will be recorded), and then the memory backing the value will be freed (and
+/// `free_factor` work will be recorded).
 ///
 /// # Timing factors for weakly reachable values
 ///
 /// There is actually a *third* possible path for a value to take in a collection cycle which is a
 /// hybrid of the two, but thankfully it is not too complex.
 ///
-/// If a value is (newly) weakly reachable this cycle, first the pointer will be marked as
-/// (weakly) reachable (`mark_factor * alloc_size` work is recorded), then during sweeping it will
-/// be *dropped* (`drop_factor * alloc_size` work is recorded), and then *kept* (`keep_factor *
-/// alloc_size` work is recorded).
+/// If a value is (newly) weakly reachable this cycle, first the `Gc` will be marked as (weakly)
+/// reachable (`mark_factor` work is recorded), then during sweeping it will be *dropped*
+/// (`drop_factor` work is recorded), and then *kept* (`keep_factor` work is recorded).
 ///
 /// # Summary
 ///
 /// This may seem complicated but it is actually not too difficult to make sure that the GC will not
-/// stall: *every path that a pointer can take must never do 1.0 or more unit of work per byte within
+/// stall: *every path that a `Gc` can take must never do 1.0 or more unit of work per `Gc` within
 /// a cycle*.
 ///
 /// The important formulas to check are:
@@ -94,7 +91,7 @@ use core::cell::Cell;
 ///   `mark_factor + drop_factor + keep_factor < 1.0`
 ///
 /// It is also important to note that this is not an exhaustive list of all the possible paths a
-/// pointer can take, but every path will always be a *subset* of one of the above paths. The above
+/// `Gc` can take, but every path will always be a *subset* of one of the above paths. The above
 /// formulas represent every possible the worst case: for example, if a weakly reachable value has
 /// already been dropped then only `mark_factor + keep_factor` work will be recorded, and if we
 /// can prove that a reachable value has [`crate::Collect::NEEDS_TRACE`] set to false, then only
@@ -105,8 +102,8 @@ use core::cell::Cell;
 pub struct Pacing {
     /// Controls the length of the [`crate::arena::CollectionPhase::Sleeping`] phase.
     ///
-    /// At the start of a new GC cycle, the collector will wait until the live size reaches
-    /// `<current heap size> + <previous remembered size> * sleep_factor` before starting
+    /// At the start of a new GC cycle, the collector will wait until the live `Gc` count reaches
+    /// `<current heap count> + <previous remembered count> * sleep_factor` before starting
     /// collection.
     pub sleep_factor: f64,
 
@@ -117,31 +114,31 @@ pub struct Pacing {
     /// restarting collections.
     pub min_sleep: usize,
 
-    /// The multiplicative factor for "work" performed per byte when a `Gc` value is first marked as
+    /// The multiplicative factor for "work" performed per `Gc` when a `Gc` is first marked as
     /// reachable.
     pub mark_factor: f64,
 
-    /// The multiplicative factor for "work" performed per byte when a `Gc` value has its
+    /// The multiplicative factor for "work" performed per `Gc` when the held value has its
     /// [`crate::Collect::trace`] method called.
     pub trace_factor: f64,
 
-    /// The multiplicative factor for "work" performed per byte when a reachable `Gc` value is
-    /// iterated over during [`crate::arena::CollectionPhase::Sweeping`].
+    /// The multiplicative factor for "work" performed per `Gc` when a reachable `Gc` is iterated
+    /// over during [`crate::arena::CollectionPhase::Sweeping`].
     pub keep_factor: f64,
 
-    /// The multiplicative factor for "work" performed per byte when a `Gc` value that is forgotten
+    /// The multiplicative factor for "work" performed per `Gc` when a `Gc` value that is forgotten
     /// or only weakly reachable is dropped during [`crate::arena::CollectionPhase::Sweeping`].
     pub drop_factor: f64,
 
-    /// The multiplicative factor for "work" performed per byte when a forgotten `Gc` value is freed
-    /// during [`crate::arena::CollectionPhase::Sweeping`].
+    /// The multiplicative factor for "work" performed per `Gc` when the allocation for a `Gc` is
+    /// freed during [`crate::arena::CollectionPhase::Sweeping`].
     pub free_factor: f64,
 }
 
 impl Pacing {
     pub const DEFAULT: Pacing = Pacing {
         sleep_factor: 0.5,
-        min_sleep: 4096,
+        min_sleep: 256,
         mark_factor: 0.1,
         trace_factor: 0.4,
         keep_factor: 0.05,
@@ -158,7 +155,7 @@ impl Pacing {
     /// (close to or even somewhat larger than 1.0).
     pub const STOP_THE_WORLD: Pacing = Pacing {
         sleep_factor: 1.0,
-        min_sleep: 4096,
+        min_sleep: 256,
         mark_factor: 0.0,
         trace_factor: 0.0,
         keep_factor: 0.0,
@@ -179,27 +176,23 @@ struct MetricsInner {
     pacing: Cell<Pacing>,
 
     total_gcs: Cell<usize>,
-    total_gc_bytes: Cell<usize>,
 
     wakeup_amount: Cell<f64>,
     artificial_debt: Cell<f64>,
 
     // Statistics for `Gc` allocations and deallocations that happen during a GC cycle.
-    allocated_gc_bytes: Cell<usize>,
-    dropped_gc_bytes: Cell<usize>,
-    freed_gc_bytes: Cell<usize>,
+    allocated_gcs: Cell<usize>,
+    dropped_gcs: Cell<usize>,
+    freed_gcs: Cell<usize>,
 
-    // Statistics for `Gc` pointers that have been marked as non-white this cycle.
+    // Statistics for `Gc`s that have been marked as non-white this cycle.
     marked_gcs: Cell<usize>,
-    marked_gc_bytes: Cell<usize>,
 
-    // Statistics for `Gc` pointers that have their contents traced.
+    // Statistics for `Gc`s that have their contents traced.
     traced_gcs: Cell<usize>,
-    traced_gc_bytes: Cell<usize>,
 
-    // Statistics for reachable `Gc` pointers as they are iterated through during the sweep phase.
+    // Statistics for reachable `Gc`s as they are iterated through during the sweep phase.
     remembered_gcs: Cell<usize>,
-    remembered_gc_bytes: Cell<usize>,
 }
 
 #[derive(Clone)]
@@ -233,22 +226,16 @@ impl Metrics {
         self.0.total_gcs.get()
     }
 
-    /// Returns the total bytes allocated by all live `Gc` pointers.
+    /// Adjust the allocation debt artificially.
     #[inline]
-    pub fn total_gc_allocation(&self) -> usize {
-        self.0.total_gc_bytes.get()
-    }
-
-    /// Adjust artificial debt equivalent to allocating or freeing the given number of bytes.
-    #[inline]
-    pub fn adjust_debt(&self, bytes: f64) {
-        cell_update(&self.0.artificial_debt, |d| d + bytes);
+    pub fn adjust_debt(&self, amt: f64) {
+        self.0.artificial_debt.update(|d| d + amt);
     }
 
     /// All arena allocation causes the arena to accumulate "allocation debt". This debt is then
     /// used to time incremental garbage collection based on the tuning parameters in the current
-    /// `Pacing`. The allocation debt is measured in bytes, but will generally increase at a rate
-    /// faster than that of allocation so that collection will always complete.
+    /// `Pacing`. The allocation debt will generally increase at a rate faster than that of
+    /// allocation so that collection will always complete.
     #[inline]
     pub fn allocation_debt(&self) -> f64 {
         let total_gcs = self.0.total_gcs.get();
@@ -258,11 +245,11 @@ impl Metrics {
             return 0.0;
         }
 
-        let allocated_bytes = self.0.allocated_gc_bytes.get() as f64;
+        let allocated_gcs = self.0.allocated_gcs.get() as f64;
 
         // Every allocation after the `wakeup_amount` in a cycle is a debit.
         let cycle_debits =
-            allocated_bytes - self.0.wakeup_amount.get() + self.0.artificial_debt.get();
+            allocated_gcs - self.0.wakeup_amount.get() + self.0.artificial_debt.get();
 
         // If our debits are not positive, then we know the total debt is not positive.
         if cycle_debits <= 0.0 {
@@ -271,20 +258,20 @@ impl Metrics {
 
         let pacing = self.0.pacing.get();
 
-        let cycle_credits = self.0.marked_gc_bytes.get() as f64 * pacing.mark_factor
-            + self.0.traced_gc_bytes.get() as f64 * pacing.trace_factor
-            + self.0.remembered_gc_bytes.get() as f64 * pacing.keep_factor
-            + self.0.dropped_gc_bytes.get() as f64 * pacing.drop_factor
-            + self.0.freed_gc_bytes.get() as f64 * pacing.free_factor;
+        let cycle_credits = self.0.marked_gcs.get() as f64 * pacing.mark_factor
+            + self.0.traced_gcs.get() as f64 * pacing.trace_factor
+            + self.0.remembered_gcs.get() as f64 * pacing.keep_factor
+            + self.0.dropped_gcs.get() as f64 * pacing.drop_factor
+            + self.0.freed_gcs.get() as f64 * pacing.free_factor;
 
         (cycle_debits - cycle_credits).max(0.0)
     }
 
     pub(crate) fn finish_cycle(&self, reset_debt: bool) {
         let pacing = self.0.pacing.get();
-        let remembered_size = self.0.remembered_gc_bytes.get();
+        let remembered_count = self.0.remembered_gcs.get();
         let wakeup_amount =
-            (remembered_size as f64 * pacing.sleep_factor).max(pacing.min_sleep as f64);
+            (remembered_count as f64 * pacing.sleep_factor).max(pacing.min_sleep as f64);
 
         let artificial_debt = if reset_debt {
             0.0
@@ -295,64 +282,48 @@ impl Metrics {
         self.0.wakeup_amount.set(wakeup_amount);
         self.0.artificial_debt.set(artificial_debt);
 
-        self.0.allocated_gc_bytes.set(0);
-        self.0.dropped_gc_bytes.set(0);
-        self.0.freed_gc_bytes.set(0);
+        self.0.allocated_gcs.set(0);
+        self.0.dropped_gcs.set(0);
+        self.0.freed_gcs.set(0);
         self.0.marked_gcs.set(0);
-        self.0.marked_gc_bytes.set(0);
         self.0.traced_gcs.set(0);
-        self.0.traced_gc_bytes.set(0);
         self.0.remembered_gcs.set(0);
-        self.0.remembered_gc_bytes.set(0);
     }
 
-    #[inline]
-    pub(crate) fn mark_gc_allocated(&self, bytes: usize) {
-        cell_update(&self.0.total_gcs, |c| c + 1);
-        cell_update(&self.0.total_gc_bytes, |b| b + bytes);
-        cell_update(&self.0.allocated_gc_bytes, |b| b.saturating_add(bytes));
+    #[inline(always)]
+    pub(crate) fn mark_gc_allocated(&self, count: usize) {
+        self.0.total_gcs.update(|c| c + count);
+        self.0.allocated_gcs.update(|b| b + count);
     }
 
-    #[inline]
-    pub(crate) fn mark_gc_dropped(&self, bytes: usize) {
-        cell_update(&self.0.dropped_gc_bytes, |b| b.saturating_add(bytes));
+    #[inline(always)]
+    pub(crate) fn mark_gc_dropped(&self, count: usize) {
+        self.0.dropped_gcs.update(|b| b + count);
     }
 
-    #[inline]
-    pub(crate) fn mark_gc_freed(&self, bytes: usize) {
-        cell_update(&self.0.total_gcs, |c| c - 1);
-        cell_update(&self.0.total_gc_bytes, |b| b - bytes);
-        cell_update(&self.0.freed_gc_bytes, |b| b.saturating_add(bytes));
+    #[inline(always)]
+    pub(crate) fn mark_gc_freed(&self, count: usize) {
+        self.0.total_gcs.update(|c| c - count);
+        self.0.freed_gcs.update(|b| b + count);
     }
 
-    #[inline]
-    pub(crate) fn mark_gc_marked(&self, bytes: usize) {
-        cell_update(&self.0.marked_gcs, |c| c + 1);
-        cell_update(&self.0.marked_gc_bytes, |b| b + bytes);
+    #[inline(always)]
+    pub(crate) fn mark_gc_marked(&self, count: usize) {
+        self.0.marked_gcs.update(|c| c + count);
     }
 
-    #[inline]
-    pub(crate) fn mark_gc_traced(&self, bytes: usize) {
-        cell_update(&self.0.traced_gcs, |c| c + 1);
-        cell_update(&self.0.traced_gc_bytes, |b| b + bytes);
+    #[inline(always)]
+    pub(crate) fn mark_gc_traced(&self, count: usize) {
+        self.0.traced_gcs.update(|c| c + count);
     }
 
-    #[inline]
-    pub(crate) fn mark_gc_untraced(&self, bytes: usize) {
-        cell_update(&self.0.traced_gcs, |c| c - 1);
-        cell_update(&self.0.traced_gc_bytes, |b| b - bytes);
+    #[inline(always)]
+    pub(crate) fn mark_gc_untraced(&self, count: usize) {
+        self.0.traced_gcs.update(|c| c - count);
     }
 
-    #[inline]
-    pub(crate) fn mark_gc_remembered(&self, bytes: usize) {
-        cell_update(&self.0.remembered_gcs, |c| c + 1);
-        cell_update(&self.0.remembered_gc_bytes, |b| b + bytes);
+    #[inline(always)]
+    pub(crate) fn mark_gc_remembered(&self, count: usize) {
+        self.0.remembered_gcs.update(|c| c + count);
     }
-}
-
-// TODO: Use `Cell::update` when it is available, see:
-// https://github.com/rust-lang/rust/issues/50186
-#[inline]
-fn cell_update<T: Copy>(c: &Cell<T>, f: impl FnOnce(T) -> T) {
-    c.set(f(c.get()))
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -129,12 +129,6 @@ impl GcBoxHeader {
         self.next.set(next)
     }
 
-    /// Returns the (shallow) size occupied by this box in memory.
-    #[inline(always)]
-    pub(crate) fn size_of_box(&self) -> usize {
-        self.vtable().box_layout.size()
-    }
-
     #[inline]
     pub(crate) fn color(&self) -> GcColor {
         match tagged_ptr::get::<0x3, _>(self.tagged_vtable.get()) {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,7 @@
 use core::{cell::Cell, mem};
 #[cfg(feature = "std")]
 use rand::distr::Distribution;
+use std::array;
 #[cfg(feature = "std")]
 use std::{collections::HashMap, rc::Rc};
 
@@ -128,20 +129,20 @@ fn repeated_allocation_deallocation() {
         TestRoot(Gc::new(mc, RefLock::new(HashMap::new())))
     });
 
-    let key_range = rand::distr::Uniform::try_from(0..1000).unwrap();
+    let key_range = rand::distr::Uniform::try_from(0..200).unwrap();
     let mut rng = rand::rng();
 
-    for _ in 0..40 {
+    for _ in 0..20 {
         arena.mutate(|mc, root| {
             let mut map = root.0.unlock(mc).borrow_mut();
-            for _ in 0..50 {
+            for _ in 0..20 {
                 let i = key_range.sample(&mut rng);
                 if let Some(old) = map.insert(i, Gc::new(mc, (i, r.clone()))) {
                     assert_eq!(old.0, i);
                 }
             }
 
-            for _ in 0..50 {
+            for _ in 0..20 {
                 let i = key_range.sample(&mut rng);
                 if let Some(old) = map.remove(&i) {
                     assert_eq!(old.0, i);
@@ -510,41 +511,44 @@ fn test_collection_bounded() {
     #[derive(Collect)]
     #[collect(no_drop)]
     struct TestRoot<'gc> {
-        test: Gc<'gc, [u8; 256]>,
+        test: [Gc<'gc, u8>; 32],
     }
 
     let mut arena = Arena::<Rootable![TestRoot<'_>]>::new(|mc| TestRoot {
-        test: Gc::new(mc, [0; 256]),
+        test: array::from_fn(|_| Gc::new(mc, 0)),
     });
 
     arena.metrics().set_pacing(Pacing {
         sleep_factor: 1.0,
-        min_sleep: 256,
+        min_sleep: 64,
         ..Default::default()
     });
 
-    // Finish the current collection cycle so that the new min_sleep is used.
+    // Finish the current collection cycle so that the new min_sleep is used. We should be asleep
+    // for exactly min_sleep, since the sleep factor is 1.0 and 32 less than 64.
     arena.finish_cycle();
 
-    for _ in 0..1024 {
+    for _ in 0..32 {
         for _ in 0..4 {
             arena.mutate(|mc, _| {
-                let _ = Gc::new(mc, [0u8; 256]);
+                for _ in 0..32 {
+                    let _ = Gc::new(mc, 0u8);
+                }
             });
         }
-        assert!(arena.metrics().total_gc_allocation() < 4096);
-        assert!(arena.metrics().allocation_debt() < 4096.0);
+        assert!(arena.metrics().total_gc_count() < 512);
+        assert!(arena.metrics().allocation_debt() < 512.0);
         arena.collect_debt();
     }
 
-    for _ in 0..1024 {
+    for _ in 0..32 {
         for _ in 0..4 {
             arena.mutate_root(|mc, root| {
-                let _ = mem::replace(&mut root.test, Gc::new(mc, [0u8; 256]));
+                let _ = mem::replace(&mut root.test, array::from_fn(|_| Gc::new(mc, 0)));
             });
         }
-        assert!(arena.metrics().total_gc_allocation() < 4096);
-        assert!(arena.metrics().allocation_debt() < 4096.0);
+        assert!(arena.metrics().total_gc_count() < 512);
+        assert!(arena.metrics().allocation_debt() < 512.0);
         arena.collect_debt();
     }
 }
@@ -705,44 +709,42 @@ fn gc_sleep_actually_sleeps() {
     #[derive(Collect)]
     #[collect(no_drop)]
     struct TestRoot<'gc> {
-        test: Gc<'gc, [u8; 256]>,
+        test: [Gc<'gc, u8>; 32],
     }
 
     let mut arena = Arena::<Rootable![TestRoot<'_>]>::new(|mc| TestRoot {
-        test: Gc::new(mc, [0; 256]),
+        test: array::from_fn(|i| Gc::new(mc, i as u8)),
     });
 
     arena.metrics().set_pacing(Pacing {
         sleep_factor: 1.0,
-        min_sleep: 1024,
+        min_sleep: 100,
         ..Default::default()
     });
 
     // Finish the current collection cycle so that the new min_sleep is used. We should be asleep
-    // for exactly min_sleep, since the sleep factor is 1.0 and 2x 256 bytes is 512 which is less
-    // than 1024.
+    // for exactly min_sleep, since the sleep factor is 1.0 and 32 less than 100.
     arena.finish_cycle();
 
     // We should be asleep, aka the debt should be zero.
     assert!(arena.metrics().allocation_debt() == 0.0);
 
-    for _ in 0..8 {
+    for _ in 0..80 {
         arena.mutate(|mc, _| {
-            let _ = Gc::new(mc, [0u8; 100]);
+            let _ = Gc::new(mc, 0u8);
         });
     }
 
-    // We should still be asleep after allocating 800 bytes (assumes that the overhead is less than
-    // 224 bytes).
+    // We should still be asleep after allocating 80 GCs.
     assert!(arena.metrics().allocation_debt() == 0.0);
 
-    for _ in 0..3 {
+    for _ in 0..30 {
         arena.mutate(|mc, _| {
-            let _ = Gc::new(mc, [0u8; 100]);
+            let _ = Gc::new(mc, 0u8);
         });
     }
 
-    // We should *not* be asleep after allocating 300 more bytes, because this is greater than 1024.
+    // We should *not* be asleep after allocating 30 more GCs, because 80 + 30 is greater than 100.
     assert!(arena.metrics().allocation_debt() > 0.0);
 }
 
@@ -751,42 +753,39 @@ fn stop_the_world_works() {
     #[derive(Collect)]
     #[collect(no_drop)]
     struct TestRoot<'gc> {
-        vec: Vec<Gc<'gc, [u8; 100]>>,
+        vec: Vec<Gc<'gc, u8>>,
     }
 
     let mut arena = Arena::<Rootable![TestRoot<'_>]>::new(|_| TestRoot { vec: Vec::new() });
 
     arena.metrics().set_pacing(Pacing {
-        min_sleep: 1024,
+        min_sleep: 100,
         sleep_factor: 1.5,
         ..Pacing::STOP_THE_WORLD
     });
 
-    // Finish the current collection cycle so that the new min_sleep is used. We should be asleep
-    // for exactly min_sleep, since the sleep factor is 1.5 and 1.5x 256 bytes is 384 which is less
-    // than 1024.
+    // Finish the current collection cycle so that the new min_sleep is used.
     arena.finish_cycle();
 
     // We should be asleep, aka the debt should be zero.
     assert!(arena.metrics().allocation_debt() == 0.0);
 
-    for _ in 0..8 {
+    for _ in 0..80 {
         arena.mutate_root(|mc, root| {
-            root.vec.push(Gc::new(mc, [0; 100]));
+            root.vec.push(Gc::new(mc, 0));
         });
     }
 
-    // We should still be asleep after allocating 800 bytes (assumes that the overhead is less than
-    // 224 bytes).
+    // We should still be asleep after allocating 80 Gcs.
     assert!(arena.metrics().allocation_debt() == 0.0);
 
-    for _ in 0..3 {
+    for _ in 0..30 {
         arena.mutate_root(|mc, root| {
-            root.vec.push(Gc::new(mc, [0; 100]));
+            root.vec.push(Gc::new(mc, 0));
         });
     }
 
-    // Our debt should now be positive, since we've definitely allocated more than 1024 bytes.
+    // Our debt should now be positive, since we've definitely allocated more than 100 Gcs.
     assert!(arena.metrics().allocation_debt() > 0.0);
 
     // This should do a full collection.
@@ -795,12 +794,11 @@ fn stop_the_world_works() {
     // And we should be back asleep.
     assert_eq!(arena.collection_phase(), CollectionPhase::Sleeping);
 
-    // The total remembered allocations after the last full collection were at least 1100 bytes,
-    // so allocating 1200 bytes (which is less than 1100 * 1.5 plus overhead) should not wake the
-    // collector.
-    for _ in 0..12 {
+    // The total remembered allocations after the last full collection was at least 110 Gcs, so
+    // allocating 150 Gcs (which is less than 110 * 1.5) should not wake the collector.
+    for _ in 0..150 {
         arena.mutate(|mc, _| {
-            Gc::new(mc, [0u8; 100]);
+            Gc::new(mc, 0);
         })
     }
     assert!(arena.metrics().allocation_debt() == 0.0);
@@ -898,11 +896,11 @@ fn test_phases() {
     #[derive(Collect)]
     #[collect(no_drop)]
     struct TestRoot<'gc> {
-        test: Gc<'gc, [u8; 1024 * 64]>,
+        test: Gc<'gc, u8>,
     }
 
     let mut arena = Arena::<Rootable![TestRoot<'_>]>::new(|mc| {
-        let test = Gc::new(mc, [0; 1024 * 64]);
+        let test = Gc::new(mc, 0);
         TestRoot { test }
     });
     arena.finish_cycle();
@@ -913,7 +911,7 @@ fn test_phases() {
     while arena.collection_phase() == CollectionPhase::Sleeping {
         // Keep accumulating debt to keep the collector moving.
         arena.mutate(|mc, _| {
-            Gc::new(mc, 0);
+            Gc::new(mc, 0u8);
         });
         // This cannot move past the Marked phase.
         arena.mark_debt();
@@ -928,7 +926,7 @@ fn test_phases() {
     loop {
         // Keep accumulating debt to keep the collector moving.
         arena.mutate(|mc, _| {
-            Gc::new(mc, 0);
+            Gc::new(mc, 0u8);
         });
 
         if let Some(marked) = arena.mark_debt() {
@@ -1065,15 +1063,15 @@ fn cycle_debt_stops() {
     #[derive(Collect)]
     #[collect(no_drop)]
     struct TestRoot<'gc> {
-        test: Gc<'gc, [u8; 512]>,
+        test: Gc<'gc, u8>,
     }
 
     let mut arena = Arena::<Rootable![TestRoot<'_>]>::new(|mc| {
-        let test = Gc::new(mc, [0; 512]);
+        let test = Gc::new(mc, 0);
         TestRoot { test }
     });
     arena.metrics().set_pacing(Pacing {
-        min_sleep: 1024,
+        min_sleep: 100,
         ..Pacing::DEFAULT
     });
 
@@ -1082,9 +1080,11 @@ fn cycle_debt_stops() {
     assert_eq!(arena.collection_phase(), CollectionPhase::Sleeping);
 
     loop {
-        arena.mutate(|mc, _| {
-            Gc::new(mc, [0u8; 128]);
-        });
+        for i in 0..4u8 {
+            arena.mutate(|mc, _| {
+                Gc::new(mc, i);
+            });
+        }
         if let Some(marked_arena) = arena.mark_debt() {
             marked_arena.start_sweeping();
             break;
@@ -1094,9 +1094,11 @@ fn cycle_debt_stops() {
     assert_eq!(arena.collection_phase(), CollectionPhase::Sweeping);
 
     loop {
-        arena.mutate(|mc, _| {
-            Gc::new(mc, [0u8; 2048]);
-        });
+        for i in 0..4u8 {
+            arena.mutate(|mc, _| {
+                Gc::new(mc, i);
+            });
+        }
         arena.cycle_debt();
         match arena.collection_phase() {
             CollectionPhase::Sweeping => {}


### PR DESCRIPTION
Allocation size, especially without "external allocation" which was really hard to use and reason about, is almost meaningless.

A Rust struct with 10 `Copy` fields could easily contain fewer `Gc`s and cost less to allocate / free than a struct with one field which happens to be a `Vec`. Without some kind of allocator integration, this is unavoidable.

Raw `Gc` count is the most sensible metric we have until a *better* way of integrating with normal Rust allocation is found.