### PR TITLE
Clean up imports, rename internal `static_collect` module.

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -2,7 +2,7 @@ use alloc::boxed::Box;
 use core::marker::PhantomData;
 
 use crate::{
-    Collect,
+    collect::Collect,
     context::{Context, Finalization, Mutation, Phase, RunUntil, Stop},
     metrics::Metrics,
 };

--- a/src/barrier.rs
+++ b/src/barrier.rs
@@ -1,21 +1,21 @@
 //! Write barrier management.
 
-use core::borrow::Borrow;
-use core::mem;
-use core::ops::{
-    Deref, DerefMut, Index, Range, RangeFrom, RangeInclusive, RangeTo, RangeToInclusive,
+use alloc::{
+    collections::{BTreeMap, VecDeque},
+    vec::Vec,
 };
-
-use alloc::collections::{BTreeMap, VecDeque};
-use alloc::vec::Vec;
-
+#[cfg(doc)]
+use core::ops::IndexMut;
+use core::{
+    borrow::Borrow,
+    mem,
+    ops::{Deref, DerefMut, Index, Range, RangeFrom, RangeInclusive, RangeTo, RangeToInclusive},
+};
 #[cfg(feature = "std")]
 use std::{collections::HashMap, hash::BuildHasher, hash::Hash};
 
 #[cfg(doc)]
 use crate::Gc;
-#[cfg(doc)]
-use core::ops::IndexMut;
 
 /// An (interiorly-)mutable reference inside a GC'd object graph.
 ///

--- a/src/collect_impl.rs
+++ b/src/collect_impl.rs
@@ -1,10 +1,14 @@
-use alloc::boxed::Box;
-use alloc::collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque};
-use alloc::rc::Rc;
-use alloc::string::String;
-use alloc::vec::Vec;
-use core::cell::{Cell, RefCell};
-use core::marker::PhantomData;
+use alloc::{
+    boxed::Box,
+    collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque},
+    rc::Rc,
+    string::String,
+    vec::Vec,
+};
+use core::{
+    cell::{Cell, RefCell},
+    marker::PhantomData,
+};
 #[cfg(feature = "std")]
 use std::collections::{HashMap, HashSet};
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -6,8 +6,9 @@ use core::{
 };
 
 use crate::{
-    Gc, GcWeak,
     collect::{Collect, Trace},
+    gc::Gc,
+    gc_weak::GcWeak,
     metrics::Metrics,
     types::{GcColor, GcPtr, Invariant},
 };

--- a/src/dynamic_roots.rs
+++ b/src/dynamic_roots.rs
@@ -1,14 +1,14 @@
-use core::{cell::RefCell, fmt, mem};
-
 use alloc::{
     rc::{Rc, Weak},
     vec::Vec,
 };
+use core::{cell::RefCell, fmt, mem};
 
 use crate::{
-    Gc, Mutation, Rootable,
-    arena::Root,
+    arena::{Root, Rootable},
     collect::{Collect, Trace},
+    context::Mutation,
+    gc::Gc,
 };
 
 /// A way of registering GC roots dynamically.

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -7,12 +7,11 @@ use core::{
 };
 
 use crate::{
-    Finalization,
     barrier::{Unlock, Write},
     collect::{Collect, Trace},
-    context::Mutation,
+    context::{Finalization, Mutation},
     gc_weak::GcWeak,
-    static_collect::Static,
+    static_wrapper::Static,
     types::{GcColor, GcPtr, Invariant},
 };
 

--- a/src/gc_weak.rs
+++ b/src/gc_weak.rs
@@ -1,9 +1,10 @@
-use crate::Mutation;
-use crate::collect::{Collect, Trace};
-use crate::context::Finalization;
-use crate::gc::Gc;
-
 use core::fmt::{self, Debug};
+
+use crate::{
+    collect::{Collect, Trace},
+    context::{Finalization, Mutation},
+    gc::Gc,
+};
 
 /// A weak pointer to a garbage collected.
 ///

--- a/src/hashbrown.rs
+++ b/src/hashbrown.rs
@@ -1,7 +1,9 @@
 use core::hash::{BuildHasher, Hash};
 
-use crate::barrier::IndexWrite;
-use crate::collect::{Collect, Trace};
+use crate::{
+    barrier::IndexWrite,
+    collect::{Collect, Trace},
+};
 
 unsafe impl<'gc, K, V, S> Collect<'gc> for hashbrown::HashMap<K, V, S>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ mod gc_weak;
 pub mod lock;
 pub mod metrics;
 mod no_drop;
-mod static_collect;
+mod static_wrapper;
 mod types;
 mod unsize;
 
@@ -51,5 +51,5 @@ pub use self::{
     gc::Gc,
     gc_weak::GcWeak,
     lock::{GcLock, GcRefLock, Lock, RefLock},
-    static_collect::Static,
+    static_wrapper::Static,
 };

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -7,9 +7,10 @@ use core::{
 };
 
 use crate::{
-    Gc, Mutation,
     barrier::Unlock,
     collect::{Collect, Trace},
+    context::Mutation,
+    gc::Gc,
 };
 
 // Helper macro to factor out the common parts of locks types.

--- a/src/static_wrapper.rs
+++ b/src/static_wrapper.rs
@@ -1,9 +1,10 @@
-use crate::Rootable;
-use crate::collect::Collect;
-
 use alloc::borrow::{Borrow, BorrowMut};
-use core::convert::{AsMut, AsRef};
-use core::ops::{Deref, DerefMut};
+use core::{
+    convert::{AsMut, AsRef},
+    ops::{Deref, DerefMut},
+};
+
+use crate::{arena::Rootable, collect::Collect};
 
 /// A wrapper type that implements Collect whenever the contained T is 'static, which is useful in
 /// generic contexts

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,9 +1,12 @@
 use alloc::alloc;
-use core::alloc::Layout;
-use core::cell::Cell;
-use core::marker::PhantomData;
-use core::ptr::NonNull;
-use core::{fmt, mem, ptr};
+use core::{
+    alloc::Layout,
+    cell::Cell,
+    fmt,
+    marker::PhantomData,
+    mem,
+    ptr::{self, NonNull},
+};
 
 use crate::{collect::Collect, context::Context};
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,9 +1,9 @@
 use core::{cell::Cell, mem};
 #[cfg(feature = "std")]
-use rand::distr::Distribution;
-use std::array;
+use std::{array, collections::HashMap, rc::Rc};
+
 #[cfg(feature = "std")]
-use std::{collections::HashMap, rc::Rc};
+use rand::distr::Distribution;
 
 use gc_arena::{
     Arena, Collect, DynamicRootSet, Gc, GcWeak, Lock, RefLock, Rootable,

--- a/tests/ui/bad_write_field_projections.rs
+++ b/tests/ui/bad_write_field_projections.rs
@@ -1,7 +1,7 @@
-
-
-use gc_arena::Gc;
-use gc_arena::barrier::{Write, field};
+use gc_arena::{
+    Gc,
+    barrier::{Write, field},
+};
 
 struct Foo<'gc> {
     foo: i32,


### PR DESCRIPTION
`static_collect` => `static_wrapper`, so as not to conflict with the exported macro.