### PR TITLE
Some obvious functionality missing from #152

### DIFF
--- a/src/gc.rs
+++ b/src/gc.rs
@@ -288,7 +288,7 @@ where
         K::from_store(gc.ptr).as_ptr()
     }
 
-    /// Retrieve a `Gc` from a raw pointer obtained from `Gc::as_ptr`
+    /// Retrieve a `Gc` from a raw pointer obtained from [`Gc::as_ptr`].
     ///
     /// # Safety
     ///
@@ -328,12 +328,26 @@ where
     /// This converts the `Gc` to point to a `()`, and changes the kind to [`DefaultGcKind`].
     ///
     /// This is always safe to do as it is always safe to dereference a `*const ()` which comes from
-    /// some other dereferencable pointer type and `DefaultGcKind` has `()` for both per-type and
-    /// per-value metadata.
+    /// some other dereferencable pointer type and `DefaultGcKind` assumes nothing about the real
+    /// per-type and per-value metadata.
     #[inline]
     pub fn erase(this: Self) -> Gc<'gc, ()> {
         Gc {
             ptr: unsafe { GcPtr::from_ptr(GcPtr::as_ptr(this.ptr) as *mut ()) },
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'gc, T: ?Sized, M, P> GcFat<'gc, T, M, P> {
+    /// Change the `Gc` kind to [`DefaultGcKind`].
+    ///
+    /// This is always safe to do because `DefaultGcKind` assumes nothing about the real per-type
+    /// and per-value metadata.
+    #[inline]
+    pub fn erase_kind(this: Self) -> Gc<'gc, T> {
+        Gc {
+            ptr: unsafe { GcPtr::from_ptr(GcPtr::as_ptr(this.ptr)) },
             _marker: PhantomData,
         }
     }
@@ -413,6 +427,17 @@ where
     }
 }
 
+impl<'gc, T: ?Sized, S, M, P> Gc<'gc, T, GcKind<S, M, P>>
+where
+    GcKind<S, M, P>: IsGcKind<'gc, T>,
+{
+    /// Retrieve the *per-type* metadata specified when a `Gc` was allocated.
+    #[inline]
+    pub fn type_metadata(gc: Gc<'gc, T, GcKind<S, M, P>>) -> &'static M {
+        unsafe { gc.ptr.type_metadata::<M>() }
+    }
+}
+
 impl<'gc, T: ?Sized, M, P> GcFat<'gc, T, M, P>
 where
     M: 'static,
@@ -437,6 +462,7 @@ where
     /// But, this means that on "thin" pointers, operations like finding the length of a slice must
     /// visit the memory that the `Gc` points to rather than this metadata being available next to
     /// the pointer itself.
+    #[inline]
     pub fn as_thin(gc: Self) -> GcThin<'gc, T, M, P> {
         unsafe { Gc::from_ptr_with_kind(Gc::as_ptr(gc)) }
     }
@@ -451,18 +477,44 @@ where
     /// Convert a "thin" `Gc` to a "fat" one.
     ///
     /// This is the reverse of [`Gc::as_thin`]
+    #[inline]
     pub fn as_fat(gc: Self) -> GcFat<'gc, T, M, P> {
         unsafe { Gc::from_ptr_with_kind(Gc::as_ptr(gc)) }
     }
 }
 
-impl<'gc, T: ?Sized, S, M, P> Gc<'gc, T, GcKind<S, M, P>>
+impl<'gc, T: ?Sized, M, P> GcThin<'gc, T, M, P>
 where
-    GcKind<S, M, P>: IsGcKind<'gc, T>,
+    M: 'static,
+    P: PtrMeta<T, M>,
+    P::Thin: 'gc,
 {
-    /// Retrieve the *per-type* metadata specified when a `Gc` was allocated.
-    pub fn type_metadata(gc: Gc<'gc, T, GcKind<S, M, P>>) -> &'static M {
-        unsafe { gc.ptr.type_metadata::<M>() }
+    /// Retrieve a reference to the thin value held in a [`GcThin`].
+    #[inline]
+    pub fn as_thin_ref(this: Self) -> &'gc P::Thin {
+        // SAFETY: The returned `'gc` lifetime is safe for the same reason as `Gc::as_ref`.
+        unsafe { this.ptr.as_ref() }
+    }
+
+    /// Retrieve the raw *thin* pointer held in a [`GcThin`].
+    #[inline]
+    pub fn as_thin_ptr(this: Self) -> *const P::Thin {
+        this.ptr.as_ptr()
+    }
+
+    /// Retrieve a `Gc` from a raw pointer obtained from [`Gc::as_thin_ptr`].
+    ///
+    /// # Safety
+    ///
+    /// This has all the same safety requirements as [`Gc::from_ptr_with_kind`].
+    #[inline]
+    pub unsafe fn from_thin_ptr_with_kind(ptr: *const P::Thin) -> GcThin<'gc, T, M, P> {
+        unsafe {
+            Gc {
+                ptr: GcPtr::from_ptr(ptr.cast_mut()),
+                _marker: PhantomData,
+            }
+        }
     }
 }
 
@@ -471,10 +523,12 @@ where
     K: IsGcKind<'gc, T>,
     T: PartialEq,
 {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.as_ref().eq(other.as_ref())
     }
 
+    #[inline]
     fn ne(&self, other: &Self) -> bool {
         self.as_ref().ne(other.as_ref())
     }
@@ -523,6 +577,7 @@ where
     K: IsGcKind<'gc, T>,
     T: Ord,
 {
+    #[inline]
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.as_ref().cmp(other.as_ref())
     }
@@ -533,6 +588,7 @@ where
     K: IsGcKind<'gc, T>,
     T: Hash,
 {
+    #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.as_ref().hash(state)
     }
@@ -554,7 +610,6 @@ impl<'gc, T: ?Sized, M, P> Drop for GcBuilder<'gc, T, M, P> {
 
 impl<'gc, T: Collect<'gc>> GcBuilder<'gc, T> {
     /// Create a new `GcBuilder` suitable for building a `Gc` pointer to a *sized* `T`.
-    #[inline]
     pub fn new() -> Self {
         GcBuilder::new_with_type_meta::<UnitTypeMeta>()
     }
@@ -569,7 +624,6 @@ where
     ///
     /// The `TM::METADATA` pointer will be stored in the static *per-type* vtable so there is no
     /// per-allocation cost, but there is one vtable per `T` <-> `TM` pair.
-    #[inline]
     pub fn new_with_type_meta<TM: TypeMeta<TypeMetadata = M>>() -> Self {
         unsafe { Self::new_with_type_and_ptr_meta::<TM>(()) }
     }
@@ -580,14 +634,13 @@ where
     T: Collect<'gc>,
     P: AllocMeta<T, M>,
 {
-    /// Create a new `GcBuilder` suitable for building a `Gc` pointing to an *unsized* `T`with the
-    /// given `ptr_meta` per-value metadata and per-type metadata from `TM`.
+    /// Create a new `GcBuilder` suitable for building a `Gc` pointer to a (potentially *unsized*)
+    /// `T` with per-type metadata from `TM` and the given `ptr_meta` per-value metadata.
     ///
     /// # Safety
     ///
     /// Using this method requires asserting that `P: AllocMeta` is correctly implemented for the
     /// `TM::METADATA` being used to create the `Gc`.
-    #[inline]
     pub unsafe fn new_with_type_and_ptr_meta<TM: TypeMeta<TypeMetadata = M>>(
         ptr_meta: P::PtrMetadata,
     ) -> Self {
@@ -631,11 +684,13 @@ impl<'gc, T: ?Sized, M, P> GcBuilder<'gc, T, M, P> {
     ///
     /// The pointer will always point to valid, aligned memory for the type `T` and may be written
     /// to to initialize the value.
+    #[inline]
     pub fn as_ptr(&mut self) -> *mut T {
         self.ptr.as_ptr()
     }
 
     /// Convert this `GcBuilder` into a bare pointer.
+    #[inline]
     pub fn into_raw(self) -> *mut T {
         let ptr = self.ptr;
         mem::forget(self);
@@ -648,6 +703,7 @@ impl<'gc, T: ?Sized, M, P> GcBuilder<'gc, T, M, P> {
     ///
     /// The types of `T`, `P`, and `M` must be compatible with the originally constructed
     /// `GcBuilder`.
+    #[inline]
     pub unsafe fn from_raw(ptr: *mut T) -> GcBuilder<'gc, T, M, P> {
         unsafe {
             Self {
@@ -674,7 +730,6 @@ impl<'gc, T: ?Sized, M, P> GcBuilder<'gc, T, M, P> {
 
 impl<'gc, T, M, P> GcBuilder<'gc, T, M, P> {
     /// Finish constructing a `Gc<T>` by initializing the (sized) value with `val`.
-    #[inline]
     pub fn write(mut self, mc: &Mutation<'gc>, val: T) -> GcFat<'gc, T, M, P> {
         unsafe {
             self.as_ptr().write(val);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,8 @@ pub use self::{
     gc_weak::GcWeak,
     lock::{GcLock, GcRefLock, Lock, RefLock},
     slice::{
-        GcSlice, GcSliceBuilder, GcSliceWithHeader, GcSliceWithHeaderBuilder, GcThinSlice,
-        GcThinSliceWithHeader, SliceWithHeader,
+        GcSlice, GcSliceBuilder, GcSliceWithHeader, GcSliceWithHeaderBuilder, GcStr, GcStrBuilder,
+        GcThinSlice, GcThinSliceWithHeader, GcThinStr, SliceWithHeader,
     },
     static_wrapper::Static,
 };

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -1,8 +1,8 @@
 use core::alloc::Layout;
 
-/// A trait which can instantiate type-level metadata for `Gc` pointers.
+/// A trait which can instantiate per-type metadata for `Gc` pointers.
 ///
-/// Types implementing this trait are what *instantiates* the type-level metadata, so that different
+/// Types implementing this trait are what *instantiates* the per-type metadata, so that different
 /// instances of this can be used for the same type of `Gc` pointer.
 ///
 /// The metadata pointer for allocated `Gc` values will be stored in a *per-type* static vtable (one
@@ -13,8 +13,7 @@ pub trait TypeMeta {
     const TYPE_METADATA: &'static Self::TypeMetadata;
 }
 
-/// A simple implementation of [`TypeMeta`] that does not store any type-level metadata (only the
-/// `()` (unit) type).
+/// A trivial implementation of [`TypeMeta`] that sets the per-type metadata to `()` (unit).
 pub struct UnitTypeMeta;
 
 impl TypeMeta for UnitTypeMeta {
@@ -37,14 +36,21 @@ impl TypeMeta for UnitTypeMeta {
 /// Though it is not unsafe to implement this trait, it is unsafe to construct a new `Gc` pointer
 /// with an arbitrary implementation of `PtrMeta` and you must assert that it is implemented
 /// correctly when doing so.
-///
-/// If `from_thin` is given `thin` and `ptr_meta` that came from a call to `to_thin`, it must return
-/// the *same* pointer value as the one given to `to_thin`.
 pub trait PtrMeta<T: ?Sized, M> {
     type PtrMetadata: Copy + Send;
     type Thin;
 
+    /// This method should return the "thin" version of the given "fat" pointer.
+    ///
+    /// The returned "thin" pointer must have the same address as the "fat" one, and also be
+    /// valid and dereferencable.
     fn to_thin(type_meta: &'static M, fat: *const T) -> *const Self::Thin;
+
+    /// This method should return the "fat" version of the given "thin" pointer.
+    ///
+    /// The returned "fat" pointer must have the same address as the provided "thin" one, and
+    /// additionally, round-tripping through `to_thin` and `from_thin` must result in the same
+    /// exact pointer.
     fn from_thin(
         type_meta: &'static M,
         thin: *const Self::Thin,
@@ -66,14 +72,15 @@ pub trait AllocMeta<T: ?Sized, M>: PtrMeta<T, M> {
     fn layout(type_meta: &'static M, ptr_meta: Self::PtrMetadata) -> Option<Layout>;
 }
 
-/// A trivial implementation of [`PtrMeta`] and [`AllocMeta`] that can only allocate sized values
-/// and cannot be used to convert a "fat" pointer to a "thin" one.
+/// A trivial implementation of [`PtrMeta`] and [`AllocMeta`] that sets the per-value metadata to
+/// `()` (unit).
 ///
-/// In this representation, the `PtrMeta::Metadata` type is `()` (unit) and the "fat" `*const T`
-/// pointer is the same as the "thin" `*const PtrMeta::Thin` pointer.
+/// This type only implements [`PtrMeta`] and [`AllocMeta`] for *sized* types. This means that it
+/// can only allocate and free sized types and it cannot be used to convert a "fat" pointer to a
+/// "thin" one.
 ///
 /// It is always safe to create or cast to a `Gc` with this `PtrMeta` implementation, because it
-/// does no pointer conversion, and assumes nothing about the per-type or per-value metadata.
+/// cannot do pointer conversion and assumes nothing about the per-type or per-value metadata.
 pub struct UnitPtrMeta;
 
 impl<T, M> PtrMeta<T, M> for UnitPtrMeta {

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -110,6 +110,7 @@ impl<'gc, H: Collect<'gc>, E: Collect<'gc>, M> GcSliceWithHeaderBuilder<'gc, H, 
 impl<'gc, H, E, M> GcSliceWithHeaderBuilder<'gc, Static<H>, E, M> {
     /// Safely unwrap a `GcSliceWithHeaderBuilder<Static<H>, _, _>` into a
     /// `GcSliceWithHeaderBuilder<H, _, _>`.
+    #[inline]
     pub fn unwrap_static_header(self) -> GcSliceWithHeaderBuilder<'gc, H, E, M> {
         unsafe {
             let builder = GcSliceWithHeaderBuilder {
@@ -122,6 +123,7 @@ impl<'gc, H, E, M> GcSliceWithHeaderBuilder<'gc, Static<H>, E, M> {
 
 impl<'gc, H, E, M> GcSliceWithHeaderBuilder<'gc, H, E, M> {
     /// Return a pointer to the (possibly uninitialized) slice being constructed.
+    #[inline]
     pub fn header_ptr(&mut self) -> *mut H {
         unsafe { &raw mut (*self.inner.as_ptr()).header }
     }
@@ -168,6 +170,7 @@ impl<'gc, H, E, M> Drop for GcSliceWithHeaderSliceBuilder<'gc, H, E, M> {
 impl<'gc, H, E, M> GcSliceWithHeaderSliceBuilder<'gc, H, Static<E>, M> {
     /// Safely unwrap a `GcSliceWithHeaderSliceBuilder<_, Static<E>, _>` into a
     /// `GcSliceWithHeaderSliceBuilder<_, E, _>`.
+    #[inline]
     pub fn unwrap_static_element(mut self) -> GcSliceWithHeaderSliceBuilder<'gc, H, E, M> {
         unsafe {
             let builder = GcSliceWithHeaderSliceBuilder {
@@ -184,6 +187,7 @@ impl<'gc, H, E, M> GcSliceWithHeaderSliceBuilder<'gc, H, Static<E>, M> {
 
 impl<'gc, H, E, M> GcSliceWithHeaderSliceBuilder<'gc, H, E, M> {
     /// Return a pointer to the (possibly uninitialized) slice being constructed.
+    #[inline]
     pub fn slice_ptr(&mut self) -> *mut [E] {
         unsafe { &raw mut (*self.inner.as_ptr()).slice }
     }
@@ -223,6 +227,11 @@ impl<'gc, H, E, M> GcSliceWithHeaderSliceBuilder<'gc, H, E, M> {
 
 impl<'gc, H, E: Copy, M> GcSliceWithHeaderSliceBuilder<'gc, H, E, M> {
     /// Finish constructing a `GcSliceWithHeader<H, E>` by copying elements from the given slice.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `elements.len()` is not at least as large as the length given in
+    /// [`GcSliceWithHeaderBuilder::new`].
     pub fn copy_slice(
         mut self,
         mc: &Mutation<'gc>,
@@ -296,7 +305,8 @@ impl<'gc, E: Collect<'gc>> GcSliceBuilder<'gc, E> {
 }
 
 impl<'gc, E: Collect<'gc>, M> GcSliceBuilder<'gc, E, M> {
-    /// Create a new `GcSliceBuilder` with an uninitialized slice of length `len`.
+    /// Create a new `GcSliceBuilder` with an uninitialized slice of length `len` and per-type
+    /// metadata from `TM`.
     pub fn new_with_type_meta<TM: TypeMeta<TypeMetadata = M>>(len: usize) -> Self {
         Self(GcSliceWithHeaderBuilder::<(), E, M>::new_with_type_meta::<TM>(len).write_header(()))
     }
@@ -304,6 +314,7 @@ impl<'gc, E: Collect<'gc>, M> GcSliceBuilder<'gc, E, M> {
 
 impl<'gc, E, M> GcSliceBuilder<'gc, Static<E>, M> {
     /// Safely unwrap a `GcSliceBuilder<Static<E>, _>` into a `GcSliceBuilder<E, _>`.
+    #[inline]
     pub fn unwrap_static(self) -> GcSliceBuilder<'gc, E, M> {
         GcSliceBuilder(self.0.unwrap_static_element())
     }
@@ -311,6 +322,7 @@ impl<'gc, E, M> GcSliceBuilder<'gc, Static<E>, M> {
 
 impl<'gc, E, M> GcSliceBuilder<'gc, E, M> {
     /// Return a pointer to the (possibly uninitialized) slice being constructed.
+    #[inline]
     pub fn slice_ptr(&mut self) -> *mut [E] {
         self.0.slice_ptr()
     }
@@ -336,8 +348,88 @@ impl<'gc, E, M> GcSliceBuilder<'gc, E, M> {
 
 impl<'gc, E: Copy, M> GcSliceBuilder<'gc, E, M> {
     /// Finish constructing a `GcSlice<E>` by copying elements from the given slice.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `elements.len()` is not at least as large as the length given in
+    /// [`GcSliceBuilder::new`].
     pub fn copy_slice(self, mc: &Mutation<'gc>, elements: &[E]) -> GcSlice<'gc, E, M> {
         let val = self.0.copy_slice(mc, elements);
         unsafe { Gc::from_ptr_with_kind(Gc::as_ptr(val) as *const [E]) }
+    }
+}
+
+pub type GcStr<'gc, M = ()> = GcFat<'gc, str, M, StrPtrMeta>;
+pub type GcThinStr<'gc, M = ()> = GcThin<'gc, str, M, StrPtrMeta>;
+
+impl<'gc> GcStr<'gc> {
+    pub fn new_str(mc: &Mutation<'gc>, s: &str) -> GcStr<'gc> {
+        GcStrBuilder::new(s.len()).copy_str(mc, s)
+    }
+}
+
+pub struct StrPtrMeta;
+
+impl<M> PtrMeta<str, M> for StrPtrMeta {
+    type PtrMetadata = usize;
+    type Thin = ();
+
+    #[inline]
+    fn to_thin(_type_meta: &M, s: *const str) -> *const () {
+        SliceWithHeader::ptr_to_thin(s as *const SliceWithHeader<(), u8>)
+    }
+
+    #[inline]
+    fn from_thin(_type_meta: &M, s: *const (), len: usize) -> *const str {
+        SliceWithHeader::<(), u8>::ptr_from_thin(s, len) as *const str
+    }
+}
+
+impl<M> AllocMeta<str, M> for StrPtrMeta {
+    #[inline]
+    fn layout(_type_meta: &M, len: usize) -> Option<Layout> {
+        SliceWithHeader::<(), u8>::layout(len)
+    }
+}
+
+/// Provides a way to construct a new `GcStr`.
+pub struct GcStrBuilder<'gc, M = ()>(GcSliceBuilder<'gc, u8, M>);
+
+impl<'gc> GcStrBuilder<'gc> {
+    /// Create a new `GcStr` with an uninitialized str of length `len`.
+    pub fn new(len: usize) -> Self {
+        Self(GcSliceBuilder::<u8>::new(len))
+    }
+}
+
+impl<'gc, M> GcStrBuilder<'gc, M> {
+    /// Create a new `GcStrBuilder` with an uninitialized str of length `len` and per-type metadata
+    /// from `TM`.
+    pub fn new_with_type_meta<TM: TypeMeta<TypeMetadata = M>>(len: usize) -> Self {
+        Self(GcSliceBuilder::<u8, M>::new_with_type_meta::<TM>(len))
+    }
+}
+
+impl<'gc, M> GcStrBuilder<'gc, M> {
+    /// Return a pointer to the (possibly uninitialized) str being constructed.
+    #[inline]
+    pub fn str_ptr(&mut self) -> *mut str {
+        self.0.slice_ptr() as *mut str
+    }
+
+    /// Finish constructing a `GcStr` by unsafely assuming that the held str is properly
+    /// initialized.
+    pub unsafe fn assume_init(self, mc: &Mutation<'gc>) -> GcStr<'gc, M> {
+        unsafe { Gc::from_ptr_with_kind(Gc::as_ptr(self.0.assume_init(mc)) as *const str) }
+    }
+
+    /// Finish constructing a `GcStr` by copying from the given `str`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `s.len()` is not at least as large as the length given in [`GcStrBuilder::new`].
+    pub fn copy_str(self, mc: &Mutation<'gc>, s: &str) -> GcStr<'gc, M> {
+        let s = self.0.copy_slice(mc, s.as_bytes());
+        unsafe { Gc::from_ptr_with_kind(Gc::as_ptr(s) as *const str) }
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1493,12 +1493,13 @@ fn test_thin_slice_with_header() {
             .copy_slice(mc, &[5, 6, 7, 8, 9]);
 
         let thin_ptr: GcThinSliceWithHeader<i32, i32> = Gc::as_thin(ptr);
-        assert_eq!(thin_ptr.as_ref().header, 47);
-        assert_eq!(thin_ptr.as_ref().slice, [5, 6, 7, 8, 9]);
+        assert_eq!(*Gc::as_thin_ref(thin_ptr), 47);
+        assert_eq!(thin_ptr.header, 47);
+        assert_eq!(thin_ptr.slice, [5, 6, 7, 8, 9]);
 
         let fat_ptr: GcSliceWithHeader<i32, i32> = Gc::as_fat(thin_ptr);
-        assert_eq!(fat_ptr.as_ref().header, 47);
-        assert_eq!(fat_ptr.as_ref().slice, [5, 6, 7, 8, 9]);
+        assert_eq!(fat_ptr.header, 47);
+        assert_eq!(fat_ptr.slice, [5, 6, 7, 8, 9]);
     });
 }
 
@@ -1513,10 +1514,28 @@ fn test_thin_slice() {
         let ptr = Gc::new_slice(mc, &[5, 6, 7, 8, 9]);
 
         let thin_ptr: GcThinSlice<i32> = Gc::as_thin(ptr);
-        assert_eq!(thin_ptr.as_ref(), [5, 6, 7, 8, 9]);
+        assert_eq!(*thin_ptr, [5, 6, 7, 8, 9]);
 
         let fat_ptr: GcSlice<i32> = Gc::as_fat(thin_ptr);
-        assert_eq!(fat_ptr.as_ref(), [5, 6, 7, 8, 9]);
+        assert_eq!(*fat_ptr, [5, 6, 7, 8, 9]);
+    });
+}
+
+#[test]
+fn test_thin_str() {
+    use gc_arena::{GcStr, GcThinStr};
+
+    assert!(mem::size_of::<GcStr>() > mem::size_of::<Gc<()>>());
+    assert!(mem::size_of::<GcThinStr>() == mem::size_of::<Gc<()>>());
+
+    gc_arena::arena::rootless_mutate(|mc| {
+        let s = Gc::new_str(mc, "foo");
+
+        let thin_s: GcThinStr = Gc::as_thin(s);
+        assert_eq!(thin_s.as_ref(), "foo");
+
+        let fat_s: GcStr = Gc::as_fat(thin_s);
+        assert_eq!(fat_s.as_ref(), "foo");
     });
 }
 


### PR DESCRIPTION
Adds `Gc::erase_kind`, `GcStrBuilder`, `Gc::new_str`, `Gc::as_thin_ref`, `Gc::as_thin_ptr` and `Gc::from_thin_ptr`.

Fixes some documentation, adds some missing `#[inline]` and makes
existing `#[inline]` a little more consistent.

Includes *two* additional requirements of `PtrMeta`, namely that the
*thin* pointer be dereferencable, and also that the *thin* pointer have
the same address as the *fat* one.