### PR TITLE
Change `Gc` and `GcWeak` to store pointers to `T` directly

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1,16 +1,15 @@
-use alloc::{boxed::Box, vec::Vec};
+use alloc::vec::Vec;
 use core::{
     cell::{Cell, UnsafeCell},
     mem,
     ops::{ControlFlow, Deref, DerefMut},
-    ptr::NonNull,
 };
 
 use crate::{
     Gc, GcWeak,
     collect::{Collect, Trace},
     metrics::Metrics,
-    types::{GcBox, GcBoxHeader, GcBoxInner, GcColor, Invariant},
+    types::{GcBox, GcColor, Invariant},
 };
 
 /// Handle value given by arena callbacks during construction and mutation. Allows allocating new
@@ -40,19 +39,15 @@ impl<'gc> Mutation<'gc> {
     /// pointer(s) before collection is next triggered.
     #[inline]
     pub fn backward_barrier(&self, parent: Gc<'gc, ()>, child: Option<Gc<'gc, ()>>) {
-        self.context.backward_barrier(
-            unsafe { GcBox::erase(parent.ptr) },
-            child.map(|p| unsafe { GcBox::erase(p.ptr) }),
-        )
+        self.context
+            .backward_barrier(parent.ptr.erase(), child.map(|p| p.ptr.erase()))
     }
 
     /// A version of [`Mutation::backward_barrier`] that allows adopting a [`GcWeak`] child.
     #[inline]
     pub fn backward_barrier_weak(&self, parent: Gc<'gc, ()>, child: GcWeak<'gc, ()>) {
         self.context
-            .backward_barrier_weak(unsafe { GcBox::erase(parent.ptr) }, unsafe {
-                GcBox::erase(child.inner.ptr)
-            })
+            .backward_barrier_weak(parent.ptr.erase(), child.inner.ptr.erase())
     }
 
     /// IF we are in the marking phase AND the `parent` pointer (if given) is colored black, AND
@@ -70,22 +65,18 @@ impl<'gc> Mutation<'gc> {
     #[inline]
     pub fn forward_barrier(&self, parent: Option<Gc<'gc, ()>>, child: Gc<'gc, ()>) {
         self.context
-            .forward_barrier(parent.map(|p| unsafe { GcBox::erase(p.ptr) }), unsafe {
-                GcBox::erase(child.ptr)
-            })
+            .forward_barrier(parent.map(|p| p.ptr.erase()), child.ptr.erase())
     }
 
     /// A version of [`Mutation::forward_barrier`] that allows adopting a [`GcWeak`] child.
     #[inline]
     pub fn forward_barrier_weak(&self, parent: Option<Gc<'gc, ()>>, child: GcWeak<'gc, ()>) {
         self.context
-            .forward_barrier_weak(parent.map(|p| unsafe { GcBox::erase(p.ptr) }), unsafe {
-                GcBox::erase(child.inner.ptr)
-            })
+            .forward_barrier_weak(parent.map(|p| p.ptr.erase()), child.inner.ptr.erase())
     }
 
     #[inline]
-    pub(crate) fn allocate<T: Collect<'gc> + 'gc>(&self, t: T) -> NonNull<GcBoxInner<T>> {
+    pub(crate) fn allocate<T: Collect<'gc> + 'gc>(&self, t: T) -> GcBox<T> {
         self.context.allocate(t)
     }
 
@@ -123,13 +114,11 @@ impl<'gc> Finalization<'gc> {
 
 impl<'gc> Trace<'gc> for Context {
     fn trace_gc(&mut self, gc: Gc<'gc, ()>) {
-        let gc_box = unsafe { GcBox::erase(gc.ptr) };
-        Context::trace(self, gc_box)
+        Context::trace(self, gc.ptr)
     }
 
     fn trace_gc_weak(&mut self, gc: GcWeak<'gc, ()>) {
-        let gc_box = unsafe { GcBox::erase(gc.inner.ptr) };
-        Context::trace_weak(self, gc_box)
+        Context::trace_weak(self, gc.inner.ptr)
     }
 }
 
@@ -364,30 +353,23 @@ impl Context {
         cx.log_progress("GC: yielding...");
     }
 
-    fn allocate<'gc, T: Collect<'gc>>(&self, t: T) -> NonNull<GcBoxInner<T>> {
-        let header = GcBoxHeader::new::<T>();
+    #[inline]
+    fn allocate<'gc, T: Collect<'gc>>(&self, t: T) -> GcBox<T> {
+        let gc_box = GcBox::alloc(t);
+
+        let header = gc_box.header();
         header.set_next(self.all.get());
         header.set_live(true);
         header.set_needs_trace(T::NEEDS_TRACE);
 
-        // Make the generated code easier to optimize into `T` being constructed in place or at the
-        // very least only memcpy'd once.
-        // For more information, see: https://github.com/kyren/gc-arena/pull/14
-        let (gc_box, ptr) = unsafe {
-            let mut uninitialized = Box::new(mem::MaybeUninit::<GcBoxInner<T>>::uninit());
-            core::ptr::write(uninitialized.as_mut_ptr(), GcBoxInner::new(header, t));
-            let ptr = NonNull::new_unchecked(Box::into_raw(uninitialized) as *mut GcBoxInner<T>);
-            (GcBox::erase(ptr), ptr)
-        };
-
-        self.all.set(Some(gc_box));
+        self.all.set(Some(gc_box.erase()));
         if self.phase == Phase::Sweep && self.sweep_prev.get().is_none() {
             self.sweep_prev.set(self.all.get());
         }
 
         self.metrics.mark_gc_allocated(1);
 
-        ptr
+        gc_box
     }
 
     #[inline]
@@ -649,7 +631,7 @@ impl Context {
                 } else {
                     // If `sweep_prev` is None, then the sweep pointer is also the
                     // beginning of the main object list, so we need to adjust it.
-                    debug_assert_eq!(self.all.get(), Some(sweep));
+                    debug_assert!(self.all.get().is_some_and(|f| f.addr_eq(sweep)));
                     self.all.set(next_box);
                 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,7 +9,7 @@ use crate::{
     Gc, GcWeak,
     collect::{Collect, Trace},
     metrics::Metrics,
-    types::{GcBox, GcColor, Invariant},
+    types::{GcColor, GcPtr, Invariant},
 };
 
 /// Handle value given by arena callbacks during construction and mutation. Allows allocating new
@@ -76,13 +76,13 @@ impl<'gc> Mutation<'gc> {
     }
 
     #[inline]
-    pub(crate) fn allocate<T: Collect<'gc> + 'gc>(&self, t: T) -> GcBox<T> {
+    pub(crate) fn allocate<T: Collect<'gc> + 'gc>(&self, t: T) -> GcPtr<T> {
         self.context.allocate(t)
     }
 
     #[inline]
-    pub(crate) fn upgrade(&self, gc_box: GcBox) -> bool {
-        self.context.upgrade(gc_box)
+    pub(crate) fn upgrade(&self, gc_ptr: GcPtr) -> bool {
+        self.context.upgrade(gc_ptr)
     }
 }
 
@@ -107,8 +107,8 @@ impl<'gc> Deref for Finalization<'gc> {
 
 impl<'gc> Finalization<'gc> {
     #[inline]
-    pub(crate) fn resurrect(&self, gc_box: GcBox) {
-        self.context.resurrect(gc_box)
+    pub(crate) fn resurrect(&self, gc_ptr: GcPtr) {
+        self.context.resurrect(gc_ptr)
     }
 }
 
@@ -158,20 +158,20 @@ pub(crate) struct Context {
     #[cfg(feature = "tracing")]
     phase_span: tracing::Span,
 
-    // A linked list of all allocated `GcBox`es.
-    all: Cell<Option<GcBox>>,
+    // A linked list of all allocated `GcPtr`s.
+    all: Cell<Option<GcPtr>>,
 
     // A copy of the head of `all` at the end of `Phase::Mark`.
     // During `Phase::Sweep`, we free all white allocations on this list.
     // Any allocations created *during* `Phase::Sweep` will be added to `all`,
     // but `sweep` will *not* be updated. This ensures that we keep allocations
     // alive until we've had a chance to trace them.
-    sweep: Option<GcBox>,
+    sweep: Option<GcPtr>,
 
     // The most recent black object that we encountered during `Phase::Sweep`.
-    // When we free objects, we update this `GcBox.next` to remove them from
+    // When we free objects, we update this `GcPtr.next` to remove them from
     // the linked list.
-    sweep_prev: Cell<Option<GcBox>>,
+    sweep_prev: Cell<Option<GcPtr>>,
 
     /// Does the root needs to be traced?
     /// This should be `true` at the beginning of `Phase::Mark`.
@@ -179,31 +179,31 @@ pub(crate) struct Context {
 
     /// A queue of gray objects, used during `Phase::Mark`.
     /// This holds traceable objects that have yet to be traced.
-    gray: Queue<GcBox>,
+    gray: Queue<GcPtr>,
 
     // A queue of gray objects that became gray as a result
     // of a write barrier.
-    gray_again: Queue<GcBox>,
+    gray_again: Queue<GcPtr>,
 }
 
 impl Drop for Context {
     fn drop(&mut self) {
-        struct DropAll<'a>(&'a Metrics, Option<GcBox>);
+        struct DropAll<'a>(&'a Metrics, Option<GcPtr>);
 
         impl<'a> Drop for DropAll<'a> {
             fn drop(&mut self) {
-                if let Some(gc_box) = self.1.take() {
-                    let mut drop_resume = DropAll(self.0, Some(gc_box));
-                    while let Some(mut gc_box) = drop_resume.1.take() {
-                        let header = gc_box.header();
+                if let Some(gc_ptr) = self.1.take() {
+                    let mut drop_resume = DropAll(self.0, Some(gc_ptr));
+                    while let Some(mut gc_ptr) = drop_resume.1.take() {
+                        let header = gc_ptr.header();
                         drop_resume.1 = header.next();
                         // SAFETY: the context owns its GC'd objects
                         unsafe {
                             if header.is_live() {
-                                gc_box.drop_in_place();
+                                gc_ptr.drop_in_place();
                                 self.0.mark_gc_dropped(1);
                             }
-                            gc_box.dealloc();
+                            gc_ptr.dealloc();
                             self.0.mark_gc_freed(1);
                         }
                     }
@@ -354,26 +354,26 @@ impl Context {
     }
 
     #[inline]
-    fn allocate<'gc, T: Collect<'gc>>(&self, t: T) -> GcBox<T> {
-        let gc_box = GcBox::alloc(t);
+    fn allocate<'gc, T: Collect<'gc>>(&self, t: T) -> GcPtr<T> {
+        let gc_ptr = GcPtr::alloc(t);
 
-        let header = gc_box.header();
+        let header = gc_ptr.header();
         header.set_next(self.all.get());
         header.set_live(true);
         header.set_needs_trace(T::NEEDS_TRACE);
 
-        self.all.set(Some(gc_box.erase()));
+        self.all.set(Some(gc_ptr.erase()));
         if self.phase == Phase::Sweep && self.sweep_prev.get().is_none() {
             self.sweep_prev.set(self.all.get());
         }
 
         self.metrics.mark_gc_allocated(1);
 
-        gc_box
+        gc_ptr
     }
 
     #[inline]
-    fn backward_barrier(&self, parent: GcBox, child: Option<GcBox>) {
+    fn backward_barrier(&self, parent: GcPtr, child: Option<GcPtr>) {
         // During the marking phase, if we are mutating a black object, we may add a white object to
         // it and invalidate the invariant that black objects may not point to white objects. Turn
         // the black parent object gray to prevent this.
@@ -390,7 +390,7 @@ impl Context {
             // Outline the actual barrier code (which is somewhat expensive and won't be executed
             // often) to promote the inlining of the write barrier.
             #[cold]
-            fn barrier(this: &Context, parent: GcBox) {
+            fn barrier(this: &Context, parent: GcPtr) {
                 this.make_gray_again(parent);
             }
             barrier(&self, parent);
@@ -398,7 +398,7 @@ impl Context {
     }
 
     #[inline]
-    fn backward_barrier_weak(&self, parent: GcBox, child: GcBox) {
+    fn backward_barrier_weak(&self, parent: GcPtr, child: GcPtr) {
         if self.phase == Phase::Mark
             && parent.header().color() == GcColor::Black
             && child.header().color() == GcColor::White
@@ -406,7 +406,7 @@ impl Context {
             // Outline the actual barrier code (which is somewhat expensive and won't be executed
             // often) to promote the inlining of the write barrier.
             #[cold]
-            fn barrier(this: &Context, parent: GcBox) {
+            fn barrier(this: &Context, parent: GcPtr) {
                 this.make_gray_again(parent);
             }
             barrier(&self, parent);
@@ -414,7 +414,7 @@ impl Context {
     }
 
     #[inline]
-    fn forward_barrier(&self, parent: Option<GcBox>, child: GcBox) {
+    fn forward_barrier(&self, parent: Option<GcPtr>, child: GcPtr) {
         // During the marking phase, if we are mutating a black object, we may add a white object
         // to it and invalidate the invariant that black objects may not point to white objects.
         // Immediately trace the child white object to turn it gray (or black) to prevent this.
@@ -426,7 +426,7 @@ impl Context {
             // Outline the actual barrier code (which is somewhat expensive and won't be executed
             // often) to promote the inlining of the write barrier.
             #[cold]
-            fn barrier(this: &Context, child: GcBox) {
+            fn barrier(this: &Context, child: GcPtr) {
                 this.trace(child);
             }
             barrier(&self, child);
@@ -434,7 +434,7 @@ impl Context {
     }
 
     #[inline]
-    fn forward_barrier_weak(&self, parent: Option<GcBox>, child: GcBox) {
+    fn forward_barrier_weak(&self, parent: Option<GcPtr>, child: GcPtr) {
         // During the marking phase, if we are mutating a black object, we may add a white object
         // to it and invalidate the invariant that black objects may not point to white objects.
         // Immediately trace the child white object to turn it gray (or black) to prevent this.
@@ -446,7 +446,7 @@ impl Context {
             // Outline the actual barrier code (which is somewhat expensive and won't be executed
             // often) to promote the inlining of the write barrier.
             #[cold]
-            fn barrier(this: &Context, child: GcBox) {
+            fn barrier(this: &Context, child: GcPtr) {
                 this.trace_weak(child);
             }
             barrier(&self, child);
@@ -454,8 +454,8 @@ impl Context {
     }
 
     #[inline]
-    fn trace(&self, gc_box: GcBox) {
-        let header = gc_box.header();
+    fn trace(&self, gc_ptr: GcPtr) {
+        let header = gc_ptr.header();
         let color = header.color();
         match color {
             GcColor::Black | GcColor::Gray => {}
@@ -465,7 +465,7 @@ impl Context {
                     // the normal gray queue.
                     header.set_color(GcColor::Gray);
                     debug_assert!(header.is_live());
-                    self.gray.push(gc_box);
+                    self.gray.push(gc_ptr);
                 } else {
                     // A white object that doesn't need tracing simply becomes black.
                     header.set_color(GcColor::Black);
@@ -480,8 +480,8 @@ impl Context {
     }
 
     #[inline]
-    fn trace_weak(&self, gc_box: GcBox) {
-        let header = gc_box.header();
+    fn trace_weak(&self, gc_ptr: GcPtr) {
+        let header = gc_ptr.header();
         if header.color() == GcColor::White {
             header.set_color(GcColor::WhiteWeak);
             self.metrics.mark_gc_marked(1);
@@ -491,8 +491,8 @@ impl Context {
     /// Determines whether or not a Gc pointer is safe to be upgraded.
     /// This is used by weak pointers to determine if it can safely upgrade to a strong pointer.
     #[inline]
-    fn upgrade(&self, gc_box: GcBox) -> bool {
-        let header = gc_box.header();
+    fn upgrade(&self, gc_ptr: GcPtr) -> bool {
+        let header = gc_ptr.header();
 
         // This object has already been freed, definitely not safe to upgrade.
         if !header.is_live() {
@@ -537,14 +537,14 @@ impl Context {
     }
 
     #[inline]
-    fn resurrect(&self, gc_box: GcBox) {
-        let header = gc_box.header();
+    fn resurrect(&self, gc_ptr: GcPtr) {
+        let header = gc_ptr.header();
         debug_assert_eq!(self.phase, Phase::Mark);
         debug_assert!(header.is_live());
         let color = header.color();
         if matches!(header.color(), GcColor::White | GcColor::WhiteWeak) {
             header.set_color(GcColor::Gray);
-            self.gray.push(gc_box);
+            self.gray.push(gc_ptr);
             // Only marking the *first* time counts as a mark metric.
             if color == GcColor::White {
                 self.metrics.mark_gc_marked(1);
@@ -556,20 +556,20 @@ impl Context {
         // We look for an object first in the normal gray queue, then the "gray again" queue.
         // Processing "gray again" objects later gives them more time to be mutated again without
         // triggering another write barrier.
-        let next_gray = if let Some(gc_box) = self.gray.pop() {
-            Some(gc_box)
-        } else if let Some(gc_box) = self.gray_again.pop() {
-            Some(gc_box)
+        let next_gray = if let Some(gc_ptr) = self.gray.pop() {
+            Some(gc_ptr)
+        } else if let Some(gc_ptr) = self.gray_again.pop() {
+            Some(gc_ptr)
         } else {
             None
         };
 
-        if let Some(gc_box) = next_gray {
+        if let Some(gc_ptr) = next_gray {
             // We always mark work for objects processed from both the gray and "gray again" queue.
             // When objects are placed into the "gray again" queue due to a write barrier, the
             // original work is *undone*, so we do it again here.
             self.metrics.mark_gc_traced(1);
-            gc_box.header().set_color(GcColor::Black);
+            gc_ptr.header().set_color(GcColor::Black);
 
             // If we have an object in the gray queue, take one, trace it, and turn it black.
 
@@ -582,21 +582,21 @@ impl Context {
             // trace method to not panic before attempting to collect it again.
             struct DropGuard<'a> {
                 context: &'a mut Context,
-                gc_box: GcBox,
+                gc_ptr: GcPtr,
             }
 
             impl<'a> Drop for DropGuard<'a> {
                 fn drop(&mut self) {
-                    self.context.make_gray_again(self.gc_box);
+                    self.context.make_gray_again(self.gc_ptr);
                 }
             }
 
             let guard = DropGuard {
                 context: self,
-                gc_box,
+                gc_ptr,
             };
-            debug_assert!(gc_box.header().is_live());
-            unsafe { gc_box.trace_value(guard.context) }
+            debug_assert!(gc_ptr.header().is_live());
+            unsafe { gc_ptr.trace_value(guard.context) }
             mem::forget(guard);
 
             ControlFlow::Continue(())
@@ -619,20 +619,20 @@ impl Context {
 
         let sweep_header = sweep.header();
 
-        let next_box = sweep_header.next();
-        self.sweep = next_box;
+        let next_ptr = sweep_header.next();
+        self.sweep = next_ptr;
 
         match sweep_header.color() {
             // If the next object in the sweep portion of the main list is white, we
             // need to remove it from the main object list and destruct it.
             GcColor::White => {
                 if let Some(sweep_prev) = self.sweep_prev.get() {
-                    sweep_prev.header().set_next(next_box);
+                    sweep_prev.header().set_next(next_ptr);
                 } else {
                     // If `sweep_prev` is None, then the sweep pointer is also the
                     // beginning of the main object list, so we need to adjust it.
                     debug_assert!(self.all.get().is_some_and(|f| f.addr_eq(sweep)));
-                    self.all.set(next_box);
+                    self.all.set(next_ptr);
                 }
 
                 // SAFETY: this object is white, and wasn't traced by a `GcWeak` during this cycle,
@@ -649,9 +649,9 @@ impl Context {
                     self.metrics.mark_gc_freed(1);
                 }
             }
-            // Keep the `GcBox` as part of the linked list if we traced a weak pointer to it. The
-            // weak pointer still needs access to the `GcBox` to be able to check if the object
-            // is still alive. We can only deallocate the `GcBox`, once there are no weak pointers
+            // Keep the `GcPtr` as part of the linked list if we traced a weak pointer to it. The
+            // weak pointer still needs access to the `GcPtr` to be able to check if the object
+            // is still alive. We can only deallocate the `GcPtr`, once there are no weak pointers
             // left.
             GcColor::WhiteWeak => {
                 self.sweep_prev.set(Some(sweep));
@@ -685,11 +685,11 @@ impl Context {
     }
 
     // Take a black pointer and turn it gray and put it in the `gray_again` queue.
-    fn make_gray_again(&self, gc_box: GcBox) {
-        let header = gc_box.header();
+    fn make_gray_again(&self, gc_ptr: GcPtr) {
+        let header = gc_ptr.header();
         debug_assert_eq!(header.color(), GcColor::Black);
         header.set_color(GcColor::Gray);
-        self.gray_again.push(gc_box);
+        self.gray_again.push(gc_ptr);
         self.metrics.mark_gc_untraced(1);
     }
 }

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -16,11 +16,14 @@ use crate::{
     types::{GcBox, GcColor, Invariant},
 };
 
-/// A garbage collected pointer to a type T. Implements Copy, and is implemented as a plain machine
-/// pointer. You can only allocate `Gc` pointers through a `&Mutation<'gc>` inside an arena type,
-/// and through "generativity" such `Gc` pointers may not escape the arena they were born in or
-/// be stored inside TLS. This, combined with correct `Collect` implementations, means that `Gc`
-/// pointers will never be dangling and are always safe to access.
+/// A garbage collected pointer to a type T.
+///
+/// This type is `Copy` and is implemented as a plain machine pointer to `T`.
+///
+/// You can only allocate `Gc` pointers through a `&Mutation<'gc>` inside an arena type, and through
+/// "generativity" such `Gc` pointers may not escape the arena they were born in or be stored inside
+/// TLS. This, combined with correct `Collect` implementations, means that `Gc` pointers will never
+/// be dangling and are always safe to access.
 pub struct Gc<'gc, T: ?Sized + 'gc> {
     pub(crate) ptr: GcBox<T>,
     pub(crate) _invariant: Invariant<'gc>,

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -13,7 +13,7 @@ use crate::{
     context::Mutation,
     gc_weak::GcWeak,
     static_collect::Static,
-    types::{GcBox, GcColor, Invariant},
+    types::{GcColor, GcPtr, Invariant},
 };
 
 /// A garbage collected pointer to a type T.
@@ -25,7 +25,7 @@ use crate::{
 /// TLS. This, combined with correct `Collect` implementations, means that `Gc` pointers will never
 /// be dangling and are always safe to access.
 pub struct Gc<'gc, T: ?Sized + 'gc> {
-    pub(crate) ptr: GcBox<T>,
+    pub(crate) ptr: GcPtr<T>,
     pub(crate) _invariant: Invariant<'gc>,
 }
 
@@ -154,7 +154,7 @@ impl<'gc, T: ?Sized + 'gc> Gc<'gc, T> {
     pub unsafe fn from_ptr(ptr: *const T) -> Gc<'gc, T> {
         unsafe {
             Gc {
-                ptr: GcBox::from_ptr(ptr),
+                ptr: GcPtr::from_ptr(ptr),
                 _invariant: PhantomData,
             }
         }

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -1,11 +1,9 @@
 use core::{
-    alloc::Layout,
     borrow::Borrow,
     fmt::{self, Debug, Display, Pointer},
     hash::{Hash, Hasher},
     marker::PhantomData,
     ops::Deref,
-    ptr::NonNull,
 };
 
 use crate::{
@@ -15,7 +13,7 @@ use crate::{
     context::Mutation,
     gc_weak::GcWeak,
     static_collect::Static,
-    types::{GcBox, GcBoxHeader, GcBoxInner, GcColor, Invariant},
+    types::{GcBox, GcColor, Invariant},
 };
 
 /// A garbage collected pointer to a type T. Implements Copy, and is implemented as a plain machine
@@ -24,7 +22,7 @@ use crate::{
 /// be stored inside TLS. This, combined with correct `Collect` implementations, means that `Gc`
 /// pointers will never be dangling and are always safe to access.
 pub struct Gc<'gc, T: ?Sized + 'gc> {
-    pub(crate) ptr: NonNull<GcBoxInner<T>>,
+    pub(crate) ptr: GcBox<T>,
     pub(crate) _invariant: Invariant<'gc>,
 }
 
@@ -67,21 +65,21 @@ impl<'gc, T: ?Sized + 'gc> Deref for Gc<'gc, T> {
 
     #[inline]
     fn deref(&self) -> &T {
-        unsafe { &self.ptr.as_ref().value }
+        unsafe { self.ptr.as_ref() }
     }
 }
 
 impl<'gc, T: ?Sized + 'gc> AsRef<T> for Gc<'gc, T> {
     #[inline]
     fn as_ref(&self) -> &T {
-        unsafe { &self.ptr.as_ref().value }
+        unsafe { self.ptr.as_ref() }
     }
 }
 
 impl<'gc, T: ?Sized + 'gc> Borrow<T> for Gc<'gc, T> {
     #[inline]
     fn borrow(&self) -> &T {
-        unsafe { &self.ptr.as_ref().value }
+        unsafe { self.ptr.as_ref() }
     }
 }
 
@@ -129,7 +127,7 @@ impl<'gc, T: ?Sized + 'gc> Gc<'gc, T> {
     #[inline]
     pub unsafe fn cast<U: 'gc>(this: Gc<'gc, T>) -> Gc<'gc, U> {
         Gc {
-            ptr: NonNull::cast(this.ptr),
+            ptr: this.ptr.cast(),
             _invariant: PhantomData,
         }
     }
@@ -152,12 +150,8 @@ impl<'gc, T: ?Sized + 'gc> Gc<'gc, T> {
     #[inline]
     pub unsafe fn from_ptr(ptr: *const T) -> Gc<'gc, T> {
         unsafe {
-            let layout = Layout::new::<GcBoxHeader>();
-            let (_, header_offset) = layout.extend(Layout::for_value(&*ptr)).unwrap();
-            let header_offset = -(header_offset as isize);
-            let ptr = (ptr as *mut T).byte_offset(header_offset) as *mut GcBoxInner<T>;
             Gc {
-                ptr: NonNull::new_unchecked(ptr),
+                ptr: GcBox::from_ptr(ptr),
                 _invariant: PhantomData,
             }
         }
@@ -182,7 +176,7 @@ impl<'gc, T: ?Sized + 'gc> Gc<'gc, T> {
         // SAFETY: The returned reference cannot escape the current arena callback, as `&'gc T`
         // never implements `Collect` (unless `'gc` is `'static`, which is impossible here), and
         // so cannot be stored inside the GC root.
-        unsafe { &self.ptr.as_ref().value }
+        unsafe { self.ptr.as_ref() }
     }
 
     #[inline]
@@ -213,17 +207,12 @@ impl<'gc, T: ?Sized + 'gc> Gc<'gc, T> {
     /// pointers.
     #[inline]
     pub fn ptr_eq(this: Gc<'gc, T>, other: Gc<'gc, T>) -> bool {
-        // TODO: Equivalent to `core::ptr::addr_eq`:
-        // https://github.com/rust-lang/rust/issues/116324
-        Gc::as_ptr(this) as *const () == Gc::as_ptr(other) as *const ()
+        this.ptr.addr_eq(other.ptr)
     }
 
     #[inline]
     pub fn as_ptr(gc: Gc<'gc, T>) -> *const T {
-        unsafe {
-            let inner = gc.ptr.as_ptr();
-            core::ptr::addr_of!((*inner).value) as *const T
-        }
+        gc.ptr.as_ptr()
     }
 
     /// Returns true when a pointer is *dead* during finalization. This is equivalent to
@@ -233,8 +222,7 @@ impl<'gc, T: ?Sized + 'gc> Gc<'gc, T> {
     /// pointers reachable only through other weak pointers that can be dead.
     #[inline]
     pub fn is_dead(_: &Finalization<'gc>, gc: Gc<'gc, T>) -> bool {
-        let inner = unsafe { gc.ptr.as_ref() };
-        matches!(inner.header.color(), GcColor::White | GcColor::WhiteWeak)
+        matches!(gc.ptr.header().color(), GcColor::White | GcColor::WhiteWeak)
     }
 
     /// Manually marks a dead `Gc` pointer as reachable and keeps it alive.
@@ -244,9 +232,7 @@ impl<'gc, T: ?Sized + 'gc> Gc<'gc, T> {
     /// collection cycle.
     #[inline]
     pub fn resurrect(fc: &Finalization<'gc>, gc: Gc<'gc, T>) {
-        unsafe {
-            fc.resurrect(GcBox::erase(gc.ptr));
-        }
+        fc.resurrect(gc.ptr.erase());
     }
 }
 

--- a/src/gc_weak.rs
+++ b/src/gc_weak.rs
@@ -2,7 +2,6 @@ use crate::Mutation;
 use crate::collect::{Collect, Trace};
 use crate::context::Finalization;
 use crate::gc::Gc;
-use crate::types::GcBox;
 
 use core::fmt::{self, Debug};
 
@@ -39,8 +38,7 @@ impl<'gc, T: ?Sized + 'gc> GcWeak<'gc, T> {
     /// [`crate::arena::CollectionPhase::Sweeping`] phase and we know the pointer *will* be dropped.
     #[inline]
     pub fn upgrade(self, mc: &Mutation<'gc>) -> Option<Gc<'gc, T>> {
-        let ptr = unsafe { GcBox::erase(self.inner.ptr) };
-        mc.upgrade(ptr).then(|| self.inner)
+        mc.upgrade(self.inner.ptr.erase()).then(|| self.inner)
     }
 
     /// Returns whether the value referenced by this `GcWeak` has already been dropped.
@@ -54,7 +52,7 @@ impl<'gc, T: ?Sized + 'gc> GcWeak<'gc, T> {
     /// It is not safe to use this to use this and casting as a substitute for [`GcWeak::upgrade`].
     #[inline]
     pub fn is_dropped(self) -> bool {
-        !unsafe { self.inner.ptr.as_ref() }.header.is_live()
+        !self.inner.ptr.header().is_live()
     }
 
     /// Returns true when a pointer is *dead* during finalization.
@@ -90,7 +88,7 @@ impl<'gc, T: ?Sized + 'gc> GcWeak<'gc, T> {
     pub fn resurrect(self, fc: &Finalization<'gc>) -> Option<Gc<'gc, T>> {
         // SAFETY: We know that we are currently marking, so any non-dropped pointer is safe to
         // resurrect.
-        if unsafe { self.inner.ptr.as_ref() }.header.is_live() {
+        if self.inner.ptr.header().is_live() {
             Gc::resurrect(fc, self.inner);
             Some(self.inner)
         } else {
@@ -104,9 +102,7 @@ impl<'gc, T: ?Sized + 'gc> GcWeak<'gc, T> {
     /// pointers.
     #[inline]
     pub fn ptr_eq(this: GcWeak<'gc, T>, other: GcWeak<'gc, T>) -> bool {
-        // TODO: Equivalent to `core::ptr::addr_eq`:
-        // https://github.com/rust-lang/rust/issues/116324
-        this.as_ptr() as *const () == other.as_ptr() as *const ()
+        this.inner.ptr.addr_eq(other.inner.ptr)
     }
 
     #[inline]

--- a/src/gc_weak.rs
+++ b/src/gc_weak.rs
@@ -5,6 +5,13 @@ use crate::gc::Gc;
 
 use core::fmt::{self, Debug};
 
+/// A weak pointer to a garbage collected.
+///
+/// A `GcWeak<T>` can be obtained from a `Gc<T>` through [`Gc::downgrade`].
+///
+/// A reachable "weak" GC pointer does not prevent having the stored value collected. Instead, the
+/// owner of a `GcWeak<T>` may check at any time if a value has been collected and if it has not,
+/// turn it back into a `Gc<T>` through [`GcWeak::upgrade`].
 pub struct GcWeak<'gc, T: ?Sized + 'gc> {
     pub(crate) inner: Gc<'gc, T>,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,77 +1,148 @@
+use alloc::alloc;
 use core::alloc::Layout;
 use core::cell::Cell;
 use core::marker::PhantomData;
 use core::ptr::NonNull;
-use core::{mem, ptr};
+use core::{fmt, mem, ptr};
 
 use crate::{collect::Collect, context::Context};
 
 /// A thin-pointer-sized box containing a type-erased GC object.
-/// Stores the metadata required by the GC algorithm inline (see `GcBoxInner`
-/// for its typed counterpart).
+///
+/// Stores the metadata required by the GC algorithm in the same allocation *before* the stored
+/// pointer.
+pub(crate) struct GcBox<T: ?Sized = ()>(NonNull<T>);
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub(crate) struct GcBox(NonNull<GcBoxInner<()>>);
-
-impl GcBox {
-    /// Erases a pointer to a typed GC object.
-    ///
-    /// **SAFETY:** The pointer must point to a valid `GcBoxInner` allocated
-    /// in a `Box`.
-    #[inline(always)]
-    pub(crate) unsafe fn erase<T: ?Sized>(ptr: NonNull<GcBoxInner<T>>) -> Self {
-        // This cast is sound because `GcBoxInner` is `repr(C)`.
-        let erased = ptr.as_ptr() as *mut GcBoxInner<()>;
-        unsafe { Self(NonNull::new_unchecked(erased)) }
+impl<T: ?Sized> fmt::Debug for GcBox<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Pointer::fmt(&self.as_ptr(), f)
     }
+}
 
-    /// Gets a pointer to the value stored inside this box.
-    /// `T` must be the same type that was used with `erase`, so that
-    /// we can correctly compute the field offset.
+impl<T: ?Sized> Copy for GcBox<T> {}
+
+impl<T: ?Sized> Clone for GcBox<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'gc, T: Collect<'gc>> GcBox<T> {
+    /// Allocate a new `GcBox` with a default header and holding the given value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if there is no valid layout we can allocate.
     #[inline(always)]
-    fn unerased_value<T>(&self) -> *mut T {
+    pub(crate) fn alloc(value: T) -> Self {
         unsafe {
-            let ptr = self.0.as_ptr() as *mut GcBoxInner<T>;
-            // Don't create a reference, to keep the full provenance.
-            // Also, this gives us interior mutability "for free".
-            ptr::addr_of_mut!((*ptr).value) as *mut T
+            let gc_layout = GcLayout::new(Layout::new::<T>()).unwrap();
+            let gc_header = GcBoxHeader::new::<T>();
+
+            let bytes = alloc::alloc(gc_layout.alloc_layout);
+            let Some(bytes) = NonNull::new(bytes) else {
+                alloc::handle_alloc_error(gc_layout.alloc_layout);
+            };
+
+            let value_ptr = gc_layout.value_ptr::<T>(bytes);
+            let header_ptr = GcLayout::header_ptr(value_ptr);
+            debug_assert!(header_ptr.is_aligned() && value_ptr.is_aligned());
+
+            ptr::write(header_ptr.as_ptr(), gc_header);
+            ptr::write(value_ptr.as_ptr(), value);
+
+            GcBox(value_ptr)
         }
     }
+}
 
+impl<T: ?Sized> GcBox<T> {
     #[inline(always)]
     pub(crate) fn header(&self) -> &GcBoxHeader {
-        unsafe { &self.0.as_ref().header }
+        unsafe { GcLayout::header_ptr(self.0).as_ref() }
+    }
+
+    #[inline(always)]
+    pub(crate) fn as_ptr(self) -> *const T {
+        self.0.as_ptr()
+    }
+
+    /// # Safety
+    ///
+    /// The provided ptr must have come from `GcBox::as_ptr`.
+    #[inline(always)]
+    pub(crate) unsafe fn from_ptr(p: *const T) -> Self {
+        Self(unsafe { NonNull::new_unchecked(p as *mut T) })
+    }
+
+    #[inline(always)]
+    pub(crate) fn cast<U>(self) -> GcBox<U> {
+        GcBox(self.0.cast())
+    }
+
+    /// A convenience method to cast to `()`.
+    #[inline(always)]
+    pub(crate) fn erase(self) -> GcBox {
+        self.cast()
+    }
+
+    /// Returns true if two `GcBox`s point to the same allocation.
+    ///
+    /// This function ignores the metadata of `dyn` pointers.
+    #[inline(always)]
+    pub(crate) fn addr_eq(self, other: GcBox<T>) -> bool {
+        ptr::addr_eq(self.as_ptr(), other.as_ptr())
+    }
+
+    /// Return a shared reference to the value.
+    ///
+    /// # Safety
+    ///
+    /// You must ensure that this pointer was not cast to a type incompatible with its allocated
+    /// type and has not been dropped or deallocated.
+    ///
+    /// Additionally, the returned reference has an unbound lifetime so the returned reference must
+    /// not be live when the value is dropped or the pointer deallocated.
+    #[inline(always)]
+    pub(crate) unsafe fn as_ref<'a>(self) -> &'a T {
+        unsafe { self.0.as_ref() }
     }
 
     /// Traces the stored value.
     ///
-    /// **SAFETY**: `Self::drop_in_place` must not have been called.
+    /// # Safety
+    ///
+    /// The value must not have been dropped and the pointer must not have been deallocated.
     #[inline(always)]
-    pub(crate) unsafe fn trace_value(&self, cc: &mut Context) {
-        unsafe { (self.header().vtable().trace_value)(*self, cc) }
+    pub(crate) unsafe fn trace_value(self, cc: &mut Context) {
+        unsafe { (self.header().vtable().trace_value)(self.0.cast::<()>().as_ptr(), cc) }
     }
 
     /// Drops the stored value.
     ///
-    /// **SAFETY**: once called, no GC pointers should access the stored value
-    /// (but accessing the `GcBox` itself is still safe).
+    /// # Safety:
+    ///
+    /// The value must not have been previously dropped and the pointer must not have been
+    /// deallocated.
     #[inline(always)]
     pub(crate) unsafe fn drop_in_place(&mut self) {
-        unsafe { (self.header().vtable().drop_value)(*self) }
+        unsafe { (self.header().vtable().drop_value)(self.0.cast::<()>().as_ptr()) }
     }
 
-    /// Deallocates the box. Failing to call `Self::drop_in_place` beforehand
-    /// will cause the stored value to be leaked.
+    /// Deallocates the box.
     ///
-    /// **SAFETY**: once called, this `GcBox` should never be accessed by any GC
-    /// pointers again.
+    /// Failing to call `Self::drop_in_place` beforehand will cause the stored value to be leaked.
+    ///
+    /// # Safety:
+    ///
+    /// The pointer must not already be deallocated.
     #[inline(always)]
     pub(crate) unsafe fn dealloc(self) {
+        let gc_layout = GcLayout::new(self.header().vtable().value_layout).unwrap();
         unsafe {
-            let layout = self.header().vtable().box_layout;
-            let ptr = self.0.as_ptr() as *mut u8;
-            // SAFETY: the pointer was `Box`-allocated with this layout.
-            alloc::alloc::dealloc(ptr, layout);
+            let ptr = gc_layout.alloc_ptr(self.0).as_ptr();
+            // SAFETY: the pointer was allocated with this layout.
+            alloc::dealloc(ptr, gc_layout.alloc_layout);
         }
     }
 }
@@ -89,6 +160,10 @@ pub(crate) struct GcBoxHeader {
 }
 
 impl GcBoxHeader {
+    /// Create a new `GcBoxHeader` with:
+    /// 1) color set to `White`
+    /// 2) `needs_trace` set to `false`
+    /// 3) `is_live` set to `false`
     #[inline(always)]
     pub fn new<'gc, T: Collect<'gc>>() -> Self {
         // Helper trait to materialize vtables in static memory.
@@ -101,6 +176,7 @@ impl GcBoxHeader {
         }
 
         let vtable: &'static _ = &<T as HasCollectVtable>::VTABLE;
+
         Self {
             next: Cell::new(None),
             tagged_vtable: Cell::new(vtable as *const _),
@@ -141,19 +217,28 @@ impl GcBoxHeader {
 
     #[inline]
     pub(crate) fn set_color(&self, color: GcColor) {
-        tagged_ptr::set::<0x3, _>(
-            &self.tagged_vtable,
-            match color {
-                GcColor::White => 0x0,
-                GcColor::WhiteWeak => 0x1,
-                GcColor::Gray => 0x2,
-                GcColor::Black => 0x3,
-            },
-        );
+        self.tagged_vtable.update(|p| {
+            tagged_ptr::set::<0x3, _>(
+                p,
+                match color {
+                    GcColor::White => 0x0,
+                    GcColor::WhiteWeak => 0x1,
+                    GcColor::Gray => 0x2,
+                    GcColor::Black => 0x3,
+                },
+            )
+        });
     }
+
     #[inline]
     pub(crate) fn needs_trace(&self) -> bool {
-        tagged_ptr::get::<0x4, _>(self.tagged_vtable.get()) != 0x0
+        tagged_ptr::get_bool::<0x4, _>(self.tagged_vtable.get())
+    }
+
+    #[inline]
+    pub(crate) fn set_needs_trace(&self, needs_trace: bool) {
+        self.tagged_vtable
+            .update(|p| tagged_ptr::set_bool::<0x4, _>(p, needs_trace));
     }
 
     /// Determines whether or not we've dropped the `dyn Collect` value
@@ -164,17 +249,13 @@ impl GcBoxHeader {
     /// (since we've already done it).
     #[inline]
     pub(crate) fn is_live(&self) -> bool {
-        tagged_ptr::get::<0x8, _>(self.tagged_vtable.get()) != 0x0
-    }
-
-    #[inline]
-    pub(crate) fn set_needs_trace(&self, needs_trace: bool) {
-        tagged_ptr::set_bool::<0x4, _>(&self.tagged_vtable, needs_trace);
+        tagged_ptr::get_bool::<0x8, _>(self.tagged_vtable.get())
     }
 
     #[inline]
     pub(crate) fn set_live(&self, alive: bool) {
-        tagged_ptr::set_bool::<0x8, _>(&self.tagged_vtable, alive);
+        self.tagged_vtable
+            .update(|p| tagged_ptr::set_bool::<0x8, _>(p, alive));
     }
 }
 
@@ -184,12 +265,12 @@ impl GcBoxHeader {
 /// The type is over-aligned so that `GcBoxHeader` can store flags into the LSBs of the vtable pointer.
 #[repr(align(16))]
 struct CollectVtable {
-    /// The layout of the `GcBox` the GC'd value is stored in.
-    box_layout: Layout,
-    /// Drops the value stored in the given `GcBox` (without deallocating the box).
-    drop_value: unsafe fn(GcBox),
-    /// Traces the value stored in the given `GcBox`.
-    trace_value: unsafe fn(GcBox, &mut Context),
+    /// Traces the value at the given pointer.
+    trace_value: unsafe fn(*const (), &mut Context),
+    /// Drops the value at the given pointer.
+    drop_value: unsafe fn(*mut ()),
+    /// The layout of the value stored in this `GcBox`.
+    value_layout: Layout,
 }
 
 impl CollectVtable {
@@ -199,34 +280,13 @@ impl CollectVtable {
     #[inline(always)]
     const fn vtable_for<'gc, T: Collect<'gc>>() -> Self {
         Self {
-            box_layout: Layout::new::<GcBoxInner<T>>(),
-            drop_value: |erased| unsafe {
-                ptr::drop_in_place(erased.unerased_value::<T>());
+            trace_value: |ptr, cc| unsafe {
+                ptr.cast::<T>().as_ref_unchecked().trace(cc);
             },
-            trace_value: |erased, cc| unsafe {
-                let val = &*(erased.unerased_value::<T>());
-                val.trace(cc)
+            drop_value: |ptr| unsafe {
+                ptr::drop_in_place(ptr.cast::<T>());
             },
-        }
-    }
-}
-
-/// A typed GC'd value, together with its metadata.
-/// This type is never manipulated directly by the GC algorithm, allowing
-/// user-facing `Gc`s to freely cast their pointer to it.
-#[repr(C)]
-pub(crate) struct GcBoxInner<T: ?Sized> {
-    pub(crate) header: GcBoxHeader,
-    /// The typed value stored in this `GcBox`.
-    pub(crate) value: mem::ManuallyDrop<T>,
-}
-
-impl<'gc, T: Collect<'gc>> GcBoxInner<T> {
-    #[inline(always)]
-    pub(crate) fn new(header: GcBoxHeader, t: T) -> Self {
-        Self {
-            header,
-            value: mem::ManuallyDrop::new(t),
+            value_layout: Layout::new::<T>(),
         }
     }
 }
@@ -257,23 +317,145 @@ pub(crate) enum GcColor {
 // Phantom type that holds a lifetime and ensures that it is invariant.
 pub(crate) type Invariant<'a> = PhantomData<Cell<&'a ()>>;
 
+/// The layout of an allocated buffer backing a `Gc` pointer.
+#[derive(Debug, Copy, Clone)]
+struct GcLayout {
+    alloc_layout: Layout,
+    value_offset: usize,
+}
+
+impl GcLayout {
+    #[inline(always)]
+    const fn new(value_layout: Layout) -> Option<Self> {
+        #[inline(always)]
+        const fn max(a: usize, b: usize) -> usize {
+            if a > b { a } else { b }
+        }
+
+        let header_size = mem::size_of::<GcBoxHeader>();
+        let header_align = mem::align_of::<GcBoxHeader>();
+
+        let value_size = value_layout.size();
+        let value_align = value_layout.align();
+
+        // We want to allocate a buffer that is large enough to hold both the value and the header
+        // at the proper alignment.
+        //
+        // We operate on pointers to the value itself, not the entire allocated buffer, so we need
+        // to be careful how we offset objects in this buffer so that the location of the header is
+        // predictable. We want the location of the header to be at a fixed position relative to the
+        // value pointer that does *not* depend on the pointer type, so that we can freely cast the
+        // value pointer.
+
+        // The allocation must be aligned to both header and value alignment so that when we offset
+        // from this pointer, if the offset is properly aligned then we know the resulting pointer
+        // is still aligned.
+        let alloc_align = max(header_align, value_align);
+
+        // We need to make sure the value offset is enough to store the header before it while also
+        // making sure that the value is aligned to *both* the header and value alignment. This way,
+        // when we subtract the header size from the value pointer, we know the resulting location
+        // is properly aligned for the header.
+        let value_offset = max(header_size, value_align);
+
+        let Some(alloc_size) = value_offset.checked_add(value_size) else {
+            return None;
+        };
+
+        let Ok(alloc_layout) = Layout::from_size_align(alloc_size, alloc_align) else {
+            return None;
+        };
+
+        // Ensure that the value and header offsets are both properly aligned.
+        debug_assert!(value_offset.is_multiple_of(value_align));
+        debug_assert!((value_offset - header_size).is_multiple_of(header_align));
+
+        Some(Self {
+            alloc_layout,
+            value_offset,
+        })
+    }
+
+    /// Compute the pointer to the GC value from the pointer to the GC allocation.
+    ///
+    /// # Safety
+    ///
+    /// Allocation must have been allocated according to `alloc_layout`.
+    #[inline(always)]
+    unsafe fn value_ptr<T>(&self, alloc_ptr: NonNull<u8>) -> NonNull<T> {
+        let value = unsafe { alloc_ptr.add(self.value_offset).cast() };
+        debug_assert!(value.is_aligned());
+        value
+    }
+
+    /// Compute the pointer to the GC header from a GC value pointer.
+    ///
+    /// # Safety
+    ///
+    /// Must be a valid GC value pointer.
+    #[inline(always)]
+    unsafe fn header_ptr<T: ?Sized>(value_ptr: NonNull<T>) -> NonNull<GcBoxHeader> {
+        let header = unsafe {
+            value_ptr
+                .cast::<GcBoxHeader>()
+                .byte_sub(mem::size_of::<GcBoxHeader>())
+        };
+        debug_assert!(header.is_aligned());
+        header
+    }
+
+    /// Compute the pointer to the beginning of the GC allocation from a GC value pointer.
+    ///
+    /// # Safety
+    ///
+    /// Must be a valid GC value pointer.
+    #[inline(always)]
+    unsafe fn alloc_ptr<T: ?Sized>(&self, value_ptr: NonNull<T>) -> NonNull<u8> {
+        unsafe { value_ptr.cast::<u8>().byte_sub(self.value_offset) }
+    }
+}
+
 /// Utility functions for tagging and untagging pointers.
 mod tagged_ptr {
-    use core::cell::Cell;
+    /// Checks that `mask` can be used to tag a pointer to `T`.
+    const fn is_valid_mask<T>(mask: usize) -> bool {
+        mask < core::mem::align_of::<T>()
+    }
+
+    /// Checks that `mask` is exactly 1 bit wide.
+    const fn is_boolean_mask(mask: usize) -> bool {
+        mask.is_power_of_two()
+    }
 
     trait ValidMask<const MASK: usize> {
         const CHECK: ();
     }
 
     impl<T, const MASK: usize> ValidMask<MASK> for T {
-        const CHECK: () = assert!(MASK < core::mem::align_of::<T>());
+        const CHECK: () = assert!(is_valid_mask::<T>(MASK));
+    }
+
+    trait BooleanMask<const MASK: usize> {
+        const CHECK: ();
+    }
+
+    impl<T, const MASK: usize> BooleanMask<MASK> for T {
+        const CHECK: () = assert!(is_boolean_mask(MASK));
     }
 
     /// Checks that `$mask` can be used to tag a pointer to `$type`.
+    ///
     /// If this isn't true, this macro will cause a post-monomorphization error.
     macro_rules! check_mask {
         ($type:ty, $mask:expr) => {
             let _ = <$type as ValidMask<$mask>>::CHECK;
+        };
+    }
+
+    macro_rules! check_bool_mask {
+        ($type:ty, $mask:expr) => {
+            let _ = <$type as ValidMask<$mask>>::CHECK;
+            let _ = <$type as BooleanMask<$mask>>::CHECK;
         };
     }
 
@@ -289,19 +471,20 @@ mod tagged_ptr {
         tagged_ptr.addr() & MASK
     }
 
-    #[inline(always)]
-    pub(super) fn set<const MASK: usize, T>(pcell: &Cell<*const T>, tag: usize) {
+    pub(super) fn set<const MASK: usize, T>(tagged_ptr: *const T, tag: usize) -> *const T {
         check_mask!(T, MASK);
-        let ptr = pcell.get();
-        let ptr = ptr.map_addr(|addr| (addr & !MASK) | (tag & MASK));
-        pcell.set(ptr)
+        tagged_ptr.map_addr(|addr| (addr & !MASK) | (tag & MASK))
     }
 
     #[inline(always)]
-    pub(super) fn set_bool<const MASK: usize, T>(pcell: &Cell<*const T>, value: bool) {
-        check_mask!(T, MASK);
-        let ptr = pcell.get();
-        let ptr = ptr.map_addr(|addr| (addr & !MASK) | if value { MASK } else { 0 });
-        pcell.set(ptr)
+    pub(super) fn get_bool<const MASK: usize, T>(tagged_ptr: *const T) -> bool {
+        check_bool_mask!(T, MASK);
+        tagged_ptr.addr() & MASK != 0x0
+    }
+
+    #[inline(always)]
+    pub(super) fn set_bool<const MASK: usize, T>(tagged_ptr: *const T, value: bool) -> *const T {
+        check_bool_mask!(T, MASK);
+        tagged_ptr.map_addr(|addr| (addr & !MASK) | if value { MASK } else { 0 })
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,28 +7,28 @@ use core::{fmt, mem, ptr};
 
 use crate::{collect::Collect, context::Context};
 
-/// A thin-pointer-sized box containing a type-erased GC object.
+/// A thin-pointer-sized pointer to a type-erased GC object.
 ///
-/// Stores the metadata required by the GC algorithm in the same allocation *before* the stored
-/// pointer.
-pub(crate) struct GcBox<T: ?Sized = ()>(NonNull<T>);
+/// Pointers to GC objects have the metadata required by the GC algorithm in the same allocation
+/// *before* the stored pointer.
+pub(crate) struct GcPtr<T: ?Sized = ()>(NonNull<T>);
 
-impl<T: ?Sized> fmt::Debug for GcBox<T> {
+impl<T: ?Sized> fmt::Debug for GcPtr<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Pointer::fmt(&self.as_ptr(), f)
     }
 }
 
-impl<T: ?Sized> Copy for GcBox<T> {}
+impl<T: ?Sized> Copy for GcPtr<T> {}
 
-impl<T: ?Sized> Clone for GcBox<T> {
+impl<T: ?Sized> Clone for GcPtr<T> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'gc, T: Collect<'gc>> GcBox<T> {
-    /// Allocate a new `GcBox` with a default header and holding the given value.
+impl<'gc, T: Collect<'gc>> GcPtr<T> {
+    /// Allocate a new GC value with a default header.
     ///
     /// # Panics
     ///
@@ -37,7 +37,7 @@ impl<'gc, T: Collect<'gc>> GcBox<T> {
     pub(crate) fn alloc(value: T) -> Self {
         unsafe {
             let gc_layout = GcLayout::new(Layout::new::<T>()).unwrap();
-            let gc_header = GcBoxHeader::new::<T>();
+            let gc_header = GcHeader::new::<T>();
 
             let bytes = alloc::alloc(gc_layout.alloc_layout);
             let Some(bytes) = NonNull::new(bytes) else {
@@ -51,14 +51,14 @@ impl<'gc, T: Collect<'gc>> GcBox<T> {
             ptr::write(header_ptr.as_ptr(), gc_header);
             ptr::write(value_ptr.as_ptr(), value);
 
-            GcBox(value_ptr)
+            GcPtr(value_ptr)
         }
     }
 }
 
-impl<T: ?Sized> GcBox<T> {
+impl<T: ?Sized> GcPtr<T> {
     #[inline(always)]
-    pub(crate) fn header(&self) -> &GcBoxHeader {
+    pub(crate) fn header(&self) -> &GcHeader {
         unsafe { GcLayout::header_ptr(self.0).as_ref() }
     }
 
@@ -69,28 +69,28 @@ impl<T: ?Sized> GcBox<T> {
 
     /// # Safety
     ///
-    /// The provided ptr must have come from `GcBox::as_ptr`.
+    /// The provided ptr must have come from `GcPtr::as_ptr`.
     #[inline(always)]
     pub(crate) unsafe fn from_ptr(p: *const T) -> Self {
         Self(unsafe { NonNull::new_unchecked(p as *mut T) })
     }
 
     #[inline(always)]
-    pub(crate) fn cast<U>(self) -> GcBox<U> {
-        GcBox(self.0.cast())
+    pub(crate) fn cast<U>(self) -> GcPtr<U> {
+        GcPtr(self.0.cast())
     }
 
     /// A convenience method to cast to `()`.
     #[inline(always)]
-    pub(crate) fn erase(self) -> GcBox {
+    pub(crate) fn erase(self) -> GcPtr {
         self.cast()
     }
 
-    /// Returns true if two `GcBox`s point to the same allocation.
+    /// Returns true if two `GcPtr`s point to the same allocation.
     ///
     /// This function ignores the metadata of `dyn` pointers.
     #[inline(always)]
-    pub(crate) fn addr_eq(self, other: GcBox<T>) -> bool {
+    pub(crate) fn addr_eq(self, other: GcPtr<T>) -> bool {
         ptr::addr_eq(self.as_ptr(), other.as_ptr())
     }
 
@@ -129,7 +129,7 @@ impl<T: ?Sized> GcBox<T> {
         unsafe { (self.header().vtable().drop_value)(self.0.cast::<()>().as_ptr()) }
     }
 
-    /// Deallocates the box.
+    /// Deallocates the allocation this pointer points to.
     ///
     /// Failing to call `Self::drop_in_place` beforehand will cause the stored value to be leaked.
     ///
@@ -147,9 +147,9 @@ impl<T: ?Sized> GcBox<T> {
     }
 }
 
-pub(crate) struct GcBoxHeader {
+pub(crate) struct GcHeader {
     /// The next element in the global linked list of allocated objects.
-    next: Cell<Option<GcBox>>,
+    next: Cell<Option<GcPtr>>,
     /// A custom virtual function table for handling type-specific operations.
     ///
     /// The lower bits of the pointer are used to store GC flags:
@@ -159,13 +159,13 @@ pub(crate) struct GcBoxHeader {
     tagged_vtable: Cell<*const CollectVtable>,
 }
 
-impl GcBoxHeader {
-    /// Create a new `GcBoxHeader` with:
+impl GcHeader {
+    /// Create a new `GcHeader` with:
     /// 1) color set to `White`
     /// 2) `needs_trace` set to `false`
     /// 3) `is_live` set to `false`
     #[inline(always)]
-    pub fn new<'gc, T: Collect<'gc>>() -> Self {
+    fn new<'gc, T: Collect<'gc>>() -> Self {
         // Helper trait to materialize vtables in static memory.
         trait HasCollectVtable {
             const VTABLE: CollectVtable;
@@ -183,7 +183,6 @@ impl GcBoxHeader {
         }
     }
 
-    /// Gets a reference to the `CollectVtable` used by this box.
     #[inline(always)]
     fn vtable(&self) -> &'static CollectVtable {
         let ptr = tagged_ptr::untag(self.tagged_vtable.get());
@@ -195,13 +194,13 @@ impl GcBoxHeader {
 
     /// Gets the next element in the global linked list of allocated objects.
     #[inline(always)]
-    pub(crate) fn next(&self) -> Option<GcBox> {
+    pub(crate) fn next(&self) -> Option<GcPtr> {
         self.next.get()
     }
 
     /// Sets the next element in the global linked list of allocated objects.
     #[inline(always)]
-    pub(crate) fn set_next(&self, next: Option<GcBox>) {
+    pub(crate) fn set_next(&self, next: Option<GcPtr>) {
         self.next.set(next)
     }
 
@@ -241,12 +240,11 @@ impl GcBoxHeader {
             .update(|p| tagged_ptr::set_bool::<0x4, _>(p, needs_trace));
     }
 
-    /// Determines whether or not we've dropped the `dyn Collect` value
-    /// stored in `GcBox.value`
-    /// When we garbage-collect a `GcBox` that still has outstanding weak pointers,
-    /// we set `alive` to false. When there are no more weak pointers remaining,
-    /// we will deallocate the `GcBox`, but skip dropping the `dyn Collect` value
-    /// (since we've already done it).
+    /// Determines whether or not we've dropped the `dyn Collect` value stored in `GcPtr.value`
+    ///
+    /// When we garbage-collect a `GcPtr` that still has outstanding weak pointers, we set `alive`
+    /// to false. When there are no more weak pointers remaining, we will deallocate the `GcPtr`,
+    /// but skip dropping the `dyn Collect` value (since we've already done it).
     #[inline]
     pub(crate) fn is_live(&self) -> bool {
         tagged_ptr::get_bool::<0x8, _>(self.tagged_vtable.get())
@@ -261,22 +259,22 @@ impl GcBoxHeader {
 
 /// Type-specific operations for GC'd values.
 ///
-/// We use a custom vtable instead of `dyn Collect` for extra flexibility.
-/// The type is over-aligned so that `GcBoxHeader` can store flags into the LSBs of the vtable pointer.
+/// We use a custom vtable instead of `dyn Collect` for extra flexibility. The type is over-aligned
+/// so that `GcHeader` can store flags into the LSBs of the vtable pointer.
 #[repr(align(16))]
 struct CollectVtable {
     /// Traces the value at the given pointer.
     trace_value: unsafe fn(*const (), &mut Context),
     /// Drops the value at the given pointer.
     drop_value: unsafe fn(*mut ()),
-    /// The layout of the value stored in this `GcBox`.
+    /// The layout of the value stored in this `GcPtr`.
     value_layout: Layout,
 }
 
 impl CollectVtable {
     /// Makes a vtable for a known, `Sized` type.
     /// Because `T: Sized`, we can recover a typed pointer
-    /// directly from the erased `GcBox`.
+    /// directly from the erased `GcPtr`.
     #[inline(always)]
     const fn vtable_for<'gc, T: Collect<'gc>>() -> Self {
         Self {
@@ -332,8 +330,8 @@ impl GcLayout {
             if a > b { a } else { b }
         }
 
-        let header_size = mem::size_of::<GcBoxHeader>();
-        let header_align = mem::align_of::<GcBoxHeader>();
+        let header_size = mem::size_of::<GcHeader>();
+        let header_align = mem::align_of::<GcHeader>();
 
         let value_size = value_layout.size();
         let value_align = value_layout.align();
@@ -394,11 +392,11 @@ impl GcLayout {
     ///
     /// Must be a valid GC value pointer.
     #[inline(always)]
-    unsafe fn header_ptr<T: ?Sized>(value_ptr: NonNull<T>) -> NonNull<GcBoxHeader> {
+    unsafe fn header_ptr<T: ?Sized>(value_ptr: NonNull<T>) -> NonNull<GcHeader> {
         let header = unsafe {
             value_ptr
-                .cast::<GcBoxHeader>()
-                .byte_sub(mem::size_of::<GcBoxHeader>())
+                .cast::<GcHeader>()
+                .byte_sub(mem::size_of::<GcHeader>())
         };
         debug_assert!(header.is_aligned());
         header

--- a/src/unsize.rs
+++ b/src/unsize.rs
@@ -1,10 +1,4 @@
-use core::marker::PhantomData;
-use core::ptr::NonNull;
-
-use crate::{
-    types::GcBoxInner,
-    {Gc, GcWeak},
-};
+use crate::{Gc, GcWeak};
 
 /// Unsizes a [`Gc`] or [`GcWeak`] pointer.
 ///
@@ -54,14 +48,14 @@ macro_rules! unsize {
         // coercion, if it compiles. Additionally, the `__CoercePtrInternal` trait
         // ensures that the resulting GC pointer has the correct `'gc` lifetime.
         unsafe {
-            $crate::__CoercePtrInternal::__coerce_unchecked(gc, |p: *mut _| -> *mut $ty { p })
+            $crate::__CoercePtrInternal::__coerce_unchecked(gc, |p: *const _| -> *const $ty { p })
         }
     }};
 }
 
 // Not public API; implementation detail of the `unsize` macro.
 //
-// Maps a raw pointer coercion (`*mut FromPtr -> *mut ToPtr`) to
+// Maps a raw pointer coercion (`*const FromPtr -> *const ToPtr`) to
 // a smart pointer coercion (`Self -> Dst`).
 #[doc(hidden)]
 pub unsafe trait __CoercePtrInternal<Dst> {
@@ -71,7 +65,7 @@ pub unsafe trait __CoercePtrInternal<Dst> {
     // pointer must have the same address and provenance as the original.
     unsafe fn __coerce_unchecked<F>(self, coerce: F) -> Dst
     where
-        F: FnOnce(*mut Self::FromPtr) -> *mut Self::ToPtr;
+        F: FnOnce(*const Self::FromPtr) -> *const Self::ToPtr;
 }
 
 unsafe impl<'gc, T, U: ?Sized> __CoercePtrInternal<Gc<'gc, U>> for Gc<'gc, T> {
@@ -81,15 +75,9 @@ unsafe impl<'gc, T, U: ?Sized> __CoercePtrInternal<Gc<'gc, U>> for Gc<'gc, T> {
     #[inline(always)]
     unsafe fn __coerce_unchecked<F>(self, coerce: F) -> Gc<'gc, U>
     where
-        F: FnOnce(*mut T) -> *mut U,
+        F: FnOnce(*const T) -> *const U,
     {
-        let ptr = self.ptr.as_ptr() as *mut T;
-        unsafe {
-            Gc {
-                ptr: NonNull::new_unchecked(coerce(ptr) as *mut GcBoxInner<U>),
-                _invariant: PhantomData,
-            }
-        }
+        unsafe { Gc::from_ptr(coerce(Gc::as_ptr(self))) }
     }
 }
 
@@ -100,7 +88,7 @@ unsafe impl<'gc, T, U: ?Sized> __CoercePtrInternal<GcWeak<'gc, U>> for GcWeak<'g
     #[inline(always)]
     unsafe fn __coerce_unchecked<F>(self, coerce: F) -> GcWeak<'gc, U>
     where
-        F: FnOnce(*mut T) -> *mut U,
+        F: FnOnce(*const T) -> *const U,
     {
         unsafe {
             let inner = self.inner.__coerce_unchecked(coerce);


### PR DESCRIPTION
Instead of storing `NonNull<GcBoxInner<T>>` inside `Gc` and doing offsets during dereference, a `*const T` is stored. This has two primary benefits...

One, it makes dereferencing `Gc` as cheap as absolutely possible at the cost of making tracing *very slightly* more expensive (equal to the decreased expense of `Gc` dereference). Since `Gc` dereferencing is likely to be vastly more common, this is a win.

Two, it makes it possible to safely cast from `Gc<T>` to `Gc<U>` with the only requirement being that it must be valid to cast `*const T` to `*const U` and dereference it. Before, this is not sufficient, as both types must also have the same alignment so that `GcBoxInner<T>` and `GcBoxInner<U>` are guaranteed to have the inner value at the same location.

The cost of allocation should never be worse than it was before. The layout of GC allocations is simply changed so that the header is always *just* before the value, and any required padding is *before* the header rather than after. This way, finding the header is always subtracting the fixed header size from the value pointer, and this is always correct no matter the held value type.